### PR TITLE
feat: add informer-based caching and field index for WebhookAuthorizer

### DIFF
--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -15,12 +15,15 @@ import (
 
 	authzv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
 	webhooks "github.com/telekom/auth-operator/internal/webhook/authorization"
+	"github.com/telekom/auth-operator/pkg/indexer"
 
 	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -32,9 +35,25 @@ func newTestScheme() *runtime.Scheme {
 	return s
 }
 
+// newIndexedFakeClient builds a fake client with the WebhookAuthorizer
+// hasNamespaceSelector field index registered, matching the real manager setup.
+func newIndexedFakeClient(scheme *runtime.Scheme, objs ...client.Object) client.Client {
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(
+			&authzv1alpha1.WebhookAuthorizer{},
+			indexer.WebhookAuthorizerHasNamespaceSelectorField,
+			indexer.WebhookAuthorizerHasNamespaceSelectorFunc,
+		)
+	if len(objs) > 0 {
+		builder = builder.WithObjects(objs...)
+	}
+	return builder.Build()
+}
+
 func TestServeHTTP_OversizedBody(t *testing.T) {
 	scheme := newTestScheme()
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeClient := newIndexedFakeClient(scheme)
 
 	authorizer := &webhooks.Authorizer{
 		Client: fakeClient,
@@ -65,7 +84,7 @@ func TestServeHTTP_OversizedBody(t *testing.T) {
 
 func TestServeHTTP_InvalidJSON(t *testing.T) {
 	scheme := newTestScheme()
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeClient := newIndexedFakeClient(scheme)
 
 	authorizer := &webhooks.Authorizer{
 		Client: fakeClient,
@@ -113,10 +132,7 @@ func TestServeHTTP_ValidSAR(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithRuntimeObjects(waObj).
-		Build()
+	fakeClient := newIndexedFakeClient(scheme, waObj)
 
 	authorizer := &webhooks.Authorizer{
 		Client: fakeClient,
@@ -161,7 +177,7 @@ func TestServeHTTP_ValidSAR(t *testing.T) {
 
 func TestServeHTTP_DeniedSAR(t *testing.T) {
 	scheme := newTestScheme()
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeClient := newIndexedFakeClient(scheme)
 
 	authorizer := &webhooks.Authorizer{
 		Client: fakeClient,
@@ -222,10 +238,7 @@ func TestServeHTTP_NonResourceSAR(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithRuntimeObjects(waObj).
-		Build()
+	fakeClient := newIndexedFakeClient(scheme, waObj)
 
 	authorizer := &webhooks.Authorizer{
 		Client: fakeClient,
@@ -264,7 +277,7 @@ func TestServeHTTP_NonResourceSAR(t *testing.T) {
 
 func TestServeHTTP_EmptyBody(t *testing.T) {
 	scheme := newTestScheme()
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeClient := newIndexedFakeClient(scheme)
 
 	authorizer := &webhooks.Authorizer{
 		Client: fakeClient,
@@ -288,7 +301,7 @@ func TestServeHTTP_EmptyBody(t *testing.T) {
 
 func TestServeHTTP_ErrorResponseDoesNotLeakInternals(t *testing.T) {
 	scheme := newTestScheme()
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeClient := newIndexedFakeClient(scheme)
 
 	authorizer := &webhooks.Authorizer{
 		Client: fakeClient,
@@ -329,5 +342,157 @@ func TestServeHTTP_ErrorResponseDoesNotLeakInternals(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestServeHTTP_NamespaceScopedAuthorizerSkippedForNonNamespacedSAR(t *testing.T) {
+	scheme := newTestScheme()
+
+	// Create a namespace-scoped authorizer that should NOT match cluster-level requests.
+	waScoped := &authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "wa-scoped"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "scoped-user"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+			NamespaceSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+		},
+	}
+
+	fakeClient := newIndexedFakeClient(scheme, waScoped)
+
+	authorizer := &webhooks.Authorizer{
+		Client: fakeClient,
+		Log:    zap.New(zap.WriteTo(io.Discard)),
+	}
+
+	// SAR without a namespace — scoped authorizer should not be consulted.
+	sar := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: "scoped-user",
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Verb:     "get",
+				Resource: "pods",
+				Group:    "",
+			},
+		},
+	}
+
+	body, err := json.Marshal(sar)
+	if err != nil {
+		t.Fatalf("failed to marshal SAR: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/authorize", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	authorizer.ServeHTTP(w, req)
+
+	var resp authzv1.SubjectAccessReview
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Scoped authorizer should be excluded for non-namespaced SAR, so access is denied.
+	if resp.Status.Allowed {
+		t.Error("expected denied for non-namespaced SAR with only scoped authorizer")
+	}
+}
+
+func TestServeHTTP_GlobalAndScopedAuthorizers(t *testing.T) {
+	scheme := newTestScheme()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-ns",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
+
+	waGlobal := &authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "wa-global"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "global-user"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"list"}, APIGroups: []string{""}, Resources: []string{"services"}},
+			},
+		},
+	}
+
+	waScoped := &authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "wa-scoped"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "scoped-user"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+			NamespaceSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+		},
+	}
+
+	fakeClient := newIndexedFakeClient(scheme, ns, waGlobal, waScoped)
+
+	authorizer := &webhooks.Authorizer{
+		Client: fakeClient,
+		Log:    zap.New(zap.WriteTo(io.Discard)),
+	}
+
+	// Test 1: Global user can access services (global authorizer, no namespace).
+	sar := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: "global-user",
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Verb:     "list",
+				Resource: "services",
+				Group:    "",
+			},
+		},
+	}
+	body, err := json.Marshal(sar)
+	if err != nil {
+		t.Fatalf("test 1: failed to marshal SAR: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/authorize", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	authorizer.ServeHTTP(w, req)
+
+	var resp authzv1.SubjectAccessReview
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("test 1: failed to decode: %v", err)
+	}
+	if !resp.Status.Allowed {
+		t.Errorf("test 1: expected global user allowed, got denied: %s", resp.Status.Reason)
+	}
+
+	// Test 2: Scoped user can access pods in matching namespace.
+	sar2 := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: "scoped-user",
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Verb:      "get",
+				Resource:  "pods",
+				Group:     "",
+				Namespace: "test-ns",
+			},
+		},
+	}
+	body2, err := json.Marshal(sar2)
+	if err != nil {
+		t.Fatalf("test 2: failed to marshal SAR: %v", err)
+	}
+	req2 := httptest.NewRequest(http.MethodPost, "/authorize", bytes.NewReader(body2))
+	w2 := httptest.NewRecorder()
+	authorizer.ServeHTTP(w2, req2)
+
+	var resp2 authzv1.SubjectAccessReview
+	if err := json.NewDecoder(w2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("test 2: failed to decode: %v", err)
+	}
+	if !resp2.Status.Allowed {
+		t.Errorf("test 2: expected scoped user allowed in matching namespace, got denied: %s", resp2.Status.Reason)
 	}
 }


### PR DESCRIPTION
## Summary

Adds informer-based caching and field indexing for `WebhookAuthorizer` resources to eliminate redundant API server list calls on every `SubjectAccessReview` evaluation.

Closes #97

## Changes

### Field Index (`pkg/indexer/indexer.go`)
- Added `WebhookAuthorizerHasNamespaceSelectorField` (`.spec.hasNamespaceSelector`) constant
- Added `WebhookAuthorizerHasNamespaceSelectorFunc` — exported extractor function that returns `"true"` or `"false"` based on whether the `NamespaceSelector` is non-empty
- Registered the index in `SetupIndexes()` so both the controller and webhook managers benefit

### Webhook Handler (`internal/webhook/authorization/webhook_authorizer.go`)
- Documented that the `Authorizer.Client` field should be the cached client from `manager.GetClient()` (which it already is)
- Replaced the single unfiltered `Client.List()` call with two field-indexed queries:
  - **Global authorizers** (`hasNamespaceSelector=false`): always queried
  - **Scoped authorizers** (`hasNamespaceSelector=true`): only queried when the SAR targets a specific namespace
- Updated `evaluateSAR` signature to accept `[]WebhookAuthorizer` slice instead of `*WebhookAuthorizerList` pointer

### Tests
- **`pkg/indexer/indexer_test.go`**: Added `TestWebhookAuthorizerHasNamespaceSelectorFunc` (4 cases: non-empty selector, empty selector, match expressions, wrong type) and `TestWebhookAuthorizerIndexWithFakeClient` (verifies indexed List queries return correct results)
- **`internal/webhook/authorization/webhook_authorizer_test.go`**: Added `newIndexedFakeClient` helper; updated all existing tests to use it; added `TestServeHTTP_NamespaceScopedAuthorizerSkippedForNonNamespacedSAR` and `TestServeHTTP_GlobalAndScopedAuthorizers`

## Performance Impact

- **Before**: Every SAR request triggered a full unfiltered List of all WebhookAuthorizers (served from cache, but iterated all objects)
- **After**: Non-namespaced SARs only query global authorizers; namespaced SARs query both global and scoped authorizers via indexed cache lookups
- The informer cache (already provided by `manager.GetClient()`) ensures no round-trips to the API server for List/Get calls

## Validation

- `make lint` — 0 issues
- `make test` — all tests pass
- `internal/webhook/authorization` coverage: 80.8%
