### PR TITLE
fix: pin Dockerfile base images by SHA256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 # Go version is read from go.mod via GO_VERSION build arg
 # Default fallback if not provided (should match go.mod)
 ARG GO_VERSION=1.25
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
+# Digest pinned for supply-chain integrity; update with:
+#   docker buildx imagetools inspect golang:<version>-alpine
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced AS build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -30,7 +32,9 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
 	-o /out/auth-operator ./main.go
 
 # Runtime stage (distroless)
-FROM gcr.io/distroless/static-debian12
+# Digest pinned for supply-chain integrity; update with:
+#   docker buildx imagetools inspect gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12@sha256:20bc6c0bc4d625a22a8fde3e55f6515709b32055ef8fb9cfbddaa06d1760f838
 
 # OCI image labels (may be overridden by docker/metadata-action in CI)
 LABEL org.opencontainers.image.title="auth-operator" \


### PR DESCRIPTION
## Summary

Pin both Dockerfile base images (`golang:1.25-alpine` and `gcr.io/distroless/static-debian12`) to their SHA256 manifest-index digests for supply-chain integrity.

## Changes

- `golang:1.25-alpine` → pinned to `@sha256:f6751d823c26342f...`
- `gcr.io/distroless/static-debian12` → pinned to `@sha256:20bc6c0bc4d625a...`
- Added inline comments documenting the update command for each image

## Rationale

Tags are mutable — a compromised registry or upstream maintainer could point a tag to a different image. SHA-pinning ensures the exact image contents are used at build time. Both digests reference the multi-arch manifest index, so QEMU cross-compilation continues to work correctly.

This aligns the auth-operator Dockerfile with k8s-breakglass, which already pins all base images by SHA.

## Audit Finding

Addresses **H1**: Dockerfile base images not SHA-pinned.

## Maintenance

When upgrading Go or distroless versions, update the digest alongside the version:

```bash
docker buildx imagetools inspect golang:<version>-alpine
docker buildx imagetools inspect gcr.io/distroless/static-debian12
```
