### PR TITLE
docs: fix --namespace default in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ See the [Operator Guide](docs/operator-guide.md) for the full reference.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--namespace` | `kube-system` | Operator namespace (falls back to `POD_NAMESPACE` env) |
+| `--namespace` | `$POD_NAMESPACE` | Operator namespace (value of `POD_NAMESPACE` env var; empty if unset) |
 | `--health-probe-bind-address` | `:8081` | Health probe bind address |
 | `--metrics-bind-address` | `:8080` | Metrics bind address |
 | `--leader-elect` | `true` | Enable leader election for HA |


### PR DESCRIPTION
The `--namespace` flag default was listed as `kube-system` but the actual default is `os.Getenv("POD_NAMESPACE")` (see cmd/root.go line 125).

Found during persona review of PR #221.