### PR TITLE
fix(ci): fix release SBOM attest and image signature verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,8 +236,12 @@ jobs:
       - name: Verify image signature
         if: steps.tag.outputs.tag_found == 'true'
         run: |
-          IMAGE="ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}"
+          # Image tags use semver without 'v' prefix (docker/metadata-action strips it)
+          IMAGE_VERSION="${TAG#v}"
+          IMAGE="ghcr.io/${{ github.repository }}:${IMAGE_VERSION}"
           cosign verify \
             --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/tags/${{ steps.tag.outputs.tag }}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             "$IMAGE"
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
-          cosign attest --yes --type spdx --predicate sbom.spdx.json ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          cosign attest --yes --type spdxjson --predicate sbom.spdx.json ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 
       # GitHub-native attestations (visible in GitHub UI and verifiable with `gh attestation verify`)
       - name: Attest container image provenance (GitHub)
@@ -281,7 +281,7 @@ jobs:
           Verify the SBOM attestation:
           \`\`\`bash
           cosign verify-attestation ${IMAGE}@${DIGEST} \\
-            --type spdx \\
+            --type spdxjson \\
             --certificate-identity-regexp="https://github.com/${{ github.repository }}/.github/workflows/release.yml@.*" \\
             --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
           \`\`\`


### PR DESCRIPTION
- release.yml: Change cosign attest --type spdx to --type spdxjson to match the SPDX JSON format produced by anchore/sbom-action (fixes 'invalid attestation: decoding json' error)
- ci.yml: Strip 'v' prefix from git tag when constructing image reference, since docker/metadata-action's semver pattern produces tags without it (fixes 'DENIED: requested access to the resource' error)
- release.yml: Update verify-attestation docs to use --type spdxjson
