### PR TITLE
security: enable seccompProfile for Pod Security Standards compliance

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,13 +50,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - command:
             - /auth-operator

--- a/config/webhook/deployment.yaml
+++ b/config/webhook/deployment.yaml
@@ -42,13 +42,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - command:
             - /auth-operator


### PR DESCRIPTION
## Summary

Enable `seccompProfile` with `RuntimeDefault` type in both controller and webhook deployments for Pod Security Standards compliance.

## Changes

- `config/manager/manager.yaml`: Enable seccompProfile at pod level
- `config/webhook/deployment.yaml`: Enable seccompProfile at pod level

## Security Impact

The `RuntimeDefault` seccomp profile:
- Restricts system calls available to container processes
- Blocks potentially dangerous syscalls while allowing normal operation
- Is required for Kubernetes Pod Security Standards (Restricted profile)
- Supported on Kubernetes 1.19+ and OpenShift 4.11+

## Before

```yaml
securityContext:
  runAsNonRoot: true
  # seccompProfile:
  #   type: RuntimeDefault
```

## After

```yaml
securityContext:
  runAsNonRoot: true
  seccompProfile:
    type: RuntimeDefault
```

## Testing

```bash
# Verify manifests are valid
make manifests
kubectl apply --dry-run=client -k config/default

# Deploy and verify pods run correctly
make deploy
kubectl get pods -n auth-operator-system
```

## Related Issue

Addresses security review finding: seccompProfile was commented out
