### PR TITLE
ci: enforce govulncheck failures and centralize version

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -53,7 +53,6 @@ jobs:
         run: go install golang.org/x/vuln/cmd/govulncheck@${{ env.GOVULNCHECK_VERSION }}
 
       - name: Run govulncheck
-        continue-on-error: true
         run: govulncheck ./...
 
   gosec:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/telekom/auth-operator
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/evanphx/json-patch v5.9.11+incompatible


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` from govulncheck steps in both `ci.yml` and `security-scan.yml` so vulnerability findings actually fail the build instead of being silently ignored
- In `ci.yml`, replace hardcoded `govulncheck@v1.1.4` with `${{ env.GOVULNCHECK_VERSION }}` loaded from `versions.env` (single source of truth), matching the pattern already used in `security-scan.yml`

## Motivation

Code review findings CICD-1 and CICD-3 identified that govulncheck was configured with `continue-on-error: true` in both CI workflows, meaning vulnerability scan results were effectively ignored. This defeats the purpose of running the scanner.

## Changes

### `.github/workflows/security-scan.yml`
- Removed `continue-on-error: true` from the "Run govulncheck" step

### `.github/workflows/ci.yml`  
- Added "Load versions from versions.env" step to the security job (matching the pattern used by lint, test, and helm-lint jobs)
- Removed `continue-on-error: true` from the govulncheck step
- Changed `govulncheck@v1.1.4` → `govulncheck@${{ env.GOVULNCHECK_VERSION }}` to use the centralized version

## Notes

- The `continue-on-error: true` on the Trivy SARIF **upload** step (not scan) is intentionally preserved — it exists because the upload may fail due to org security-events permission policy on forks
- If there are currently known vulnerabilities in dependencies, this PR will correctly cause CI to fail until they are resolved