### PR TITLE
chore: align composite action SHAs with workflow files

### DIFF
--- a/.github/actions/build-operator-image/action.yml
+++ b/.github/actions/build-operator-image/action.yml
@@ -52,11 +52,11 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
     - name: Log in to Container Registry
       if: inputs.push-to-registry == 'true'
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.registry-username }}

--- a/.github/actions/setup-go-env/action.yml
+++ b/.github/actions/setup-go-env/action.yml
@@ -56,7 +56,7 @@ runs:
         echo "Using Go version: $VERSION"
 
     - name: Setup Go
-      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         cache: true


### PR DESCRIPTION
## Summary

Align SHA-pinned action versions in composite actions with the versions already used in the main workflow files.

## Changes

| Composite Action | Action | Old Version | New Version |
|------------------|--------|-------------|-------------|
| `.github/actions/setup-go-env/action.yml` | `actions/setup-go` | v5.4.0 (`0aaccfd...`) | v6.2.0 (`7a3fe6c...`) |
| `.github/actions/build-operator-image/action.yml` | `docker/setup-buildx-action` | v3.10.0 (`b5ca514...`) | v3.12.0 (`8d2750c...`) |
| `.github/actions/build-operator-image/action.yml` | `docker/login-action` | v3.4.0 (`74a5d14...`) | v3.7.0 (`c94ce9f...`) |

The new SHAs match exactly what's already used in `release.yml`, `ci.yml`, `security-scan.yml`, and `helm-chart-test.yml`.
