### PR TITLE
feat: integrate custom metrics into controllers and tracker

### DIFF
--- a/internal/controller/authorization/binddefinition_helpers.go
+++ b/internal/controller/authorization/binddefinition_helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/telekom/auth-operator/api/authorization/v1alpha1/applyconfiguration/ssa"
 	"github.com/telekom/auth-operator/pkg/conditions"
 	"github.com/telekom/auth-operator/pkg/helpers"
+	"github.com/telekom/auth-operator/pkg/metrics"
 )
 
 // logStatusApplyError logs a status apply error without failing the operation.
@@ -200,6 +201,7 @@ func (r *BindDefinitionReconciler) deleteClusterRoleBinding(
 		return 0, fmt.Errorf("delete ClusterRoleBinding %s: %w", crbName, err)
 	}
 
+	metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceClusterRoleBinding).Inc()
 	log.V(1).Info("Successfully deleted ClusterRoleBinding",
 		"bindDefinitionName", bindDef.Name, "clusterRoleBindingName", crbName)
 	return deleteResultDeleted, nil
@@ -253,6 +255,7 @@ func (r *BindDefinitionReconciler) deleteRoleBinding(
 		return 0, fmt.Errorf("delete RoleBinding %s/%s: %w", namespace, rbName, err)
 	}
 
+	metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceRoleBinding).Inc()
 	log.V(1).Info("Successfully deleted RoleBinding",
 		"bindDefinitionName", bindDef.Name, "roleBindingName", rbName, "namespace", namespace)
 	return deleteResultDeleted, nil
@@ -444,6 +447,7 @@ func (r *BindDefinitionReconciler) createClusterRoleBindings(
 				"bindDefinitionName", bindDef.Name, "clusterRoleBindingName", crbName)
 			return fmt.Errorf("create ClusterRoleBinding %s: %w", crbName, err)
 		}
+		metrics.RBACResourcesCreated.WithLabelValues(metrics.ResourceClusterRoleBinding).Inc()
 		log.V(1).Info("Created ClusterRoleBinding",
 			"bindDefinitionName", bindDef.Name, "clusterRoleBindingName", crbName)
 		r.recorder.Eventf(bindDef, corev1.EventTypeNormal, authnv1alpha1.EventReasonCreate,
@@ -588,6 +592,7 @@ func (r *BindDefinitionReconciler) createSingleRoleBinding(
 	if err := r.client.Create(ctx, rb); err != nil {
 		return fmt.Errorf("create RoleBinding %s/%s: %w", namespace, rbName, err)
 	}
+	metrics.RBACResourcesCreated.WithLabelValues(metrics.ResourceRoleBinding).Inc()
 	log.Info("Created", "RoleBinding", rb.Name)
 	r.recorder.Eventf(bindDef, corev1.EventTypeNormal, authnv1alpha1.EventReasonCreate,
 		"Created resource %s/%s in namespace %s", rb.Kind, rb.Name, rb.Namespace)


### PR DESCRIPTION
## Summary

Integrates the custom metrics infrastructure (added in PR #26) into the controllers and ResourceTracker. The metrics were defined but not actually being recorded.

## Changes

### Metrics Integration

**RoleDefinition Controller:**
- Reconciliation duration histogram (`auth_operator_reconcile_duration_seconds`)
- Reconcile total counter with result labels (`auth_operator_reconcile_total`)
- Error counter by type (`auth_operator_reconcile_errors_total`)
- RBAC resource created/updated counters

**BindDefinition Controller:**
- Reconciliation duration histogram
- Reconcile total counter with result labels (success, error, skipped, finalized)
- Error counter by type
- RoleBinding/ClusterRoleBinding created/deleted counters

**ResourceTracker:**
- API discovery duration histogram (`auth_operator_api_discovery_duration_seconds`)
- API discovery error counter (`auth_operator_api_discovery_errors_total`)

### Code Quality Improvements

Refactored `createRole()` and `reconcileDelete()` helper functions to return `error` only instead of `(ctrl.Result, error)`, since the Result was always `ctrl.Result{}`. This fixes `unparam` lint warnings properly rather than silencing them.

## Testing

- [x] `make lint` - 0 issues
- [x] `make test` - All tests pass
- [x] `go build ./...` - Compiles successfully

## Related


- Built on top of PR #26 metrics infrastructure
