### PR TITLE
docs: explain DefaultRequeueInterval rationale

### DIFF
--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -28,8 +28,20 @@ import (
 )
 
 const (
-	// DefaultRequeueInterval is the interval at which resources are requeued
-	// to ensure drift from manual modifications is corrected
+	// DefaultRequeueInterval is the interval at which BindDefinition resources are
+	// re-reconciled to ensure drift from manual modifications is corrected.
+	//
+	// This interval serves multiple purposes:
+	// 1. Drift Correction: If someone manually modifies a ClusterRoleBinding, RoleBinding,
+	//    or ServiceAccount managed by the operator, the next reconciliation will restore
+	//    the desired state defined in the BindDefinition.
+	// 2. Namespace Discovery: New namespaces matching the BindDefinition's selector will
+	//    be picked up within this interval, creating the appropriate RoleBindings.
+	// 3. Resilience: Acts as a safety net in case watch events are missed due to
+	//    temporary network issues or API server restarts.
+	//
+	// The 60-second interval balances responsiveness with API server load. For clusters
+	// with many BindDefinitions, this can be tuned via the operator's configuration.
 	DefaultRequeueInterval = 60 * time.Second
 )
 


### PR DESCRIPTION
## Summary

Documents the rationale behind the `DefaultRequeueInterval` of 60 seconds in the BindDefinition controller.

## Changes

- Added detailed comment explaining the 60-second interval choice
- Documents the purpose of periodic drift correction
- Explains tradeoffs between API load and recency

## Related

Addresses TODO item #10: Document DefaultRequeueInterval rationale
