### PR TITLE
refactor: extract binding suffix as constant

### DIFF
--- a/internal/controller/authorization/binddefinition_helpers.go
+++ b/internal/controller/authorization/binddefinition_helpers.go
@@ -46,6 +46,9 @@ const (
 	deleteResultNoOwnerRef
 )
 
+// BindingSuffix is the suffix appended to binding resource names.
+const BindingSuffix = "binding"
+
 // deleteServiceAccount attempts to delete a service account if it has a controller reference.
 // Returns the result of the deletion and any error encountered.
 func (r *bindDefinitionReconciler) deleteServiceAccount(
@@ -219,7 +222,7 @@ func (r *bindDefinitionReconciler) deleteRoleBinding(
 
 // buildBindingName constructs a binding name from target name and role ref.
 func buildBindingName(targetName, roleRef string) string {
-	return fmt.Sprintf("%s-%s-%s", targetName, roleRef, "binding")
+	return fmt.Sprintf("%s-%s-%s", targetName, roleRef, BindingSuffix)
 }
 
 // filterActiveNamespaces returns namespaces that are not in terminating phase.


### PR DESCRIPTION
## Summary
Extract the magic string `"binding"` as a constant `BindingSuffix`.

## Changes
- Added `BindingSuffix` constant in `internal/controller/authorization/binddefinition_helpers.go`
- Updated `buildBindingName` function to use the constant

## Rationale
- **Maintainability**: Easier to change the suffix in one place if needed
- **Clarity**: Makes the naming convention explicit and documented
- **Consistency**: Follows best practice of avoiding magic strings