### PR TITLE
fix(ci): add release job dependency to helm-release to prevent upload race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -669,7 +669,14 @@ jobs:
 
   helm-release:
     name: Release Helm Chart
-    needs: [prepare, assemble]
+    needs: [prepare, assemble, release]
+    # Run after release job: on tag pushes wait for release to succeed,
+    # on PRs the release job is skipped so allow helm-release to proceed.
+    if: >-
+      !cancelled()
+      && needs.prepare.result == 'success'
+      && needs.assemble.result == 'success'
+      && (needs.release.result == 'success' || needs.release.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0-rc.13] — Pre-release
+
 ### Added
 
-- ServiceAccount namespace label inheritance: when no BindDefinition matches, SAs can create/update namespaces inheriting ownership labels from their source namespace as a last-resort fallback (#202)
+- ServiceAccount namespace label inheritance: when no BindDefinition matches, SAs can create/update namespaces inheriting ownership labels from their source namespace as a last-resort fallback (#202, #213)
+- `MaxItems` validation on `RestrictedResources` and `RestrictedVerbs` fields to enforce bounded input sizes (#218)
 
 ### Fixed
 
+- WebhookAuthorizer metrics now cleaned up on CR deletion, preventing stale metric series (#215)
+- Namespace mutating webhook now registers the UPDATE operation, fixing label inheritance on namespace updates (#216)
+- Periodic drift-correction requeue added to WebhookAuthorizer controller to self-heal configuration drift (#214)
 - Repeated label key checks in `getLabelsFromNamespaceSelector()` replaced with set-based lookup (#156)
-- Stale resource defaults in kustomize base configs (`config/manager/manager.yaml`, `config/webhook/deployment.yaml`)
-- Documentation drift in `docs/operator-guide.md` — Helm Values section now matches current chart defaults
+- Stale resource defaults in kustomize base configs (#199)
+- Incorrect `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable documentation (#217)
+- `--namespace` flag default documentation corrected in README (#222)
+
+### Documentation
+
+- End-user documentation improvements for operator guide (#221)
+- Missing BindDefinition status fields added to API reference (#220)
+- Documentation drift in `docs/operator-guide.md` — Helm Values section now matches current chart defaults (#199)
+
+### CI
+
+- `govulncheck` and `gosec` pinned to specific versions for reproducible builds (#219)
+- `anchore/sbom-action` bumped from 0.23.0 to 0.23.1 (#200)
+- `sigstore/cosign-installer` bumped from 4.0.0 to 4.1.0 (#201)
+- Release workflow: `helm-release` job now depends on `release` job to prevent upload-before-creation race
 
 ## [0.4.0-rc.12] — Pre-release
 


### PR DESCRIPTION
## Problem

The `helm-release` job in the Release workflow was running in parallel with the `release` job. When `helm-release` completed first and tried to upload the Helm chart `.tgz` to the GitHub release, it failed with `release not found` because the `release` job had not yet created it.

This caused the v0.4.0-rc.13 release to fail at the "Upload Helm chart to release" step.

## Fix

Add `release` to the `needs` array of `helm-release`, ensuring the GitHub Release is created before the Helm chart upload runs.

A conditional `if` expression is added so that on PRs (where the `release` job is skipped), the `helm-release` job still runs for chart packaging and OCI push validation.

## Changes

- `.github/workflows/release.yml`: Add `release` to `helm-release.needs` with conditional
- `CHANGELOG.md`: Add v0.4.0-rc.13 release notes

## Testing

The release workflow is triggered by tag pushes — this fix will be validated when the next RC is tagged after this PR merges.
