### PR TITLE
fix: mergeReconcileResults now also merges Requeue flag

### DIFF
--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -227,6 +227,13 @@ func (r *bindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 func mergeReconcileResults(results ...ctrl.Result) ctrl.Result {
 	merged := ctrl.Result{}
 	for _, res := range results {
+		// Merge Requeue flag - if any result requests requeue, the merged result should too
+		// Note: Requeue is deprecated in favor of RequeueAfter, but we still need to handle
+		// it for backward compatibility with sub-reconcilers that may still use it.
+		if res.Requeue { //nolint:staticcheck // SA1019: Handling deprecated Requeue for compatibility
+			merged.Requeue = true //nolint:staticcheck // SA1019: Setting deprecated Requeue for compatibility
+		}
+		// Merge RequeueAfter - use the longest requeue duration
 		if res.RequeueAfter > 0 && (merged.RequeueAfter == 0 || res.RequeueAfter > merged.RequeueAfter) {
 			merged.RequeueAfter = res.RequeueAfter
 		}


### PR DESCRIPTION
## Summary

Fix `mergeReconcileResults` function to properly merge the `Requeue` boolean flag in addition to `RequeueAfter`.

## Problem

The function was only merging `RequeueAfter` durations but ignoring `Requeue` boolean:

```go
// Before: Only merges RequeueAfter
func mergeReconcileResults(results ...ctrl.Result) ctrl.Result {
    merged := ctrl.Result{}
    for _, res := range results {
        if res.RequeueAfter > 0 && ... {
            merged.RequeueAfter = res.RequeueAfter
        }
    }
    return merged
}
```

This could cause immediate requeue requests (`Requeue: true`) to be silently dropped when merging results from sub-reconcilers.

## Solution

Now merges both fields:
- `Requeue`: Set to `true` if any result requests immediate requeue
- `RequeueAfter`: Uses the longest duration from all results

```go
// After: Merges both Requeue and RequeueAfter
if res.Requeue {
    merged.Requeue = true
}
if res.RequeueAfter > 0 && ... {
    merged.RequeueAfter = res.RequeueAfter
}
```

## Testing

```bash
go build ./...
go test ./internal/controller/authorization/...
```

## Related Issue

Addresses code review finding: mergeReconcileResults ignores Requeue flag
