### PR TITLE
feat: add MaxLength and Pattern validation to TargetName field

### DIFF
--- a/api/authorization/v1alpha1/roledefinition_types.go
+++ b/api/authorization/v1alpha1/roledefinition_types.go
@@ -17,9 +17,12 @@ type RoleDefinitionSpec struct {
 	// +kubebuilder:validation:Enum=ClusterRole;Role
 	TargetRole string `json:"targetRole"`
 
-	// The name of the target role. This can be any name that accurately describes the ClusterRole/Role
+	// The name of the target role. This can be any name that accurately describes the ClusterRole/Role.
+	// Must be a valid Kubernetes name (max 63 characters for most resources).
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=5
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	TargetName string `json:"targetName"`
 
 	// The target namespace for the Role. This value is necessary when the "TargetRole" is "Role"

--- a/config/crd/bases/authorization.t-caas.telekom.com_roledefinitions.yaml
+++ b/config/crd/bases/authorization.t-caas.telekom.com_roledefinitions.yaml
@@ -253,9 +253,12 @@ spec:
                   running `kubectl api-resources --namespaced=true/false`
                 type: boolean
               targetName:
-                description: The name of the target role. This can be any name that
-                  accurately describes the ClusterRole/Role
+                description: |-
+                  The name of the target role. This can be any name that accurately describes the ClusterRole/Role.
+                  Must be a valid Kubernetes name (max 63 characters for most resources).
+                maxLength: 63
                 minLength: 5
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               targetNamespace:
                 description: The target namespace for the Role. This value is necessary


### PR DESCRIPTION
## Summary

Add `MaxLength` and `Pattern` validation to `RoleDefinition.Spec.TargetName` field.

## Problem

The `TargetName` field only had `MinLength=5` validation, which meant:
- Users could create names exceeding Kubernetes limits (63 chars for most resources)
- Users could create names with invalid characters that would fail at Role/ClusterRole creation time

## Solution

Added kubebuilder validation markers:
- `MaxLength=63`: Standard Kubernetes name length limit
- `Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`: DNS subdomain name pattern

## Changes

- `api/authorization/v1alpha1/roledefinition_types.go`: Added validation markers
- `config/crd/bases/`: Regenerated CRD manifests

## Before

```go
// +kubebuilder:validation:MinLength=5
TargetName string `json:"targetName"`
```

## After

```go
// +kubebuilder:validation:MinLength=5
// +kubebuilder:validation:MaxLength=63
// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
TargetName string `json:"targetName"`
```

## Testing

```bash
make manifests
go build ./...
# Try creating a RoleDefinition with an invalid name - should be rejected
```

## Related Issue

Addresses code review finding: missing TargetName maximum length validation
