### PR TITLE
Add GitHub Copilot agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,233 @@
+# Auth Operator - Copilot Instructions
+
+## Project Overview
+
+Auth Operator is a Kubernetes operator for T-CaaS that manages authentication (`authN`) and authorization (`authZ`) across multiple cluster consumers. It provides three CRDs:
+- **RoleDefinition**: Dynamically generates ClusterRoles/Roles based on API discovery
+- **BindDefinition**: Creates ClusterRoleBindings/RoleBindings for subjects (Users, Groups, ServiceAccounts)
+- **WebhookAuthorizer**: Configures webhook-based authorization decisions
+
+**Stack**: Go 1.25, Kubebuilder v4 (multi-group layout), controller-runtime v0.23, Ginkgo/Gomega testing, Helm chart  
+**Domain**: `t-caas.telekom.com` | **API Group**: `authorization.t-caas.telekom.com` | **Version**: `v1alpha1`
+
+## Build & Validation Commands
+
+**Always run from repository root.** Tool versions in `versions.env`.
+
+### Essential Workflow
+```bash
+make manifests generate  # ALWAYS after editing *_types.go or kubebuilder markers
+make fmt vet lint        # Format, vet, lint
+make build               # Build binary (includes manifests, generate, fmt, vet)
+make test                # Unit + integration tests (envtest)
+make docs                # Regenerate API docs
+make helm                # Sync CRDs to Helm chart
+```
+
+### Pre-Commit Validation (Run Before Every PR)
+```bash
+go mod tidy              # CI verifies this
+make manifests generate  # Regenerate CRDs/DeepCopy
+make lint                # golangci-lint
+make test                # Unit tests
+make helm-lint           # Lint Helm chart
+git diff --exit-code     # Verify no uncommitted generated changes
+```
+
+### CI Checks (GitHub Actions)
+| Check | Command | Workflow |
+|-------|---------|----------|
+| Lint | `golangci-lint run --timeout 10m` | ci.yml |
+| Vet | `go vet ./...` | ci.yml |
+| go.mod tidy | `go mod tidy && git diff --exit-code go.mod go.sum` | ci.yml |
+| Unit Tests | `make test` (envtest K8s 1.34.1) | ci.yml, e2e.yml |
+| Build | `go build -v -o bin/auth-operator ./main.go` | ci.yml |
+| Docker | `docker build -t auth-operator:test .` | ci.yml |
+| Helm Lint | `helm lint chart/auth-operator --strict` | ci.yml |
+| Security | `govulncheck ./...` | ci.yml |
+| REUSE | License headers in all files | reuse-compliance.yml |
+
+### E2E Testing (Requires kind + Docker)
+```bash
+make test-e2e-full       # Full suite (fresh kind cluster)
+make test-e2e-helm-full  # Helm installation tests
+make test-e2e-ha         # HA/leader-election (multi-node)
+```
+Set `SKIP_E2E_CLEANUP=true` to keep cluster for debugging.
+
+**E2E Test Labels**: `helm`, `complex`, `ha`, `leader-election`, `integration`, `golden`, `dev`
+
+## Project Structure (Multi-Group Kubebuilder v4)
+
+```
+main.go                              # Entry point (invokes cmd package)
+cmd/
+  root.go                            # CLI setup, scheme registration
+  controller.go                      # Controller manager init
+  webhook.go                         # Webhook server init
+api/authorization/v1alpha1/
+  roledefinition_types.go            # RoleDefinition CRD schema
+  binddefinition_types.go            # BindDefinition CRD schema
+  webhookauthorizer_types.go         # WebhookAuthorizer CRD schema
+  *_webhook.go                       # Validation webhooks
+  conditions.go                      # Condition type definitions
+  groupversion_info.go               # API group registration
+  zz_generated.deepcopy.go           # AUTO-GENERATED (never edit)
+internal/controller/authorization/
+  roledefinition_controller.go       # RoleDefinition reconciliation
+  binddefinition_controller.go       # BindDefinition reconciliation
+  *_helpers.go                       # Controller helpers
+internal/webhook/
+  authorization/                     # Webhook handlers
+  certrotator/                       # TLS cert rotation (cert-controller)
+pkg/
+  conditions/                        # Condition management utilities
+  discovery/                         # API resource discovery & tracking
+  helpers/                           # Shared helpers
+  indexer/                           # Client indexer utilities
+  system/                            # System-level utilities
+config/
+  crd/bases/                         # AUTO-GENERATED CRDs (never edit)
+  rbac/                              # AUTO-GENERATED RBAC (never edit)
+  webhook/manifests.yaml             # AUTO-GENERATED (never edit)
+  overlays/dev/                      # Dev overlay (debug logging)
+  overlays/production/               # Prod overlay
+  samples/                           # Example CRs (edit these)
+chart/auth-operator/
+  crds/                              # AUTO-SYNCED from config/crd/bases
+test/e2e/                            # E2E tests (Ginkgo)
+docs/api-reference/                  # Generated API documentation
+```
+
+## Critical Rules
+
+### Never Edit Auto-Generated Files
+- `config/crd/bases/*.yaml` — run `make manifests`
+- `config/rbac/role.yaml` — run `make manifests`
+- `config/webhook/manifests.yaml` — run `make manifests`
+- `api/**/zz_generated.deepcopy.go` — run `make generate`
+- `chart/auth-operator/crds/*.yaml` — run `make helm`
+- `PROJECT` — Kubebuilder metadata (do not edit)
+
+### Never Remove Scaffold Markers
+Do NOT delete `// +kubebuilder:scaffold:*` comments. Kubebuilder CLI injects code at these markers.
+
+### Keep Project Structure
+Do not move files around. The Kubebuilder CLI expects files in specific locations.
+
+### After Editing Type Files
+After modifying `api/authorization/v1alpha1/*_types.go` or kubebuilder markers:
+```bash
+make manifests generate  # Regenerate CRDs, RBAC, DeepCopy
+make docs                # Regenerate API reference
+make helm                # Sync CRDs to Helm chart
+```
+
+### Use Standard Library Constants
+```go
+// Good                    // Bad
+http.MethodGet            "GET"
+rbacv1.GroupName          "rbac.authorization.k8s.io"
+```
+
+### Testing Requirements
+All new features must include tests (target >70% coverage):
+- Unit tests: `*_test.go` colocated with source
+- Controller tests: `internal/controller/authorization/*_test.go`
+- E2E tests: `test/e2e/` (use Ginkgo labels)
+
+### E2E Tests Require Isolated Kind Cluster
+Run E2E tests against a dedicated kind cluster, not dev/prod clusters.
+
+## Controller & Webhook Patterns
+
+### Reconciliation (Idempotent)
+```go
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    logger := log.FromContext(ctx)
+    // 1. Fetch resource (use client.IgnoreNotFound)
+    // 2. Handle finalizers for cleanup
+    // 3. Reconcile desired state
+    // 4. Update status and conditions
+}
+```
+
+### Condition Management
+```go
+import "github.com/telekom/auth-operator/pkg/conditions"
+conditions.SetCondition(obj, metav1.Condition{
+    Type: "Ready", Status: metav1.ConditionTrue, Reason: "Reconciled", Message: "Success",
+})
+```
+
+### RBAC Markers (in controllers)
+```go
+// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=roledefinitions,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=roledefinitions/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=roledefinitions/finalizers,verbs=update
+```
+
+### Webhook Markers
+```go
+// +kubebuilder:webhook:path=/validate-...,mutating=false,failurePolicy=fail,sideEffects=None,...
+```
+
+### Structured Logging
+```go
+logger := log.FromContext(ctx)
+logger.Info("msg", "key", val)
+logger.V(1).Info("debug")  // Verbose
+```
+
+## Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `.golangci.yml` | Go linter config (v2 format, Go 1.25) |
+| `.yamllint.yml` | YAML linting rules |
+| `versions.env` | Tool versions (controller-gen, kustomize, etc.) |
+| `PROJECT` | Kubebuilder project metadata (do not edit) |
+| `Makefile` | All build/test/deploy commands |
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NAMESPACE` | Operator namespace | `kube-system` |
+| `LEADER_ELECTION` | Enable leader election | `true` |
+| `PROBE_ADDR` | Health probe address | `:8081` |
+| `METRICS_ADDR` | Metrics address | `:8080` |
+
+## Common Issues & Workarounds
+
+| Issue | Solution |
+|-------|----------|
+| "go.mod is not tidy" in CI | Run `go mod tidy` before committing |
+| "Generated code out of date" | Run `make manifests generate` and commit |
+| Envtest failures | Run `make envtest && $(LOCALBIN)/setup-envtest use 1.34.1 --bin-dir ./bin` |
+| Helm CRD sync | Run `make helm` after modifying CRDs |
+
+## Kubebuilder CLI Commands (Reference)
+
+```bash
+# Create new API
+kubebuilder create api --group <group> --version <version> --kind <Kind>
+
+# Create webhooks
+kubebuilder create webhook --group <group> --version <version> --kind <Kind> --defaulting --programmatic-validation
+
+# Controller for core K8s types (no CRD)
+kubebuilder create api --group core --version v1 --kind Pod --controller=true --resource=false
+```
+
+## References
+
+- **Kubebuilder Book**: https://book.kubebuilder.io
+- **controller-runtime**: https://github.com/kubernetes-sigs/controller-runtime
+- **API Conventions**: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md
+- **Markers Reference**: https://book.kubebuilder.io/reference/markers.html
+- **Good Practices**: https://book.kubebuilder.io/reference/good-practices.html
+- **cert-controller**: https://github.com/open-policy-agent/cert-controller (TLS management)
+
+## Trust These Instructions
+The information above is validated and accurate. Only search the codebase if these instructions are incomplete or produce errors.


### PR DESCRIPTION
## Summary

Add `.github/copilot-instructions.md` to onboard AI coding agents (GitHub Copilot) to this repository.

## What's Included

This file provides comprehensive guidance for AI agents to work efficiently with the codebase:

- **Project overview** and stack information (Go 1.25, Kubebuilder v4, controller-runtime v0.23)
- **Build and validation commands** with CI checks table
- **Project structure** for multi-group Kubebuilder v4 layout
- **Critical rules** (auto-generated files, scaffold markers, keep project structure)
- **Controller and webhook patterns** with code examples
- **Configuration files and environment variables** tables
- **Common issues and workarounds**
- **Kubebuilder CLI commands reference**

## Benefits

- Reduces exploration time for AI agents
- Minimizes CI failures from common mistakes
- Provides clear guidance on what files can/cannot be edited
- Documents the correct order of build commands

## Related

Information was consolidated from:
- Local `AGENTS.md`
- [Kubebuilder project-v4 AGENTS.md](https://github.com/kubernetes-sigs/kubebuilder/blob/v4.11.0/testdata/project-v4/AGENTS.md)
