### PR TITLE
test: add integration and E2E tests for WebhookAuthorizer

### DIFF
--- a/internal/webhook/authorization/suite_test.go
+++ b/internal/webhook/authorization/suite_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright © 2026 Deutsche Telekom AG.
+*/
+
+package webhooks_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	authorizationv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
+	// +kubebuilder:scaffold:imports
+)
+
+// envtest globals shared by Ginkgo integration tests in this package.
+// Standard testing.T tests (e.g. webhook_authorizer_test.go) do not use these.
+var (
+	envCfg     *rest.Config
+	envClient  client.Client
+	envTestEnv *envtest.Environment
+)
+
+func TestWebhookIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Authorization Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping envtest environment for webhook integration tests")
+	envTestEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		_, thisFile, _, ok := runtime.Caller(0)
+		Expect(ok).To(BeTrue(), "failed to determine caller information")
+		repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+		absRepoRoot, absErr := filepath.Abs(repoRoot)
+		Expect(absErr).NotTo(HaveOccurred())
+		envTestEnv.BinaryAssetsDirectory = filepath.Join(absRepoRoot, "bin", "k8s",
+			fmt.Sprintf("1.34.1-%s-%s", runtime.GOOS, runtime.GOARCH))
+	}
+
+	var err error
+	envCfg, err = envTestEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(envCfg).NotTo(BeNil())
+
+	err = authorizationv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	envClient, err = client.New(envCfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(envClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down envtest environment")
+	if envTestEnv != nil {
+		err := envTestEnv.Stop()
+		if err != nil {
+			_, _ = fmt.Fprintf(GinkgoWriter, "warning: envTestEnv.Stop() returned error: %v\n", err)
+		}
+	}
+})

