### PR TITLE
fix: correct AGENTS.md convention violations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
 	golang.org/x/sync v0.19.0
 	golang.org/x/time v0.14.0
@@ -63,6 +62,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect


### PR DESCRIPTION
## Summary

Fixes convention violations identified in the codebase per AGENTS.md rules.

Closes #103

## Changes

- Replace raw string HTTP methods with `http.MethodPost`, `http.MethodGet` constants
- Replace raw RBAC group string with `rbacv1.GroupName` constant
- Use `fmt.Errorf("...: %w", err)` instead of `%v` for proper error wrapping
- Fix import alias conventions (`authorizationv1alpha1`, `rbacv1`)
- Ensure all error paths wrap errors correctly

## Testing

- `make lint` passes
- `make test` passes — all existing tests continue to pass