### PR TITLE
fix: add periodic drift-correction requeue to WebhookAuthorizer controller

### DIFF
--- a/internal/controller/authorization/webhookauthorizer_controller.go
+++ b/internal/controller/authorization/webhookauthorizer_controller.go
@@ -167,9 +167,10 @@ func (r *WebhookAuthorizerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	metrics.ReconcileTotal.WithLabelValues(metrics.ControllerWebhookAuthorizer, metrics.ResultSuccess).Inc()
 	logger.V(1).Info("WebhookAuthorizer reconciled successfully",
 		"webhookAuthorizer", wa.Name,
-		"generation", wa.Generation)
+		"generation", wa.Generation,
+		"requeueAfter", DefaultRequeueInterval)
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: DefaultRequeueInterval}, nil
 }
 
 // validateNamespaceSelector validates that the NamespaceSelector can be parsed

--- a/internal/controller/authorization/webhookauthorizer_controller_test.go
+++ b/internal/controller/authorization/webhookauthorizer_controller_test.go
@@ -71,7 +71,7 @@ func TestReconcile_EmptySelector_Ready(t *testing.T) {
 
 	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("test-authorizer"))
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
 
 	// Verify status was updated
 	var updated authorizationv1alpha1.WebhookAuthorizer
@@ -108,7 +108,7 @@ func TestReconcile_WithMatchLabels_Ready(t *testing.T) {
 
 	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("label-authorizer"))
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
 
 	var updated authorizationv1alpha1.WebhookAuthorizer
 	g.Expect(c.Get(ctxWithLogger(), types.NamespacedName{Name: "label-authorizer"}, &updated)).To(gomega.Succeed())
@@ -148,7 +148,7 @@ func TestReconcile_WithMatchExpressions_Ready(t *testing.T) {
 
 	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("expr-authorizer"))
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
 
 	var updated authorizationv1alpha1.WebhookAuthorizer
 	g.Expect(c.Get(ctxWithLogger(), types.NamespacedName{Name: "expr-authorizer"}, &updated)).To(gomega.Succeed())
@@ -209,7 +209,7 @@ func TestReconcile_GenerationUpdate(t *testing.T) {
 
 	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("gen-authorizer"))
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
 
 	var updated authorizationv1alpha1.WebhookAuthorizer
 	g.Expect(c.Get(ctxWithLogger(), types.NamespacedName{Name: "gen-authorizer"}, &updated)).To(gomega.Succeed())
@@ -238,7 +238,7 @@ func TestReconcile_WithPrincipals_Ready(t *testing.T) {
 
 	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("principals-authorizer"))
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
 
 	var updated authorizationv1alpha1.WebhookAuthorizer
 	g.Expect(c.Get(ctxWithLogger(), types.NamespacedName{Name: "principals-authorizer"}, &updated)).To(gomega.Succeed())
@@ -266,7 +266,7 @@ func TestReconcile_NoMatchingNamespaces_StillReady(t *testing.T) {
 
 	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("no-match-authorizer"))
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
 
 	var updated authorizationv1alpha1.WebhookAuthorizer
 	g.Expect(c.Get(ctxWithLogger(), types.NamespacedName{Name: "no-match-authorizer"}, &updated)).To(gomega.Succeed())


### PR DESCRIPTION
## Summary

The WebhookAuthorizer controller returned `ctrl.Result{}` on success, unlike RoleDefinition and BindDefinition controllers which requeue at `DefaultRequeueInterval` (60s) for periodic drift correction.

## Problem

Without periodic requeue, if a WebhookAuthorizer's managed resources are modified or deleted externally, the controller would not detect or correct the drift until the next watch event.

## Changes

- `webhookauthorizer_controller.go`: Return `ctrl.Result{RequeueAfter: DefaultRequeueInterval}` on successful reconciliation
- `webhookauthorizer_controller_test.go`: Update 6 success-path tests to assert `DefaultRequeueInterval`

## Testing

- All existing unit and envtest tests pass
- `make lint` passes cleanly

Closes #204