### PR TITLE
fix: add issues:write permission to labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   labeler:


### PR DESCRIPTION
Split out from PR #267 — this fixes the 'Add Labels to PR' CI job that fails due to missing GitHub API permissions.