### PR TITLE
ci: pin govulncheck and gosec to specific versions

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -46,8 +46,11 @@ jobs:
           go-version: ${{ steps.go-version.outputs.version }}
           cache: true
 
+      - name: Load versions from versions.env
+        run: grep -v '^#' versions.env | grep -v '^$' >> $GITHUB_ENV
+
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@${{ env.GOVULNCHECK_VERSION }}
 
       - name: Run govulncheck
         continue-on-error: true
@@ -78,8 +81,11 @@ jobs:
           go-version: ${{ steps.go-version.outputs.version }}
           cache: true
 
+      - name: Load versions from versions.env
+        run: grep -v '^#' versions.env | grep -v '^$' >> $GITHUB_ENV
+
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@${{ env.GOSEC_VERSION }}
 
       - name: Run gosec
         run: gosec -fmt sarif -out gosec-results.sarif -exclude=G104,G304 ./... || true

--- a/versions.env
+++ b/versions.env
@@ -17,3 +17,7 @@ HELM_VERSION=v3.17.0
 
 # Desktop tools (not tracked by CI)
 DRAWIO=24.7.8
+
+# Security scanning tools
+GOVULNCHECK_VERSION=v1.1.4
+GOSEC_VERSION=v2.24.7


### PR DESCRIPTION
## Summary

Pin security scanning tools to specific versions from versions.env instead of using @latest.

## Problem

CI workflows installed govulncheck and gosec using @latest, making builds non-reproducible and introducing supply chain risk.

## Changes

- versions.env: Added GOVULNCHECK_VERSION=v1.1.4 and GOSEC_VERSION=v2.24.7
- security-scan.yml: Added versions.env loading to govulncheck and gosec jobs, replaced @latest with pinned versions

Note: setup-envtest retains @latest because the module has no tagged releases.

Closes #208