### PR TITLE
fix: handle User kind subjects in MatchesSubjects

### DIFF
--- a/internal/webhook/authorization/helpers.go
+++ b/internal/webhook/authorization/helpers.go
@@ -178,17 +178,22 @@ func hasGroup(groups []string, expected string) bool {
 	return false
 }
 
-// MatchesSubjects checks if the user (via groups or service account) matches any of the subjects.
-func MatchesSubjects(userGroups []string, saInfo ServiceAccountInfo, subjects []rbacv1.Subject) bool {
+// MatchesSubjects checks if the user (via username, groups, or service account) matches any of the subjects.
+func MatchesSubjects(username string, userGroups []string, saInfo ServiceAccountInfo, subjects []rbacv1.Subject) bool {
 	for _, subject := range subjects {
-		if subject.Kind == "Group" {
+		switch subject.Kind {
+		case "User":
+			if subject.Name == username {
+				return true
+			}
+		case "Group":
 			for _, userGroup := range userGroups {
 				if subject.Name == userGroup {
 					return true
 				}
 			}
-		} else if subject.Kind == "ServiceAccount" && saInfo.IsServiceAccount {
-			if subject.Namespace == saInfo.Namespace && subject.Name == saInfo.Name {
+		case "ServiceAccount":
+			if saInfo.IsServiceAccount && subject.Namespace == saInfo.Namespace && subject.Name == saInfo.Name {
 				return true
 			}
 		}

--- a/internal/webhook/authorization/helpers.go
+++ b/internal/webhook/authorization/helpers.go
@@ -182,17 +182,17 @@ func hasGroup(groups []string, expected string) bool {
 func MatchesSubjects(username string, userGroups []string, saInfo ServiceAccountInfo, subjects []rbacv1.Subject) bool {
 	for _, subject := range subjects {
 		switch subject.Kind {
-		case "User":
+		case rbacv1.UserKind:
 			if subject.Name == username {
 				return true
 			}
-		case "Group":
+		case rbacv1.GroupKind:
 			for _, userGroup := range userGroups {
 				if subject.Name == userGroup {
 					return true
 				}
 			}
-		case "ServiceAccount":
+		case rbacv1.ServiceAccountKind:
 			if saInfo.IsServiceAccount && subject.Namespace == saInfo.Namespace && subject.Name == saInfo.Name {
 				return true
 			}

--- a/internal/webhook/authorization/helpers_test.go
+++ b/internal/webhook/authorization/helpers_test.go
@@ -412,7 +412,7 @@ func TestMatchesSubjects(t *testing.T) {
 			userGroups: []string{"oidc:developer"},
 			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
 			subjects: []rbacv1.Subject{
-				{Kind: "User", Name: "jane.doe@example.com"},
+				{Kind: rbacv1.UserKind, Name: "jane.doe@example.com"},
 			},
 			want: true,
 		},
@@ -422,7 +422,7 @@ func TestMatchesSubjects(t *testing.T) {
 			userGroups: []string{"oidc:developer"},
 			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
 			subjects: []rbacv1.Subject{
-				{Kind: "User", Name: "jane.doe@example.com"},
+				{Kind: rbacv1.UserKind, Name: "jane.doe@example.com"},
 			},
 			want: false,
 		},
@@ -432,8 +432,8 @@ func TestMatchesSubjects(t *testing.T) {
 			userGroups: []string{},
 			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
 			subjects: []rbacv1.Subject{
-				{Kind: "Group", Name: "oidc:admin"},
-				{Kind: "User", Name: "jane.doe@example.com"},
+				{Kind: rbacv1.GroupKind, Name: "oidc:admin"},
+				{Kind: rbacv1.UserKind, Name: "jane.doe@example.com"},
 			},
 			want: true,
 		},
@@ -443,7 +443,7 @@ func TestMatchesSubjects(t *testing.T) {
 			userGroups: []string{"oidc:admin", "oidc:developer"},
 			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
 			subjects: []rbacv1.Subject{
-				{Kind: "Group", Name: "oidc:admin"},
+				{Kind: rbacv1.GroupKind, Name: "oidc:admin"},
 			},
 			want: true,
 		},
@@ -453,7 +453,7 @@ func TestMatchesSubjects(t *testing.T) {
 			userGroups: []string{"oidc:viewer"},
 			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
 			subjects: []rbacv1.Subject{
-				{Kind: "Group", Name: "oidc:admin"},
+				{Kind: rbacv1.GroupKind, Name: "oidc:admin"},
 			},
 			want: false,
 		},
@@ -463,7 +463,7 @@ func TestMatchesSubjects(t *testing.T) {
 			userGroups: []string{},
 			saInfo:     ServiceAccountInfo{Namespace: "kube-system", Name: "default", IsServiceAccount: true},
 			subjects: []rbacv1.Subject{
-				{Kind: "ServiceAccount", Namespace: "kube-system", Name: "default"},
+				{Kind: rbacv1.ServiceAccountKind, Namespace: "kube-system", Name: "default"},
 			},
 			want: true,
 		},
@@ -473,7 +473,7 @@ func TestMatchesSubjects(t *testing.T) {
 			userGroups: []string{},
 			saInfo:     ServiceAccountInfo{Namespace: "other-ns", Name: "default", IsServiceAccount: true},
 			subjects: []rbacv1.Subject{
-				{Kind: "ServiceAccount", Namespace: "kube-system", Name: "default"},
+				{Kind: rbacv1.ServiceAccountKind, Namespace: "kube-system", Name: "default"},
 			},
 			want: false,
 		},
@@ -483,7 +483,7 @@ func TestMatchesSubjects(t *testing.T) {
 			userGroups: []string{},
 			saInfo:     ServiceAccountInfo{Namespace: "kube-system", Name: "other", IsServiceAccount: true},
 			subjects: []rbacv1.Subject{
-				{Kind: "ServiceAccount", Namespace: "kube-system", Name: "default"},
+				{Kind: rbacv1.ServiceAccountKind, Namespace: "kube-system", Name: "default"},
 			},
 			want: false,
 		},
@@ -501,8 +501,8 @@ func TestMatchesSubjects(t *testing.T) {
 			userGroups: []string{"oidc:developer"},
 			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
 			subjects: []rbacv1.Subject{
-				{Kind: "Group", Name: "oidc:admin"},
-				{Kind: "Group", Name: "oidc:developer"},
+				{Kind: rbacv1.GroupKind, Name: "oidc:admin"},
+				{Kind: rbacv1.GroupKind, Name: "oidc:developer"},
 			},
 			want: true,
 		},

--- a/internal/webhook/authorization/helpers_test.go
+++ b/internal/webhook/authorization/helpers_test.go
@@ -400,13 +400,46 @@ func TestCheckBypassValidatorCases(t *testing.T) {
 func TestMatchesSubjects(t *testing.T) {
 	tests := []struct {
 		name       string
+		username   string
 		userGroups []string
 		saInfo     ServiceAccountInfo
 		subjects   []rbacv1.Subject
 		want       bool
 	}{
 		{
+			name:       "matches user",
+			username:   "jane.doe@example.com",
+			userGroups: []string{"oidc:developer"},
+			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
+			subjects: []rbacv1.Subject{
+				{Kind: "User", Name: "jane.doe@example.com"},
+			},
+			want: true,
+		},
+		{
+			name:       "does not match user",
+			username:   "john.doe@example.com",
+			userGroups: []string{"oidc:developer"},
+			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
+			subjects: []rbacv1.Subject{
+				{Kind: "User", Name: "jane.doe@example.com"},
+			},
+			want: false,
+		},
+		{
+			name:       "matches user among multiple subjects",
+			username:   "jane.doe@example.com",
+			userGroups: []string{},
+			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
+			subjects: []rbacv1.Subject{
+				{Kind: "Group", Name: "oidc:admin"},
+				{Kind: "User", Name: "jane.doe@example.com"},
+			},
+			want: true,
+		},
+		{
 			name:       "matches group",
+			username:   "someone@example.com",
 			userGroups: []string{"oidc:admin", "oidc:developer"},
 			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
 			subjects: []rbacv1.Subject{
@@ -416,6 +449,7 @@ func TestMatchesSubjects(t *testing.T) {
 		},
 		{
 			name:       "does not match group",
+			username:   "someone@example.com",
 			userGroups: []string{"oidc:viewer"},
 			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
 			subjects: []rbacv1.Subject{
@@ -425,6 +459,7 @@ func TestMatchesSubjects(t *testing.T) {
 		},
 		{
 			name:       "matches service account",
+			username:   "system:serviceaccount:kube-system:default",
 			userGroups: []string{},
 			saInfo:     ServiceAccountInfo{Namespace: "kube-system", Name: "default", IsServiceAccount: true},
 			subjects: []rbacv1.Subject{
@@ -434,6 +469,7 @@ func TestMatchesSubjects(t *testing.T) {
 		},
 		{
 			name:       "service account namespace mismatch",
+			username:   "system:serviceaccount:other-ns:default",
 			userGroups: []string{},
 			saInfo:     ServiceAccountInfo{Namespace: "other-ns", Name: "default", IsServiceAccount: true},
 			subjects: []rbacv1.Subject{
@@ -443,6 +479,7 @@ func TestMatchesSubjects(t *testing.T) {
 		},
 		{
 			name:       "service account name mismatch",
+			username:   "system:serviceaccount:kube-system:other",
 			userGroups: []string{},
 			saInfo:     ServiceAccountInfo{Namespace: "kube-system", Name: "other", IsServiceAccount: true},
 			subjects: []rbacv1.Subject{
@@ -452,6 +489,7 @@ func TestMatchesSubjects(t *testing.T) {
 		},
 		{
 			name:       "empty subjects returns false",
+			username:   "someone@example.com",
 			userGroups: []string{"oidc:admin"},
 			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
 			subjects:   []rbacv1.Subject{},
@@ -459,6 +497,7 @@ func TestMatchesSubjects(t *testing.T) {
 		},
 		{
 			name:       "multiple subjects - matches second",
+			username:   "someone@example.com",
 			userGroups: []string{"oidc:developer"},
 			saInfo:     ServiceAccountInfo{IsServiceAccount: false},
 			subjects: []rbacv1.Subject{
@@ -471,7 +510,7 @@ func TestMatchesSubjects(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := MatchesSubjects(tt.userGroups, tt.saInfo, tt.subjects)
+			got := MatchesSubjects(tt.username, tt.userGroups, tt.saInfo, tt.subjects)
 			if got != tt.want {
 				t.Errorf("MatchesSubjects() = %v, want %v", got, tt.want)
 			}

--- a/internal/webhook/authorization/namespace_mutating_webhook.go
+++ b/internal/webhook/authorization/namespace_mutating_webhook.go
@@ -72,7 +72,7 @@ func (m *NamespaceMutator) Handle(ctx context.Context, req admission.Request) ad
 	}
 
 	// Collect labels from matching BindDefinitions
-	labelsToAdd, listErr := m.collectBindDefinitionLabels(ctx, req.Name, userGroups, saInfo)
+	labelsToAdd, listErr := m.collectBindDefinitionLabels(ctx, req.Name, req.UserInfo.Username, userGroups, saInfo)
 	if listErr != nil {
 		metrics.WebhookRequestsTotal.WithLabelValues(metrics.WebhookNamespaceMutator, string(req.Operation), metrics.WebhookResultErrored).Inc()
 		return admission.Errored(http.StatusInternalServerError, listErr)
@@ -131,7 +131,7 @@ func (m *NamespaceMutator) Handle(ctx context.Context, req admission.Request) ad
 
 // collectBindDefinitionLabels iterates over all BindDefinitions and collects labels to add
 // from those whose subjects match the requesting user.
-func (m *NamespaceMutator) collectBindDefinitionLabels(ctx context.Context, nsName string, userGroups []string, saInfo ServiceAccountInfo) (map[string]string, error) {
+func (m *NamespaceMutator) collectBindDefinitionLabels(ctx context.Context, nsName, username string, userGroups []string, saInfo ServiceAccountInfo) (map[string]string, error) {
 	logger := logf.FromContext(ctx).WithName("namespace-mutator")
 
 	// Fetch all BindDefinition CRDs
@@ -155,7 +155,7 @@ func (m *NamespaceMutator) collectBindDefinitionLabels(ctx context.Context, nsNa
 		logger.V(3).Info("checking BindDefinition for user match",
 			"namespace", nsName, "bindDefinitionName", bindDef.Name, "bdIndex", bdIdx)
 
-		if MatchesSubjects(userGroups, saInfo, bindDef.Spec.Subjects) {
+		if MatchesSubjects(username, userGroups, saInfo, bindDef.Spec.Subjects) {
 			logger.V(3).Info("user matched - extracting labels from RoleBindings",
 				"namespace", nsName, "bindDefinition", bindDef.Name)
 

--- a/internal/webhook/authorization/namespace_validating_webhook.go
+++ b/internal/webhook/authorization/namespace_validating_webhook.go
@@ -303,7 +303,7 @@ func (v *NamespaceValidator) authorizeViaBindDefinitions(ctx context.Context, lo
 		logger.V(3).Info("checking BindDefinition", "namespace", req.Name,
 			"bindDefinitionName", bindDef.Name, "bdIndex", bdIdx, "subjectCount", len(bindDef.Spec.Subjects))
 
-		if !MatchesSubjects(userGroups, saInfo, bindDef.Spec.Subjects) {
+		if !MatchesSubjects(req.UserInfo.Username, userGroups, saInfo, bindDef.Spec.Subjects) {
 			logger.V(4).Info("user not found in BindDefinition subjects",
 				"namespace", req.Name, "bindDefinitionName", bindDef.Name)
 			continue


### PR DESCRIPTION
## Summary

- **Finding**: `MatchesSubjects()` in `helpers.go` only handled `Group` and `ServiceAccount` subject kinds, silently ignoring `User`. BindDefinitions with `User` subjects produced valid RBAC bindings (controller path worked), but the admission webhook never matched those users — silently denying namespace operations that should be allowed.
- **Fix**: Add `User` case to the switch statement in `MatchesSubjects()`, thread the `username` parameter through from the admission request (`req.UserInfo.Username`).
- **Tests**: Added 3 test cases for User matching (exact match, mismatch, mixed subjects).

## Changes

| File | Change |
|------|--------|
| `internal/webhook/authorization/helpers.go` | Added `User` case to `MatchesSubjects()`, added `username` parameter |
| `internal/webhook/authorization/namespace_validating_webhook.go` | Pass `req.UserInfo.Username` to `MatchesSubjects()` |
| `internal/webhook/authorization/namespace_mutating_webhook.go` | Thread `username` through `collectBindDefinitionLabels()` to `MatchesSubjects()` |
| `internal/webhook/authorization/helpers_test.go` | Added `username` field + 3 User test cases, updated all existing tests |

## Verification

- `make test` — all tests pass ✅
- `make lint` — 0 issues ✅
- Refactored if-else chain to switch per `gocritic` lint suggestion
- Combined consecutive `string` params per `gocritic:paramTypeCombine`