### PR TITLE
feat: add Prometheus metrics for observability

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -17,6 +17,9 @@ import (
 	"github.com/telekom/auth-operator/pkg/discovery"
 	"github.com/telekom/auth-operator/pkg/indexer"
 
+	// Import metrics package to register custom Prometheus metrics
+	_ "github.com/telekom/auth-operator/pkg/metrics"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.23.2
 	golang.org/x/sync v0.19.0
 	golang.org/x/time v0.14.0
 )
@@ -51,7 +52,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,157 @@
+/*
+Copyright © 2025 Deutsche Telekom AG
+*/
+
+// Package metrics provides Prometheus metrics for the auth-operator.
+// It exposes custom metrics for reconciliation performance, error tracking,
+// and operational insights.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	// Namespace is the Prometheus metrics namespace for auth-operator
+	Namespace = "auth_operator"
+)
+
+var (
+	// ReconcileTotal counts the total number of reconciliations per controller
+	ReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "reconcile_total",
+			Help:      "Total number of reconciliations per controller",
+		},
+		[]string{"controller", "result"},
+	)
+
+	// ReconcileDuration measures the duration of reconciliations in seconds
+	ReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Name:      "reconcile_duration_seconds",
+			Help:      "Duration of reconciliations per controller in seconds",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"controller"},
+	)
+
+	// ReconcileErrors counts the total number of reconciliation errors per controller
+	ReconcileErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "reconcile_errors_total",
+			Help:      "Total number of reconciliation errors per controller",
+		},
+		[]string{"controller", "error_type"},
+	)
+
+	// ResourcesManaged tracks the number of resources managed per controller type
+	ResourcesManaged = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "resources_managed",
+			Help:      "Number of resources currently being managed per controller type",
+		},
+		[]string{"controller", "resource_type"},
+	)
+
+	// APIDiscoveryDuration measures the duration of API discovery operations in seconds
+	APIDiscoveryDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Name:      "api_discovery_duration_seconds",
+			Help:      "Duration of API discovery operations in seconds",
+			Buckets:   prometheus.DefBuckets,
+		},
+	)
+
+	// APIDiscoveryErrors counts the total number of API discovery errors
+	APIDiscoveryErrors = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "api_discovery_errors_total",
+			Help:      "Total number of API discovery errors",
+		},
+	)
+
+	// RBACResourcesCreated counts the total number of RBAC resources created
+	RBACResourcesCreated = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "rbac_resources_created_total",
+			Help:      "Total number of RBAC resources created",
+		},
+		[]string{"resource_type"},
+	)
+
+	// RBACResourcesDeleted counts the total number of RBAC resources deleted
+	RBACResourcesDeleted = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "rbac_resources_deleted_total",
+			Help:      "Total number of RBAC resources deleted",
+		},
+		[]string{"resource_type"},
+	)
+
+	// RBACResourcesUpdated counts the total number of RBAC resources updated
+	RBACResourcesUpdated = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "rbac_resources_updated_total",
+			Help:      "Total number of RBAC resources updated",
+		},
+		[]string{"resource_type"},
+	)
+)
+
+func init() {
+	// Register all metrics with controller-runtime's registry
+	metrics.Registry.MustRegister(
+		ReconcileTotal,
+		ReconcileDuration,
+		ReconcileErrors,
+		ResourcesManaged,
+		APIDiscoveryDuration,
+		APIDiscoveryErrors,
+		RBACResourcesCreated,
+		RBACResourcesDeleted,
+		RBACResourcesUpdated,
+	)
+}
+
+// ReconcileResult constants for labeling reconcile outcomes
+const (
+	ResultSuccess   = "success"
+	ResultError     = "error"
+	ResultRequeue   = "requeue"
+	ResultSkipped   = "skipped"
+	ResultFinalized = "finalized"
+)
+
+// ErrorType constants for categorizing reconciliation errors
+const (
+	ErrorTypeAPI        = "api"
+	ErrorTypeValidation = "validation"
+	ErrorTypeConflict   = "conflict"
+	ErrorTypeNotFound   = "not_found"
+	ErrorTypeInternal   = "internal"
+)
+
+// ControllerName constants
+const (
+	ControllerRoleDefinition = "RoleDefinition"
+	ControllerBindDefinition = "BindDefinition"
+)
+
+// ResourceType constants
+const (
+	ResourceClusterRole        = "ClusterRole"
+	ResourceRole               = "Role"
+	ResourceClusterRoleBinding = "ClusterRoleBinding"
+	ResourceRoleBinding        = "RoleBinding"
+)


### PR DESCRIPTION
Add a new pkg/metrics package with custom Prometheus metrics for improved observability. Metrics include reconciliation counts, duration, errors per controller, API discovery metrics, and RBAC resource operation counters. All metrics are automatically registered with controller-runtime's registry.