### PR TITLE
refactor: use rbacv1.GroupName constant instead of hardcoded string

### DIFF
--- a/internal/controller/authorization/binddefinition_helpers.go
+++ b/internal/controller/authorization/binddefinition_helpers.go
@@ -379,7 +379,7 @@ func (r *bindDefinitionReconciler) createClusterRoleBindings(
 			},
 			Subjects: bindDef.Spec.Subjects,
 			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
+				APIGroup: rbacv1.GroupName,
 				Kind:     "ClusterRole",
 				Name:     clusterRoleRef,
 			},
@@ -525,7 +525,7 @@ func (r *bindDefinitionReconciler) createSingleRoleBinding(
 		},
 		Subjects: bindDef.Spec.Subjects,
 		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
+			APIGroup: rbacv1.GroupName,
 			Kind:     roleKind,
 			Name:     roleRef,
 		},
@@ -636,7 +636,7 @@ func (r *bindDefinitionReconciler) updateClusterRoleBindings(
 			},
 			Subjects: bindDef.Spec.Subjects,
 			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
+				APIGroup: rbacv1.GroupName,
 				Kind:     "ClusterRole",
 				Name:     clusterRoleRef,
 			},
@@ -721,7 +721,7 @@ func (r *bindDefinitionReconciler) updateSingleRoleBinding(
 		},
 		Subjects: bindDef.Spec.Subjects,
 		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
+			APIGroup: rbacv1.GroupName,
 			Kind:     roleKind,
 			Name:     roleRef,
 		},


### PR DESCRIPTION
## Summary
Replace hardcoded `"rbac.authorization.k8s.io"` string literals with `rbacv1.GroupName` constant.

## Changes
- Updated `internal/controller/authorization/binddefinition_helpers.go`
- Replaced 4 occurrences of hardcoded RBAC API group string with the constant

## Rationale
Using the `rbacv1.GroupName` constant instead of hardcoded strings improves:
- **Maintainability**: Single source of truth for the API group name
- **Type safety**: Catches typos at compile time rather than runtime
- **Consistency**: Aligns with Kubernetes client-go best practices