### PR TITLE
feat: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -27,6 +27,7 @@ jobs:
     name: OpenSSF Scorecard
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
       id-token: write
 
@@ -51,8 +52,7 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        if: always()
-        continue-on-error: true
+        if: ${{ github.event_name != 'pull_request' }}
         uses: github/codeql-action/upload-sarif@f3a6ee42055dd5f618fb31d987aae7b94518f043 # v4.32.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Adds the OpenSSF Scorecard GitHub Actions workflow for automated security health assessment, matching the pattern already used in k8s-breakglass.

## Changes

- Add `.github/workflows/openssf-scorecard.yml` with weekly schedule and push triggers
- All actions are SHA-pinned for supply-chain security
- Results uploaded to GitHub code scanning dashboard via SARIF

## Audit Finding

Addresses **Finding #25** (MEDIUM — CI / Security) from the cross-repo audit.