### PR TITLE
refactor: extract hardcoded label keys into constants

### DIFF
--- a/api/authorization/v1alpha1/labels.go
+++ b/api/authorization/v1alpha1/labels.go
@@ -1,0 +1,27 @@
+package v1alpha1
+
+// Label keys used for namespace ownership and tenant identification.
+// These labels are used by the namespace webhooks to control access
+// and inject ownership metadata.
+const (
+	// LabelKeyOwner identifies the owner type of a namespace (platform, tenant, or thirdparty)
+	LabelKeyOwner = "t-caas.telekom.com/owner"
+
+	// LabelKeyTenant identifies the specific tenant that owns the namespace
+	LabelKeyTenant = "t-caas.telekom.com/tenant"
+
+	// LabelKeyThirdParty identifies the specific third party that owns the namespace
+	LabelKeyThirdParty = "t-caas.telekom.com/thirdparty"
+)
+
+// Owner label values
+const (
+	// OwnerPlatform indicates the namespace is owned by the platform team
+	OwnerPlatform = "platform"
+
+	// OwnerTenant indicates the namespace is owned by a tenant
+	OwnerTenant = "tenant"
+
+	// OwnerThirdParty indicates the namespace is owned by a third party
+	OwnerThirdParty = "thirdparty"
+)

--- a/internal/webhook/authorization/namespace_mutating_webhook.go
+++ b/internal/webhook/authorization/namespace_mutating_webhook.go
@@ -165,25 +165,25 @@ func getLabelsFromNamespaceSelector(selector metav1.LabelSelector) map[string]st
 	labels := map[string]string{}
 	// Process matchLabels
 	for key, value := range selector.MatchLabels {
-		if key == "t-caas.telekom.com/owner" {
+		if key == authzv1alpha1.LabelKeyOwner {
 			labels[key] = value
 		}
-		if key == "t-caas.telekom.com/tenant" {
+		if key == authzv1alpha1.LabelKeyTenant {
 			labels[key] = value
 		}
-		if key == "t-caas.telekom.com/thirdparty" {
+		if key == authzv1alpha1.LabelKeyThirdParty {
 			labels[key] = value
 		}
 	}
 	// Process matchExpressions
 	for _, expr := range selector.MatchExpressions {
-		if expr.Key == "t-caas.telekom.com/owner" && expr.Operator == metav1.LabelSelectorOpIn && len(expr.Values) == 1 {
+		if expr.Key == authzv1alpha1.LabelKeyOwner && expr.Operator == metav1.LabelSelectorOpIn && len(expr.Values) == 1 {
 			labels[expr.Key] = expr.Values[0]
 		}
-		if expr.Key == "t-caas.telekom.com/tenant" && expr.Operator == metav1.LabelSelectorOpIn && len(expr.Values) == 1 {
+		if expr.Key == authzv1alpha1.LabelKeyTenant && expr.Operator == metav1.LabelSelectorOpIn && len(expr.Values) == 1 {
 			labels[expr.Key] = expr.Values[0]
 		}
-		if expr.Key == "t-caas.telekom.com/thirdparty" && expr.Operator == metav1.LabelSelectorOpIn && len(expr.Values) == 1 {
+		if expr.Key == authzv1alpha1.LabelKeyThirdParty && expr.Operator == metav1.LabelSelectorOpIn && len(expr.Values) == 1 {
 			labels[expr.Key] = expr.Values[0]
 		}
 	}

--- a/internal/webhook/authorization/namespace_validating_webhook.go
+++ b/internal/webhook/authorization/namespace_validating_webhook.go
@@ -95,9 +95,9 @@ func (v *NamespaceValidator) Handle(ctx context.Context, req admission.Request) 
 
 		// Define the label keys of interest
 		labelKeys := []string{
-			"t-caas.telekom.com/owner",
-			"t-caas.telekom.com/tenant",
-			"t-caas.telekom.com/thirdparty",
+			authzv1alpha1.LabelKeyOwner,
+			authzv1alpha1.LabelKeyTenant,
+			authzv1alpha1.LabelKeyThirdParty,
 		}
 
 		// If TDGMigration is enabled, add the additional label key


### PR DESCRIPTION
## Summary

Extract hardcoded namespace label keys into constants for better maintainability.

## Changes

### New file: `api/authorization/v1alpha1/labels.go`

Defines constants for namespace ownership labels:
- `LabelKeyOwner` = `"t-caas.telekom.com/owner"`
- `LabelKeyTenant` = `"t-caas.telekom.com/tenant"`
- `LabelKeyThirdParty` = `"t-caas.telekom.com/thirdparty"`

Also defines owner value constants:
- `OwnerPlatform` = `"platform"`
- `OwnerTenant` = `"tenant"`
- `OwnerThirdParty` = `"thirdparty"`

### Updated files:
- `internal/webhook/authorization/namespace_mutating_webhook.go`
- `internal/webhook/authorization/namespace_validating_webhook.go`

## Benefits

1. **Single source of truth**: Label keys defined in one place
2. **Type safety**: Typos caught at compile time
3. **Discoverability**: Labels documented with comments
4. **Maintainability**: Easier to update if labels change

## Testing

```bash
go build ./...
go test ./internal/webhook/authorization/...
```

## Related Issue

Addresses code review finding: hardcoded label keys in namespace webhooks