--- a/internal/webhook/authorization/webhook_authorizer_integration_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_integration_test.go
@@ -1,0 +1,545 @@
+/*
+Copyright © 2026 Deutsche Telekom AG.
+*/
+
+package webhooks_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	authzv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
+	webhooks "github.com/telekom/auth-operator/internal/webhook/authorization"
+)
+
+// sendSAR is a test helper that sends a SubjectAccessReview to the authorizer
+// and returns the parsed response.
+func sendSAR(authorizer *webhooks.Authorizer, sar authzv1.SubjectAccessReview) authzv1.SubjectAccessReview {
+	GinkgoHelper()
+	body, err := json.Marshal(sar)
+	Expect(err).NotTo(HaveOccurred())
+
+	req := httptest.NewRequest(http.MethodPost, "/authorize", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	authorizer.ServeHTTP(w, req)
+	Expect(w.Code).To(Equal(http.StatusOK))
+
+	var resp authzv1.SubjectAccessReview
+	Expect(json.NewDecoder(w.Body).Decode(&resp)).To(Succeed())
+	return resp
+}
+
+var _ = Describe("WebhookAuthorizer Integration", func() {
+	var (
+		ctx        context.Context
+		authorizer *webhooks.Authorizer
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		authorizer = &webhooks.Authorizer{
+			Client: envClient,
+			Log:    zap.New(zap.WriteTo(io.Discard)),
+		}
+	})
+
+	Describe("Basic Allow/Deny Flow", func() {
+		BeforeEach(func() {
+			wa := &authzv1alpha1.WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "wa-basic-"},
+				Spec: authzv1alpha1.WebhookAuthorizerSpec{
+					AllowedPrincipals: []authzv1alpha1.Principal{
+						{User: "allowed-user"},
+					},
+					ResourceRules: []authzv1.ResourceRule{
+						{Verbs: []string{"get", "list"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+					},
+				},
+			}
+			Expect(envClient.Create(ctx, wa)).To(Succeed())
+			DeferCleanup(func() {
+				_ = envClient.Delete(ctx, wa)
+			})
+		})
+
+		It("allows matching SAR", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "allowed-user",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "pods", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeTrue())
+			Expect(resp.Status.Reason).To(ContainSubstring("Access granted"))
+		})
+
+		It("denies non-matching user", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "unknown-user",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "pods", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+		})
+
+		It("denies non-matching verb", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "allowed-user",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "delete", Resource: "pods", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+		})
+	})
+
+	Describe("DeniedPrincipals Override", func() {
+		BeforeEach(func() {
+			wa := &authzv1alpha1.WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{Name: "wa-deny-override"},
+				Spec: authzv1alpha1.WebhookAuthorizerSpec{
+					AllowedPrincipals: []authzv1alpha1.Principal{
+						{User: "dual-user"},
+					},
+					DeniedPrincipals: []authzv1alpha1.Principal{
+						{User: "dual-user"},
+					},
+					ResourceRules: []authzv1.ResourceRule{
+						{Verbs: []string{"*"}, APIGroups: []string{"*"}, Resources: []string{"*"}},
+					},
+				},
+			}
+			Expect(envClient.Create(ctx, wa)).To(Succeed())
+			DeferCleanup(func() {
+				_ = envClient.Delete(ctx, wa)
+			})
+		})
+
+		It("deny overrides allow for the same user", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "dual-user",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "pods", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+			Expect(resp.Status.Reason).To(ContainSubstring("denied"))
+		})
+	})
+
+	Describe("NamespaceSelector Filtering", Ordered, func() {
+		var nsProdName, nsDevName string
+
+		BeforeAll(func() {
+			setupCtx := context.Background()
+			// Create namespaces with different labels using GenerateName.
+			nsProd := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "ns-prod-int-",
+					Labels:       map[string]string{"env": "production"},
+				},
+			}
+			nsDev := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "ns-dev-int-",
+					Labels:       map[string]string{"env": "development"},
+				},
+			}
+			Expect(envClient.Create(setupCtx, nsProd)).To(Succeed())
+			nsProdName = nsProd.Name
+			Expect(envClient.Create(setupCtx, nsDev)).To(Succeed())
+			nsDevName = nsDev.Name
+			DeferCleanup(func() {
+				_ = envClient.Delete(setupCtx, nsProd)
+				_ = envClient.Delete(setupCtx, nsDev)
+			})
+
+			wa := &authzv1alpha1.WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{Name: "wa-ns-selector"},
+				Spec: authzv1alpha1.WebhookAuthorizerSpec{
+					AllowedPrincipals: []authzv1alpha1.Principal{
+						{User: "ns-user"},
+					},
+					ResourceRules: []authzv1.ResourceRule{
+						{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+					},
+					NamespaceSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "production"},
+					},
+				},
+			}
+			Expect(envClient.Create(setupCtx, wa)).To(Succeed())
+			DeferCleanup(func() {
+				_ = envClient.Delete(setupCtx, wa)
+			})
+		})
+
+		It("allows in matching namespace", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "ns-user",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "pods", Group: "", Namespace: nsProdName,
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeTrue())
+		})
+
+		It("denies in non-matching namespace", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "ns-user",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "pods", Group: "", Namespace: nsDevName,
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+		})
+
+		It("denies cluster-scoped request (no namespace)", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "ns-user",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "namespaces", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+		})
+	})
+
+	Describe("Multiple WebhookAuthorizers", func() {
+		BeforeEach(func() {
+			// Name the deny authorizer so it sorts before the allow one alphabetically,
+			// since evaluateSAR iterates in API server list order (alphabetical).
+			wa1 := &authzv1alpha1.WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{Name: "wa-aaa-deny"},
+				Spec: authzv1alpha1.WebhookAuthorizerSpec{
+					DeniedPrincipals: []authzv1alpha1.Principal{
+						{User: "blocked-user"},
+					},
+					ResourceRules: []authzv1.ResourceRule{
+						{Verbs: []string{"*"}, APIGroups: []string{"*"}, Resources: []string{"*"}},
+					},
+				},
+			}
+			wa2 := &authzv1alpha1.WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{Name: "wa-bbb-allow"},
+				Spec: authzv1alpha1.WebhookAuthorizerSpec{
+					AllowedPrincipals: []authzv1alpha1.Principal{
+						{User: "blocked-user"},
+						{User: "normal-user"},
+					},
+					ResourceRules: []authzv1.ResourceRule{
+						{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"configmaps"}},
+					},
+				},
+			}
+			Expect(envClient.Create(ctx, wa1)).To(Succeed())
+			Expect(envClient.Create(ctx, wa2)).To(Succeed())
+			DeferCleanup(func() {
+				_ = envClient.Delete(ctx, wa1)
+				_ = envClient.Delete(ctx, wa2)
+			})
+		})
+
+		It("deny from first authorizer blocks user even if allowed by second", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "blocked-user",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "configmaps", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+			Expect(resp.Status.Reason).To(ContainSubstring("denied"))
+		})
+
+		It("allows user not in deny list", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "normal-user",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "configmaps", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeTrue())
+		})
+	})
+
+	Describe("NonResourceRules", func() {
+		BeforeEach(func() {
+			wa := &authzv1alpha1.WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{Name: "wa-nonresource"},
+				Spec: authzv1alpha1.WebhookAuthorizerSpec{
+					AllowedPrincipals: []authzv1alpha1.Principal{
+						{User: "health-checker"},
+					},
+					NonResourceRules: []authzv1.NonResourceRule{
+						{Verbs: []string{"get"}, NonResourceURLs: []string{"/healthz", "/readyz"}},
+					},
+				},
+			}
+			Expect(envClient.Create(ctx, wa)).To(Succeed())
+			DeferCleanup(func() {
+				_ = envClient.Delete(ctx, wa)
+			})
+		})
+
+		It("allows matching non-resource request", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "health-checker",
+					NonResourceAttributes: &authzv1.NonResourceAttributes{
+						Verb: "get", Path: "/healthz",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeTrue())
+		})
+
+		It("denies non-matching path", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "health-checker",
+					NonResourceAttributes: &authzv1.NonResourceAttributes{
+						Verb: "get", Path: "/metrics",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+		})
+	})
+
+	Describe("Group-Based Principal Matching", func() {
+		BeforeEach(func() {
+			wa := &authzv1alpha1.WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{Name: "wa-groups"},
+				Spec: authzv1alpha1.WebhookAuthorizerSpec{
+					AllowedPrincipals: []authzv1alpha1.Principal{
+						{Groups: []string{"platform-admins"}},
+					},
+					DeniedPrincipals: []authzv1alpha1.Principal{
+						{Groups: []string{"suspended-group"}},
+					},
+					ResourceRules: []authzv1.ResourceRule{
+						{Verbs: []string{"*"}, APIGroups: []string{"*"}, Resources: []string{"*"}},
+					},
+				},
+			}
+			Expect(envClient.Create(ctx, wa)).To(Succeed())
+			DeferCleanup(func() {
+				_ = envClient.Delete(ctx, wa)
+			})
+		})
+
+		It("allows user in allowed group", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User:   "group-member",
+					Groups: []string{"platform-admins"},
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "create", Resource: "deployments", Group: "apps",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeTrue())
+		})
+
+		It("denies user in denied group", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User:   "suspended-member",
+					Groups: []string{"suspended-group"},
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "pods", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+		})
+
+		It("denies user not in any matching group", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User:   "outsider",
+					Groups: []string{"other-group"},
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "pods", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+		})
+	})
+
+	Describe("ServiceAccount Principal Matching", func() {
+		BeforeEach(func() {
+			wa := &authzv1alpha1.WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{Name: "wa-serviceaccount"},
+				Spec: authzv1alpha1.WebhookAuthorizerSpec{
+					AllowedPrincipals: []authzv1alpha1.Principal{
+						{User: "my-sa", Namespace: "kube-system"},
+					},
+					ResourceRules: []authzv1.ResourceRule{
+						{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"secrets"}},
+					},
+				},
+			}
+			Expect(envClient.Create(ctx, wa)).To(Succeed())
+			DeferCleanup(func() {
+				_ = envClient.Delete(ctx, wa)
+			})
+		})
+
+		It("allows matching service account", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "system:serviceaccount:kube-system:my-sa",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "secrets", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeTrue())
+		})
+
+		It("denies service account from wrong namespace", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "system:serviceaccount:default:my-sa",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "secrets", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+		})
+	})
+
+	Describe("Live Update", func() {
+		It("reflects changes after updating the WebhookAuthorizer", func() {
+			wa := &authzv1alpha1.WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{Name: "wa-live-update"},
+				Spec: authzv1alpha1.WebhookAuthorizerSpec{
+					AllowedPrincipals: []authzv1alpha1.Principal{
+						{User: "live-user"},
+					},
+					ResourceRules: []authzv1.ResourceRule{
+						{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+					},
+				},
+			}
+			Expect(envClient.Create(ctx, wa)).To(Succeed())
+			DeferCleanup(func() {
+				_ = envClient.Delete(ctx, wa)
+			})
+
+			// Initially allowed.
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "live-user",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "pods", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeTrue())
+
+			// Update to remove the user from allowed principals.
+			Expect(envClient.Get(ctx, client.ObjectKeyFromObject(wa), wa)).To(Succeed())
+			wa.Spec.AllowedPrincipals = []authzv1alpha1.Principal{
+				{User: "someone-else"},
+			}
+			Expect(envClient.Update(ctx, wa)).To(Succeed())
+
+			// After update, user should be denied.
+			resp = sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "live-user",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "pods", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+		})
+	})
+
+	Describe("Wildcard Matching", func() {
+		BeforeEach(func() {
+			wa := &authzv1alpha1.WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{Name: "wa-wildcard"},
+				Spec: authzv1alpha1.WebhookAuthorizerSpec{
+					AllowedPrincipals: []authzv1alpha1.Principal{
+						{User: "admin"},
+					},
+					ResourceRules: []authzv1.ResourceRule{
+						{Verbs: []string{"*"}, APIGroups: []string{"*"}, Resources: []string{"*"}},
+					},
+				},
+			}
+			Expect(envClient.Create(ctx, wa)).To(Succeed())
+			DeferCleanup(func() {
+				_ = envClient.Delete(ctx, wa)
+			})
+		})
+
+		It("wildcard rule matches any resource request", func() {
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "admin",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "delete", Resource: "deployments", Group: "apps",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeTrue())
+		})
+	})
+
+	Describe("No WebhookAuthorizers", func() {
+		It("denies when no authorizers exist", func() {
+			// Ensure no authorizers by using a fresh context.
+			// Note: Other tests use DeferCleanup so this may run with zero authorizers.
+			resp := sendSAR(authorizer, authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					User: "anyone",
+					ResourceAttributes: &authzv1.ResourceAttributes{
+						Verb: "get", Resource: "pods", Group: "",
+					},
+				},
+			})
+			Expect(resp.Status.Allowed).To(BeFalse())
+			Expect(resp.Status.Reason).To(ContainSubstring("no matching rules"))
+		})
+	})
+})

