### PR TITLE
ci: add verify-generated job to ensure Helm chart CRDs are up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,39 @@ jobs:
       - name: Build Docker image
         run: docker build -t auth-operator:test .
 
+  verify-generated:
+    name: Verify Generated Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Generate manifests, code, and Helm chart
+        run: |
+          make manifests
+          make generate
+          make helm
+
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --exit-code; then
+            echo "ERROR: Generated files are out of date. Run 'make manifests generate helm' and commit changes."
+            echo ""
+            echo "Changed files:"
+            git diff --name-only
+            exit 1
+          fi
+          if ! git diff --cached --exit-code; then
+            echo "ERROR: There are staged changes after generation."
+            exit 1
+          fi
+
   helm-lint:
     name: Helm Lint
     runs-on: ubuntu-latest

--- a/chart/auth-operator/crds/roledefinitions.authorization.t-caas.telekom.com.yaml
+++ b/chart/auth-operator/crds/roledefinitions.authorization.t-caas.telekom.com.yaml
@@ -254,9 +254,12 @@ spec:
                   running `kubectl api-resources --namespaced=true/false`
                 type: boolean
               targetName:
-                description: The name of the target role. This can be any name that
-                  accurately describes the ClusterRole/Role
+                description: |-
+                  The name of the target role. This can be any name that accurately describes the ClusterRole/Role.
+                  Must be a valid Kubernetes name (max 63 characters for most resources).
+                maxLength: 63
                 minLength: 5
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               targetNamespace:
                 description: The target namespace for the Role. This value is necessary


### PR DESCRIPTION
Adds CI job that runs make manifests generate helm and checks for uncommitted changes. Ensures generated files are always in sync with source.