### PR TITLE
fix: correct default NAMESPACE in Makefile to match deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ include versions.env
 PROJECT_NAME = "auth-operator"
 APP ?= auth-operator
 IMG ?= $(APP):latest
-NAMESPACE ?= kube-system
+NAMESPACE ?= auth-operator-system
 
 # E2E run identifier and deterministic kind cluster name
 RUN_ID ?= $(shell date +%s)


### PR DESCRIPTION
## Summary

Fix the default `NAMESPACE` variable in Makefile to match the actual deployment namespace.

## Problem

The Makefile had:
```makefile
NAMESPACE ?= kube-system
```

But the operator is actually deployed to `auth-operator-system` (as defined in kustomize overlays and helm chart).

## Solution

Changed to:
```makefile
NAMESPACE ?= auth-operator-system
```

## Impact

This ensures Makefile targets that use `$(NAMESPACE)` (like `make logs`, `make undeploy`, etc.) work correctly with the deployed resources without requiring manual override.

## Testing

```bash
make deploy
kubectl get pods -n auth-operator-system
make logs  # Should now work without specifying NAMESPACE
```

## Related Issue

Addresses code review finding: namespace mismatch in Makefile