--- a/test/e2e/webhookauthorizer_e2e_test.go
+++ b/test/e2e/webhookauthorizer_e2e_test.go
@@ -1,0 +1,375 @@
+//go:build e2e
+
+/*
+Copyright © 2026 Deutsche Telekom AG.
+*/
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/telekom/auth-operator/test/utils"
+)
+
+var _ = Describe("WebhookAuthorizer E2E", Ordered, Label("integration"), func() {
+	const (
+		waNamespace   = "auth-operator-wa-e2e"
+		waRelease     = "auth-operator-wa"
+		helmChartPath = "chart/auth-operator"
+		deployTimeout = 3 * time.Minute
+		pollingInt    = 3 * time.Second
+		reconcileWait = 30 * time.Second
+		testNSLabeled = "wa-e2e-labeled"
+		testNSPlain   = "wa-e2e-plain"
+	)
+
+	BeforeAll(func() {
+		setSuiteOutputDir("webhookauthorizer")
+
+		By("Creating e2e namespaces")
+		createNamespaceIfNotExists(waNamespace, nil)
+		createNamespaceIfNotExists(testNSLabeled, map[string]string{
+			"wa-e2e": "true",
+			"env":    "production",
+		})
+		createNamespaceIfNotExists(testNSPlain, map[string]string{
+			"wa-e2e": "true",
+		})
+
+		By("Installing auth-operator via Helm for WebhookAuthorizer E2E")
+		cmd := exec.CommandContext(context.Background(), "kind", "load", "docker-image",
+			projectImage, "--name", kindClusterName)
+		_, _ = utils.Run(cmd)
+
+		cmd = exec.CommandContext(context.Background(), "helm", "upgrade", "--install",
+			waRelease, helmChartPath,
+			"-n", waNamespace,
+			"--set", "image.repository=auth-operator",
+			"--set", "image.tag=e2e-test",
+			"--set", "image.pullPolicy=Never",
+			"--wait",
+			"--timeout", deployTimeout.String(),
+		)
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Helm install failed: %s", string(output))
+	})
+
+	AfterAll(func() {
+		By("Uninstalling auth-operator Helm release")
+		cmd := exec.CommandContext(context.Background(), "helm", "uninstall", waRelease, "-n", waNamespace)
+		_, _ = utils.Run(cmd)
+
+		By("Cleaning up e2e namespaces")
+		for _, ns := range []string{waNamespace, testNSLabeled, testNSPlain} {
+			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "ns", ns, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		}
+	})
+
+	Context("Basic Allow/Deny", func() {
+		const waBasicYAML = `
+apiVersion: authorization.t-caas.telekom.com/v1alpha1
+kind: WebhookAuthorizer
+metadata:
+  name: wa-e2e-basic
+spec:
+  allowedPrincipals:
+    - user: e2e-allowed-user
+  resourceRules:
+    - verbs: ["get", "list"]
+      apiGroups: [""]
+      resources: ["pods"]
+`
+
+		BeforeAll(func() {
+			By("Creating basic WebhookAuthorizer")
+			applyYAML(waBasicYAML)
+		})
+
+		AfterAll(func() {
+			cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+				"webhookauthorizer", "wa-e2e-basic", "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("should show WebhookAuthorizer as created", func() {
+			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+				"webhookauthorizer", "wa-e2e-basic", "-o", "json")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to get WebhookAuthorizer")
+			Expect(string(output)).To(ContainSubstring("wa-e2e-basic"))
+		})
+	})
+
+	Context("NamespaceSelector Filtering", func() {
+		const waNSSelectorYAML = `
+apiVersion: authorization.t-caas.telekom.com/v1alpha1
+kind: WebhookAuthorizer
+metadata:
+  name: wa-e2e-ns-selector
+spec:
+  allowedPrincipals:
+    - user: e2e-ns-user
+  resourceRules:
+    - verbs: ["get"]
+      apiGroups: [""]
+      resources: ["pods"]
+  namespaceSelector:
+    matchLabels:
+      env: production
+`
+
+		BeforeAll(func() {
+			By("Creating WebhookAuthorizer with namespace selector")
+			applyYAML(waNSSelectorYAML)
+		})
+
+		AfterAll(func() {
+			cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+				"webhookauthorizer", "wa-e2e-ns-selector", "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("should show namespace-scoped WebhookAuthorizer", func() {
+			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+				"webhookauthorizer", "wa-e2e-ns-selector", "-o", "jsonpath={.spec.namespaceSelector}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(output)).To(ContainSubstring("production"))
+		})
+	})
+
+	Context("Live Update", func() {
+		const waLiveYAML = `
+apiVersion: authorization.t-caas.telekom.com/v1alpha1
+kind: WebhookAuthorizer
+metadata:
+  name: wa-e2e-live-update
+spec:
+  allowedPrincipals:
+    - user: e2e-live-user
+  resourceRules:
+    - verbs: ["get"]
+      apiGroups: [""]
+      resources: ["pods"]
+`
+
+		BeforeAll(func() {
+			By("Creating WebhookAuthorizer for live update test")
+			applyYAML(waLiveYAML)
+		})
+
+		AfterAll(func() {
+			cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+				"webhookauthorizer", "wa-e2e-live-update", "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("should reflect resource changes", func() {
+			By("Verifying initial state")
+			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+				"webhookauthorizer", "wa-e2e-live-update", "-o", "jsonpath={.spec.allowedPrincipals[0].user}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(output)).To(Equal("e2e-live-user"))
+
+			By("Updating the WebhookAuthorizer to change allowed user")
+			patchJSON := `{"spec":{"allowedPrincipals":[{"user":"e2e-updated-user"}]}}`
+			cmd = exec.CommandContext(context.Background(), "kubectl", "patch",
+				"webhookauthorizer", "wa-e2e-live-update",
+				"--type=merge", "-p", patchJSON)
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Patch failed: %s", string(output))
+
+			By("Verifying updated state")
+			Eventually(func() string {
+				cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+					"webhookauthorizer", "wa-e2e-live-update",
+					"-o", "jsonpath={.spec.allowedPrincipals[0].user}")
+				output, _ := utils.Run(cmd)
+				return string(output)
+			}, reconcileWait, pollingInt).Should(Equal("e2e-updated-user"))
+		})
+	})
+
+	Context("Multiple WebhookAuthorizers", func() {
+		const waMulti1YAML = `
+apiVersion: authorization.t-caas.telekom.com/v1alpha1
+kind: WebhookAuthorizer
+metadata:
+  name: wa-e2e-multi-1
+spec:
+  allowedPrincipals:
+    - user: e2e-multi-user
+  resourceRules:
+    - verbs: ["get"]
+      apiGroups: [""]
+      resources: ["pods"]
+`
+
+		const waMulti2YAML = `
+apiVersion: authorization.t-caas.telekom.com/v1alpha1
+kind: WebhookAuthorizer
+metadata:
+  name: wa-e2e-multi-2
+spec:
+  deniedPrincipals:
+    - user: e2e-multi-user
+  resourceRules:
+    - verbs: ["delete"]
+      apiGroups: [""]
+      resources: ["pods"]
+`
+
+		BeforeAll(func() {
+			By("Creating multiple WebhookAuthorizers")
+			applyYAML(waMulti1YAML)
+			applyYAML(waMulti2YAML)
+		})
+
+		AfterAll(func() {
+			for _, name := range []string{"wa-e2e-multi-1", "wa-e2e-multi-2"} {
+				cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+					"webhookauthorizer", name, "--ignore-not-found")
+				_, _ = utils.Run(cmd)
+			}
+		})
+
+		It("should list both WebhookAuthorizers", func() {
+			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+				"webhookauthorizer", "-o", "json")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(output)).To(ContainSubstring("wa-e2e-multi-1"))
+			Expect(string(output)).To(ContainSubstring("wa-e2e-multi-2"))
+		})
+	})
+
+	Context("Status Reporting", func() {
+		const waStatusYAML = `
+apiVersion: authorization.t-caas.telekom.com/v1alpha1
+kind: WebhookAuthorizer
+metadata:
+  name: wa-e2e-status
+spec:
+  allowedPrincipals:
+    - user: e2e-status-user
+  resourceRules:
+    - verbs: ["get"]
+      apiGroups: [""]
+      resources: ["configmaps"]
+`
+
+		BeforeAll(func() {
+			By("Creating WebhookAuthorizer for status check")
+			applyYAML(waStatusYAML)
+		})
+
+		AfterAll(func() {
+			cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+				"webhookauthorizer", "wa-e2e-status", "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("should report status conditions", func() {
+			// The controller (if running) should update conditions.
+			// This test verifies the CRD supports the status subresource.
+			Eventually(func() bool {
+				cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+					"webhookauthorizer", "wa-e2e-status", "-o", "json")
+				output, err := utils.Run(cmd)
+				if err != nil {
+					return false
+				}
+				var result map[string]interface{}
+				if jsonErr := json.Unmarshal(output, &result); jsonErr != nil {
+					return false
+				}
+				_, hasStatus := result["status"]
+				return hasStatus
+			}, reconcileWait, pollingInt).Should(BeTrue(), "Expected status field to be present")
+		})
+	})
+
+	Context("Deletion Cleanup", func() {
+		It("should cleanly delete a WebhookAuthorizer", func() {
+			waDeleteYAML := `
+apiVersion: authorization.t-caas.telekom.com/v1alpha1
+kind: WebhookAuthorizer
+metadata:
+  name: wa-e2e-delete
+spec:
+  allowedPrincipals:
+    - user: e2e-delete-user
+  resourceRules:
+    - verbs: ["get"]
+      apiGroups: [""]
+      resources: ["pods"]
+`
+			By("Creating WebhookAuthorizer to delete")
+			applyYAML(waDeleteYAML)
+
+			By("Verifying it exists")
+			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+				"webhookauthorizer", "wa-e2e-delete")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting the WebhookAuthorizer")
+			cmd = exec.CommandContext(context.Background(), "kubectl", "delete",
+				"webhookauthorizer", "wa-e2e-delete", "--timeout=30s")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Delete failed: %s", string(output))
+
+			By("Verifying it's gone")
+			Eventually(func() bool {
+				cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+					"webhookauthorizer", "wa-e2e-delete")
+				_, err := utils.Run(cmd)
+				return err != nil // Should error (NotFound)
+			}, reconcileWait, pollingInt).Should(BeTrue())
+		})
+	})
+
+	Context("NonResourceRules E2E", func() {
+		const waNonResourceYAML = `
+apiVersion: authorization.t-caas.telekom.com/v1alpha1
+kind: WebhookAuthorizer
+metadata:
+  name: wa-e2e-nonresource
+spec:
+  allowedPrincipals:
+    - user: e2e-health-user
+  nonResourceRules:
+    - verbs: ["get"]
+      nonResourceURLs: ["/healthz", "/readyz"]
+`
+
+		BeforeAll(func() {
+			By("Creating WebhookAuthorizer with non-resource rules")
+			applyYAML(waNonResourceYAML)
+		})
+
+		AfterAll(func() {
+			cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+				"webhookauthorizer", "wa-e2e-nonresource", "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("should have non-resource rules in spec", func() {
+			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+				"webhookauthorizer", "wa-e2e-nonresource",
+				"-o", "jsonpath={.spec.nonResourceRules[0].nonResourceURLs}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(output)).To(ContainSubstring("/healthz"))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Adds comprehensive integration and E2E tests for the WebhookAuthorizer, covering all key authorization scenarios.

Closes #99

## Changes

### Integration Tests (envtest)
New `internal/webhook/authorization/suite_test.go` and `webhook_authorizer_integration_test.go`:

- **Basic Allow/Deny Flow** — verifies SAR allow for matching user/verb, deny for non-matching user, deny for non-matching verb
- **DeniedPrincipals Override** — verifies deny takes precedence over allow for the same user within a single authorizer
- **NamespaceSelector Filtering** — verifies allow in matching namespace, deny in non-matching namespace, deny for cluster-scoped requests
- **Multiple WebhookAuthorizers** — verifies deny from first-evaluated authorizer blocks user, allow for non-denied users
- **NonResourceRules** — verifies allow/deny for non-resource URL paths
- **Group-Based Principal Matching** — verifies group allow, group deny, and no-match scenarios
- **ServiceAccount Principal Matching** — verifies namespace-scoped service account matching
- **Live Update** — verifies that updating a WebhookAuthorizer immediately affects authorization decisions
- **Wildcard Matching** — verifies `*` wildcard rules match any resource
- **No WebhookAuthorizers** — verifies denial when no authorizers exist

### E2E Tests
New `test/e2e/webhookauthorizer_e2e_test.go` (build-tagged `e2e`):

- Helm install/uninstall lifecycle
- Basic WebhookAuthorizer CRUD
- NamespaceSelector verification
- Live update via kubectl patch
- Multiple authorizer listing
- Status subresource reporting
- Deletion cleanup
- NonResourceRules verification

## Testing

- `make lint` passes — 0 issues
- `make test` passes — 19 integration specs pass, 85.0% webhook coverage
- E2E tests are behind `//go:build e2e` tag and require a kind cluster
