### PR TITLE
fix: register UPDATE operation for namespace mutating webhook

### DIFF
--- a/chart/auth-operator/templates/namespace-mutating-webhook-configuration.yaml
+++ b/chart/auth-operator/templates/namespace-mutating-webhook-configuration.yaml
@@ -23,6 +23,7 @@ webhooks:
     - v1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - namespaces
     scope: '*'

--- a/config/webhook/namespace_webhooks.yaml
+++ b/config/webhook/namespace_webhooks.yaml
@@ -57,6 +57,7 @@ webhooks:
           - v1
         operations:
           - CREATE
+          - UPDATE
         resources:
           - namespaces
         scope: "*"


### PR DESCRIPTION
## Summary

Register the UPDATE operation for the namespace mutating webhook configuration.

## Problem

The namespace mutating webhook was only registered for CREATE operations, but the handler already supports both CREATE and UPDATE. This meant namespace label mutations were not applied when namespaces were updated after initial creation.

## Changes

- config/webhook/namespace_webhooks.yaml: Added UPDATE to mutating webhook operations
- chart/auth-operator/templates/namespace-mutating-webhook-configuration.yaml: Same change in Helm template

Both files now match the validating webhook which already has CREATE, UPDATE, and DELETE registered.

## Testing

- All unit and envtest tests pass
- make lint and make helm-lint clean

Closes #203