### PR TITLE
chore: update CODEOWNERS team to @telekom/t-caas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,14 @@
 # Default owners for everything in the repo
-* @telekom/t-caas-maintainers
+* @telekom/t-caas
 
 # API definitions require additional review
-/api/ @telekom/t-caas-maintainers
+/api/ @telekom/t-caas
 
 # Helm chart changes
-/chart/ @telekom/t-caas-maintainers
+/chart/ @telekom/t-caas
 
 # CI/CD changes
-/.github/ @telekom/t-caas-maintainers
+/.github/ @telekom/t-caas
 
 # Documentation
-/docs/ @telekom/t-caas-maintainers
+/docs/ @telekom/t-caas


### PR DESCRIPTION
## Description

Update CODEOWNERS to use the correct team `@telekom/t-caas` (replacing `@telekom/t-caas-maintainers`).

Part of a cross-project alignment initiative to standardize community & legal files across all t-caas repositories.

## Type of Change

- [x] 🔧 Configuration change

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## API Changes

- [x] No API changes

## Testing

No testing required — configuration-only change.