### PR TITLE
refactor: remove deprecated InjectDecoder and improve code docs

### DIFF
--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -216,12 +216,11 @@ func configureWebhooks(mgr manager.Manager, tp *tracing.Provider) error {
 	}
 	// Setup Namespace mutator
 	log.Info("setting up Namespace mutator webhook", "tdgMigration", enableTDGMigration)
+	decoder := admission.NewDecoder(mgr.GetScheme())
 	namespaceMutator := &authorizationwebhook.NamespaceMutator{
 		Client:       mgr.GetClient(),
+		Decoder:      decoder,
 		TDGMigration: enableTDGMigration,
-	}
-	if err := namespaceMutator.InjectDecoder(admission.NewDecoder(mgr.GetScheme())); err != nil {
-		return fmt.Errorf("unable to inject decoder for NamespaceMutator: %w", err)
 	}
 	mgr.GetWebhookServer().Register("/mutate-v1-namespace", &webhook.Admission{Handler: namespaceMutator})
 
@@ -229,10 +228,8 @@ func configureWebhooks(mgr manager.Manager, tp *tracing.Provider) error {
 	log.Info("setting up Namespace validator webhook", "tdgMigration", enableTDGMigration)
 	namespaceValidator := &authorizationwebhook.NamespaceValidator{
 		Client:       mgr.GetClient(),
+		Decoder:      decoder,
 		TDGMigration: enableTDGMigration,
-	}
-	if err := namespaceValidator.InjectDecoder(admission.NewDecoder(mgr.GetScheme())); err != nil {
-		return fmt.Errorf("unable to inject decoder for NamespaceValidator: %w", err)
 	}
 	mgr.GetWebhookServer().Register("/validate-v1-namespace", &webhook.Admission{Handler: namespaceValidator})
 

--- a/internal/controller/authorization/rolebinding_terminator_controller.go
+++ b/internal/controller/authorization/rolebinding_terminator_controller.go
@@ -308,6 +308,10 @@ func formatBlockingResourcesMessage(blockingResources []namespaceDeletionResourc
 	return strings.Join(resourceDetails, "; ")
 }
 
+// isOwnedByBindDefinition reports whether the given owner references include
+// a BindDefinition from the authorization.t-caas.telekom.com API group.
+// It is used across multiple files within this package (terminator controller,
+// helpers) so it remains package-private here rather than exported to pkg/helpers.
 func isOwnedByBindDefinition(ownerReferences []metav1.OwnerReference) bool {
 	for _, ownerRef := range ownerReferences {
 		if ownerRef.Kind == "BindDefinition" && ownerRef.APIVersion == authorizationv1alpha1.GroupVersion.String() {

--- a/internal/webhook/authorization/namespace_mutating_webhook.go
+++ b/internal/webhook/authorization/namespace_mutating_webhook.go
@@ -25,12 +25,6 @@ type NamespaceMutator struct {
 	TDGMigration bool
 }
 
-// InjectDecoder injects the decoder into the NamespaceMutator.
-func (m *NamespaceMutator) InjectDecoder(d admission.Decoder) error {
-	m.Decoder = d
-	return nil
-}
-
 // Handle mutates the Namespace by adding a label based on user groups or ServiceAccount.
 func (m *NamespaceMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	logger := logf.FromContext(ctx).WithName("namespace-mutator")

--- a/internal/webhook/authorization/namespace_mutating_webhook_test.go
+++ b/internal/webhook/authorization/namespace_mutating_webhook_test.go
@@ -120,12 +120,8 @@ func TestNamespaceMutatorHandle(t *testing.T) {
 	// 4. Create our NamespaceMutator with the fake client
 	// ----------------------------------------------------------------------
 	mutator := &webhooks.NamespaceMutator{
-		Client: fakeClient,
-	}
-
-	dec := crAdmission.NewDecoder(scheme)
-	if err := mutator.InjectDecoder(dec); err != nil {
-		t.Fatalf("failed to inject decoder: %v", err)
+		Client:  fakeClient,
+		Decoder: crAdmission.NewDecoder(scheme),
 	}
 
 	// ----------------------------------------------------------------------
@@ -523,11 +519,8 @@ func TestNamespaceMutatorPerformance(t *testing.T) {
 		Build()
 
 	mutator := &webhooks.NamespaceMutator{
-		Client: fakeClient,
-	}
-	dec := crAdmission.NewDecoder(scheme)
-	if err := mutator.InjectDecoder(dec); err != nil {
-		t.Fatalf("failed to inject decoder: %v", err)
+		Client:  fakeClient,
+		Decoder: crAdmission.NewDecoder(scheme),
 	}
 
 	// 2) Define concurrency and total requests

--- a/internal/webhook/authorization/namespace_validating_webhook.go
+++ b/internal/webhook/authorization/namespace_validating_webhook.go
@@ -31,12 +31,6 @@ type NamespaceValidator struct {
 	TDGMigration bool
 }
 
-// InjectDecoder injects the decoder into the NamespaceValidator.
-func (v *NamespaceValidator) InjectDecoder(d admission.Decoder) error {
-	v.Decoder = d
-	return nil
-}
-
 // Handle validates namespace operations based on BindDefinition configurations.
 func (v *NamespaceValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	logger := logf.FromContext(ctx).WithName("namespace-validator")

--- a/pkg/helpers/subjects.go
+++ b/pkg/helpers/subjects.go
@@ -8,6 +8,8 @@ import (
 )
 
 // SubjectExists checks if an rbacv1.Subject exists in a slice.
+// This uses O(n) linear search via slices.ContainsFunc, which is appropriate
+// because BindDefinition subject lists are typically small (single-digit).
 func SubjectExists(subjectList []rbacv1.Subject, subject rbacv1.Subject) bool {
 	return slices.ContainsFunc(subjectList, func(s rbacv1.Subject) bool {
 		return s.Kind == subject.Kind &&


### PR DESCRIPTION
## Summary

Address remaining Go code quality items from issue #159. Closes #159.

## Changes

### GO-003: Remove deprecated InjectDecoder pattern
- Remove `InjectDecoder` methods from `NamespaceMutator` and `NamespaceValidator`
- Pass `admission.NewDecoder(mgr.GetScheme())` directly in struct initialization in `cmd/webhook.go`
- Eliminates error-handling boilerplate for an operation that cannot fail
- Update tests to use direct struct initialization instead of calling `InjectDecoder`

### GO-010: Document SubjectExists complexity
- Add comment documenting that O(n) linear search via `slices.ContainsFunc` is appropriate for single-digit subject list sizes

### GO-019: Add godoc to isOwnedByBindDefinition
- Document cross-file package-private usage and why it remains in the controller package rather than exported to pkg/helpers

## Testing
- `make fmt vet lint` - 0 issues
- `make test` - all tests pass with race detector
