### PR TITLE
ci: increase output-delta reconciliation timeouts to 180s

### DIFF
--- a/.github/workflows/output-delta.yml
+++ b/.github/workflows/output-delta.yml
@@ -111,12 +111,12 @@ jobs:
           # Deploy the operator
           make deploy IMG=auth-operator:main
           echo "Waiting for operator to be ready..."
-          kubectl wait --for=condition=available --timeout=120s deployment -l control-plane=controller-manager -A 2>/dev/null || \
+          kubectl wait --for=condition=available --timeout=180s deployment -l control-plane=controller-manager -A 2>/dev/null || \
             echo "::warning::Could not verify controller-manager readiness, continuing anyway"
 
           # Wait for webhook server if deployed (required for BindDefinition validation)
           echo "Waiting for webhook server to be ready..."
-          kubectl wait --for=condition=available --timeout=120s deployment -l control-plane=webhook-server -A 2>/dev/null || \
+          kubectl wait --for=condition=available --timeout=180s deployment -l control-plane=webhook-server -A 2>/dev/null || \
             echo "::notice::Webhook server not found or not ready, continuing anyway"
           sleep 5
 
@@ -137,8 +137,8 @@ jobs:
 
           # Wait for all CRs to be fully reconciled (Ready condition)
           echo "Waiting for resources to be reconciled..."
-          kubectl wait --for=condition=Ready roledefinition --all --timeout=120s 2>/dev/null || echo "::notice::Some RoleDefinitions not fully reconciled"
-          kubectl wait --for=condition=Ready binddefinition --all --timeout=120s 2>/dev/null || echo "::notice::Some BindDefinitions not fully reconciled"
+          kubectl wait --for=condition=Ready roledefinition --all --timeout=180s 2>/dev/null || echo "::notice::Some RoleDefinitions not fully reconciled"
+          kubectl wait --for=condition=Ready binddefinition --all --timeout=180s 2>/dev/null || echo "::notice::Some BindDefinitions not fully reconciled"
 
           # Capture generated resources (yq strips volatile K8s internal fields)
           bash ../pr-branch/hack/ci/capture-operator-output.sh /tmp/main-output
@@ -188,7 +188,7 @@ jobs:
             echo "::warning::Controller-manager deployment not Available in time (fallback baseline will continue anyway)"
 
           echo "Waiting for webhook server to be ready..."
-          kubectl wait --for=condition=available --timeout=120s deployment -l control-plane=webhook-server -A 2>/dev/null || \
+          kubectl wait --for=condition=available --timeout=180s deployment -l control-plane=webhook-server -A 2>/dev/null || \
             echo "::warning::Webhook server not ready in time, continuing anyway"
           sleep 5
 
@@ -203,8 +203,8 @@ jobs:
           done
 
           # Wait for reconciliation
-          kubectl wait --for=condition=Ready roledefinition --all --timeout=120s 2>/dev/null || echo "::notice::Some RoleDefinitions not fully reconciled"
-          kubectl wait --for=condition=Ready binddefinition --all --timeout=120s 2>/dev/null || echo "::notice::Some BindDefinitions not fully reconciled"
+          kubectl wait --for=condition=Ready roledefinition --all --timeout=180s 2>/dev/null || echo "::notice::Some RoleDefinitions not fully reconciled"
+          kubectl wait --for=condition=Ready binddefinition --all --timeout=180s 2>/dev/null || echo "::notice::Some BindDefinitions not fully reconciled"
 
           bash hack/ci/capture-operator-output.sh /tmp/main-output
 
@@ -248,10 +248,10 @@ jobs:
             exit 0
           }
           echo "Waiting for operator to be ready..."
-          kubectl wait --for=condition=available --timeout=120s deployment -l control-plane=controller-manager -A 2>/dev/null || true
+          kubectl wait --for=condition=available --timeout=180s deployment -l control-plane=controller-manager -A 2>/dev/null || true
 
           echo "Waiting for webhook server to be ready..."
-          kubectl wait --for=condition=available --timeout=120s deployment -l control-plane=webhook-server -A 2>/dev/null || \
+          kubectl wait --for=condition=available --timeout=180s deployment -l control-plane=webhook-server -A 2>/dev/null || \
             echo "::notice::Webhook server not found or not ready, continuing anyway"
           sleep 5
 
@@ -271,8 +271,8 @@ jobs:
             exit 0
           fi
 
-          kubectl wait --for=condition=Ready roledefinition --all --timeout=120s 2>/dev/null || echo "::notice::Some RoleDefinitions not fully reconciled"
-          kubectl wait --for=condition=Ready binddefinition --all --timeout=120s 2>/dev/null || echo "::notice::Some BindDefinitions not fully reconciled"
+          kubectl wait --for=condition=Ready roledefinition --all --timeout=180s 2>/dev/null || echo "::notice::Some RoleDefinitions not fully reconciled"
+          kubectl wait --for=condition=Ready binddefinition --all --timeout=180s 2>/dev/null || echo "::notice::Some BindDefinitions not fully reconciled"
 
           bash ../pr-branch/hack/ci/capture-operator-output.sh /tmp/tag-output
 
@@ -315,11 +315,11 @@ jobs:
 
           make deploy IMG=auth-operator:pr
           echo "Waiting for operator to be ready..."
-          kubectl wait --for=condition=available --timeout=120s deployment -l control-plane=controller-manager -A 2>/dev/null || \
+          kubectl wait --for=condition=available --timeout=180s deployment -l control-plane=controller-manager -A 2>/dev/null || \
             echo "::warning::Could not verify controller-manager readiness, continuing anyway"
 
           echo "Waiting for webhook server to be ready..."
-          kubectl wait --for=condition=available --timeout=120s deployment -l control-plane=webhook-server -A 2>/dev/null || \
+          kubectl wait --for=condition=available --timeout=180s deployment -l control-plane=webhook-server -A 2>/dev/null || \
             echo "::warning::Could not verify webhook-server readiness, continuing anyway"
           sleep 5
 
@@ -333,8 +333,8 @@ jobs:
             sleep 10
           done
 
-          kubectl wait --for=condition=Ready roledefinition --all --timeout=120s 2>/dev/null || echo "::notice::Some RoleDefinitions not fully reconciled"
-          kubectl wait --for=condition=Ready binddefinition --all --timeout=120s 2>/dev/null || echo "::notice::Some BindDefinitions not fully reconciled"
+          kubectl wait --for=condition=Ready roledefinition --all --timeout=180s 2>/dev/null || echo "::notice::Some RoleDefinitions not fully reconciled"
+          kubectl wait --for=condition=Ready binddefinition --all --timeout=180s 2>/dev/null || echo "::notice::Some BindDefinitions not fully reconciled"
 
           bash hack/ci/capture-operator-output.sh /tmp/pr-output
 


### PR DESCRIPTION
## Summary

Increase all kubectl wait --timeout values in the output-delta workflow from 120s to 180s to allow more time for resources to fully reconcile.

## Changes

- All --timeout=120s waits increased to --timeout=180s across all sections (main branch, fallback baseline, tag branch, PR branch)

## Motivation

The output-delta CI job occasionally times out waiting for resources to reconcile, particularly when multiple CRDs with dependency chains need processing.