### PR TITLE
fix: add defer r.Body.Close() to webhook authorizer handler

### DIFF
--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -38,6 +38,9 @@ func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Use request context for proper cancellation and deadline propagation
 	ctx := r.Context()
 
+	// Ensure request body is closed to prevent resource leaks
+	defer func() { _ = r.Body.Close() }()
+
 	var sar authzv1.SubjectAccessReview
 
 	if err := json.NewDecoder(r.Body).Decode(&sar); err != nil {


### PR DESCRIPTION
## Summary

Add `defer r.Body.Close()` to the webhook authorizer's HTTP handler.

## Problem

The `ServeHTTP` method in `webhook_authorizer.go` was not explicitly closing the request body after reading it.

## Solution

Added `defer r.Body.Close()` immediately after obtaining the context:

```go
func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
    ctx := r.Context()
    
    // Ensure request body is closed to prevent resource leaks
    defer r.Body.Close()
    
    // ... rest of handler
}
```

## Why This Matters

While Go's HTTP server typically handles closing the body after the handler returns, explicitly closing it is a best practice:

1. **Explicit resource management**: Makes it clear the body will be closed
2. **Defensive programming**: Works correctly even if called outside a standard server context
3. **Follows conventions**: Common pattern in Go HTTP handlers
4. **Prevents potential leaks**: Ensures cleanup in all code paths

## Testing

```bash
go build ./...
go test ./internal/webhook/authorization/...
```

## Related Issue

Addresses code review finding: missing request body close in webhook authorizer
