### PR TITLE
perf: cache namespace labels per SAR request to reduce redundant cache lookups

### DIFF
--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -489,6 +489,12 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 	evaluated := 0
 	skipped := 0
 
+	// nsLabelCache is a per-request cache of namespace labels keyed by namespace
+	// name. It eliminates redundant client.Get calls when multiple scoped
+	// authorizers share the same target namespace within a single SAR evaluation.
+	// The cache must NOT be shared across requests to avoid stale label reads.
+	nsLabelCache := make(map[string]labels.Set)
+
 	for i, webhookAuthorizer := range items {
 		// Skip namespace-scoped authorizers for non-resource or cluster-scoped SARs
 		// that have no namespace target. This is a defensive guard — the list query
@@ -505,7 +511,7 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 				skipped++
 				continue
 			}
-			if !wa.namespaceMatches(ctx, resourceNS, &webhookAuthorizer.Spec.NamespaceSelector) {
+			if !wa.namespaceMatches(ctx, resourceNS, &webhookAuthorizer.Spec.NamespaceSelector, nsLabelCache) {
 				wa.Log.V(2).Info("namespace selector did not match, skipping",
 					"authorizer", webhookAuthorizer.Name,
 					"namespace", resourceNS)
@@ -580,7 +586,10 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 }
 
 // namespaceMatches checks if the namespace matches the selector.
-func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector) bool {
+// nsCache is a per-request map[string]labels.Set that avoids redundant Get
+// calls when multiple scoped authorizers target the same namespace within one
+// SAR evaluation. Callers must not share the map across requests.
+func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector, nsCache map[string]labels.Set) bool {
 	if wa.Tracer != nil {
 		var span trace.Span
 		ctx, span = wa.Tracer.Start(ctx, "webhook.NamespaceMatch",
@@ -591,18 +600,24 @@ func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, se
 	if namespace == "" {
 		return false
 	}
-	var ns corev1.Namespace
-	err := wa.Client.Get(ctx, types.NamespacedName{Name: namespace}, &ns)
-	if err != nil {
-		wa.Log.Error(err, "Failed to get namespace", "namespace", namespace)
-		return false
+
+	nsLabels, ok := nsCache[namespace]
+	if !ok {
+		var ns corev1.Namespace
+		if err := wa.Client.Get(ctx, types.NamespacedName{Name: namespace}, &ns); err != nil {
+			wa.Log.Error(err, "Failed to get namespace", "namespace", namespace)
+			return false
+		}
+		nsLabels = labels.Set(ns.Labels)
+		nsCache[namespace] = nsLabels
 	}
+
 	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
 		wa.Log.Error(err, "Invalid label selector")
 		return false
 	}
-	return labelSelector.Matches(labels.Set(ns.Labels))
+	return labelSelector.Matches(nsLabels)
 }
 
 // principalMatches checks if the user or groups match the principals.

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -489,11 +489,13 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 	evaluated := 0
 	skipped := 0
 
-	// nsLabelCache is a per-request cache of namespace labels keyed by namespace
-	// name. It eliminates redundant client.Get calls when multiple scoped
-	// authorizers share the same target namespace within a single SAR evaluation.
-	// The cache must NOT be shared across requests to avoid stale label reads.
-	nsLabelCache := make(map[string]labels.Set)
+	// nsLabelCache is a per-request cache keyed by namespace name. A nil pointer
+	// value records a failed Get (namespace not found or error); a non-nil pointer
+	// holds the fetched label set, which may itself be an empty map. This
+	// avoids redundant client.Get calls and repeated error logging when multiple
+	// scoped authorizers target the same namespace in one SAR. The map must NOT
+	// be shared across requests to avoid stale label reads.
+	nsLabelCache := make(map[string]*labels.Set)
 
 	for i, webhookAuthorizer := range items {
 		// Skip namespace-scoped authorizers for non-resource or cluster-scoped SARs
@@ -586,10 +588,11 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 }
 
 // namespaceMatches checks if the namespace matches the selector.
-// nsCache is a per-request map[string]labels.Set that avoids redundant Get
-// calls when multiple scoped authorizers target the same namespace within one
-// SAR evaluation. Callers must not share the map across requests.
-func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector, nsCache map[string]labels.Set) bool {
+// nsCache is a per-request map that avoids redundant Get calls when multiple
+// scoped authorizers target the same namespace within one SAR evaluation. A nil
+// pointer value signals a previously failed Get; callers must not share the map
+// across requests.
+func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector, nsCache map[string]*labels.Set) bool {
 	if wa.Tracer != nil {
 		var span trace.Span
 		ctx, span = wa.Tracer.Start(ctx, "webhook.NamespaceMatch",
@@ -601,16 +604,26 @@ func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, se
 		return false
 	}
 
-	nsLabels, ok := nsCache[namespace]
-	if !ok {
-		var ns corev1.Namespace
-		if err := wa.Client.Get(ctx, types.NamespacedName{Name: namespace}, &ns); err != nil {
-			wa.Log.Error(err, "Failed to get namespace", "namespace", namespace)
+	if cached, ok := nsCache[namespace]; ok {
+		if cached == nil {
 			return false
 		}
-		nsLabels = labels.Set(ns.Labels)
-		nsCache[namespace] = nsLabels
+		labelSelector, err := metav1.LabelSelectorAsSelector(selector)
+		if err != nil {
+			wa.Log.Error(err, "Invalid label selector")
+			return false
+		}
+		return labelSelector.Matches(*cached)
 	}
+
+	var ns corev1.Namespace
+	if err := wa.Client.Get(ctx, types.NamespacedName{Name: namespace}, &ns); err != nil {
+		wa.Log.Error(err, "Failed to get namespace", "namespace", namespace)
+		nsCache[namespace] = nil
+		return false
+	}
+	nsLabels := labels.Set(ns.Labels)
+	nsCache[namespace] = &nsLabels
 
 	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -514,11 +514,10 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 
 	// nsLabelCache is a per-request cache keyed by namespace name. A nil pointer
 	// value records a failed Get (namespace not found or error); a non-nil pointer
-	// holds the fetched label set, which may itself be an empty map. This
-	// avoids redundant client.Get calls and repeated error logging when multiple
-	// scoped authorizers target the same namespace in one SAR. The map must NOT
-	// be shared across requests to avoid stale label reads.
-	nsLabelCache := make(map[string]*labels.Set)
+	// holds the fetched label set, which may itself be an empty map. Initialize
+	// it lazily so cluster-scoped-only SARs avoid an unnecessary map allocation.
+	// The map must NOT be shared across requests to avoid stale label reads.
+	var nsLabelCache map[string]*labels.Set
 
 	for i, webhookAuthorizer := range items {
 		// Skip namespace-scoped authorizers for non-resource or cluster-scoped SARs
@@ -535,6 +534,9 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 					"authorizer", webhookAuthorizer.Name)
 				skipped++
 				continue
+			}
+			if nsLabelCache == nil {
+				nsLabelCache = make(map[string]*labels.Set)
 			}
 			matched, err := wa.namespaceMatches(ctx, resourceNS, &webhookAuthorizer.Spec.NamespaceSelector, nsLabelCache)
 			if err != nil {

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -512,6 +512,12 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 	evaluated := 0
 	skipped := 0
 
+	// nsLabelCache is a per-request cache of namespace labels keyed by namespace
+	// name. It eliminates redundant client.Get calls when multiple scoped
+	// authorizers share the same target namespace within a single SAR evaluation.
+	// The cache must NOT be shared across requests to avoid stale label reads.
+	nsLabelCache := make(map[string]labels.Set)
+
 	for i, webhookAuthorizer := range items {
 		// Skip namespace-scoped authorizers for non-resource or cluster-scoped SARs
 		// that have no namespace target. This is a defensive guard — the list query
@@ -528,7 +534,7 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 				skipped++
 				continue
 			}
-			matched, err := wa.namespaceMatches(ctx, resourceNS, &webhookAuthorizer.Spec.NamespaceSelector)
+			matched, err := wa.namespaceMatches(ctx, resourceNS, &webhookAuthorizer.Spec.NamespaceSelector, nsLabelCache)
 			if err != nil {
 				return evaluationResult{}, fmt.Errorf("namespace match for authorizer %s: %w", webhookAuthorizer.Name, err)
 			}
@@ -608,8 +614,10 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 
 // namespaceMatches checks if the namespace matches the selector.
 // On API errors the error is returned so callers can fail-closed rather than
-// skipping the authorizer as if it were a non-match.
-func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector) (bool, error) {
+// skipping the authorizer as if it were a non-match. nsCache is a per-request
+// map that avoids redundant Get calls when multiple scoped authorizers target
+// the same namespace within one SAR evaluation.
+func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector, nsCache map[string]labels.Set) (bool, error) {
 	if wa.Tracer != nil {
 		var span trace.Span
 		ctx, span = wa.Tracer.Start(ctx, "webhook.NamespaceMatch",
@@ -620,17 +628,24 @@ func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, se
 	if namespace == "" {
 		return false, nil
 	}
-	var ns corev1.Namespace
-	getCtx, cancel := context.WithTimeout(ctx, authorizationv1alpha1.WebhookCacheTimeout)
-	defer cancel()
-	if err := wa.Client.Get(getCtx, types.NamespacedName{Name: namespace}, &ns); err != nil {
-		return false, fmt.Errorf("get namespace %s: %w", namespace, err)
+
+	nsLabels, ok := nsCache[namespace]
+	if !ok {
+		var ns corev1.Namespace
+		getCtx, cancel := context.WithTimeout(ctx, authorizationv1alpha1.WebhookCacheTimeout)
+		defer cancel()
+		if err := wa.Client.Get(getCtx, types.NamespacedName{Name: namespace}, &ns); err != nil {
+			return false, fmt.Errorf("get namespace %s: %w", namespace, err)
+		}
+		nsLabels = labels.Set(ns.Labels)
+		nsCache[namespace] = nsLabels
 	}
+
 	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
 		return false, fmt.Errorf("parse namespace label selector: %w", err)
 	}
-	return labelSelector.Matches(labels.Set(ns.Labels)), nil
+	return labelSelector.Matches(nsLabels), nil
 }
 
 // principalMatches checks if the user or groups match the principals.

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -512,11 +512,13 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 	evaluated := 0
 	skipped := 0
 
-	// nsLabelCache is a per-request cache of namespace labels keyed by namespace
-	// name. It eliminates redundant client.Get calls when multiple scoped
-	// authorizers share the same target namespace within a single SAR evaluation.
-	// The cache must NOT be shared across requests to avoid stale label reads.
-	nsLabelCache := make(map[string]labels.Set)
+	// nsLabelCache is a per-request cache keyed by namespace name. A nil pointer
+	// value records a failed Get (namespace not found or error); a non-nil pointer
+	// holds the fetched label set, which may itself be an empty map. This
+	// avoids redundant client.Get calls and repeated error logging when multiple
+	// scoped authorizers target the same namespace in one SAR. The map must NOT
+	// be shared across requests to avoid stale label reads.
+	nsLabelCache := make(map[string]*labels.Set)
 
 	for i, webhookAuthorizer := range items {
 		// Skip namespace-scoped authorizers for non-resource or cluster-scoped SARs
@@ -616,8 +618,9 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 // On API errors the error is returned so callers can fail-closed rather than
 // skipping the authorizer as if it were a non-match. nsCache is a per-request
 // map that avoids redundant Get calls when multiple scoped authorizers target
-// the same namespace within one SAR evaluation.
-func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector, nsCache map[string]labels.Set) (bool, error) {
+// the same namespace within one SAR evaluation. A nil pointer value signals a
+// previously failed Get; callers must not share the map across requests.
+func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector, nsCache map[string]*labels.Set) (bool, error) {
 	if wa.Tracer != nil {
 		var span trace.Span
 		ctx, span = wa.Tracer.Start(ctx, "webhook.NamespaceMatch",
@@ -629,17 +632,26 @@ func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, se
 		return false, nil
 	}
 
-	nsLabels, ok := nsCache[namespace]
-	if !ok {
-		var ns corev1.Namespace
-		getCtx, cancel := context.WithTimeout(ctx, authorizationv1alpha1.WebhookCacheTimeout)
-		defer cancel()
-		if err := wa.Client.Get(getCtx, types.NamespacedName{Name: namespace}, &ns); err != nil {
-			return false, fmt.Errorf("get namespace %s: %w", namespace, err)
+	if cached, ok := nsCache[namespace]; ok {
+		if cached == nil {
+			return false, fmt.Errorf("get namespace %s: previous lookup failed", namespace)
 		}
-		nsLabels = labels.Set(ns.Labels)
-		nsCache[namespace] = nsLabels
+		labelSelector, err := metav1.LabelSelectorAsSelector(selector)
+		if err != nil {
+			return false, fmt.Errorf("parse namespace label selector: %w", err)
+		}
+		return labelSelector.Matches(*cached), nil
 	}
+
+	var ns corev1.Namespace
+	getCtx, cancel := context.WithTimeout(ctx, authorizationv1alpha1.WebhookCacheTimeout)
+	defer cancel()
+	if err := wa.Client.Get(getCtx, types.NamespacedName{Name: namespace}, &ns); err != nil {
+		nsCache[namespace] = nil
+		return false, fmt.Errorf("get namespace %s: %w", namespace, err)
+	}
+	nsLabels := labels.Set(ns.Labels)
+	nsCache[namespace] = &nsLabels
 
 	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -194,13 +194,14 @@ func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return strings.Compare(a.Name, b.Name)
 	})
 
-	result, evalErr := wa.evaluateSAR(ctx, &sar, items)
-	if evalErr != nil {
-		wa.Log.Error(evalErr, "failed to evaluate SubjectAccessReview",
+	result, err := wa.evaluateSAR(ctx, &sar, items)
+	if err != nil {
+		wa.Log.Error(err, "failed to evaluate SubjectAccessReview",
+			"user", sar.Spec.User,
 			"latency", time.Since(start).String())
 		if span := trace.SpanFromContext(ctx); span.IsRecording() {
-			span.RecordError(evalErr)
-			span.SetStatus(codes.Error, "evaluation error")
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "failed to evaluate SubjectAccessReview")
 		}
 		wa.recordErrorMetrics(start)
 		http.Error(w, "internal evaluation error", http.StatusInternalServerError)
@@ -508,16 +509,20 @@ func isFieldIndexError(err error) bool {
 		(strings.Contains(msg, "does not exist") || strings.Contains(msg, "no index with name"))
 }
 
+type namespaceLabelCacheEntry struct {
+	labels labels.Set
+	err    error
+}
+
 func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAccessReview, items []authorizationv1alpha1.WebhookAuthorizer) (evaluationResult, error) {
 	evaluated := 0
 	skipped := 0
 
-	// nsLabelCache is a per-request cache keyed by namespace name. A nil pointer
-	// value records a failed Get (namespace not found or error); a non-nil pointer
-	// holds the fetched label set, which may itself be an empty map. Initialize
-	// it lazily so cluster-scoped-only SARs avoid an unnecessary map allocation.
-	// The map must NOT be shared across requests to avoid stale label reads.
-	var nsLabelCache map[string]*labels.Set
+	// nsLabelCache is a per-request cache keyed by namespace name. It records
+	// both successful label fetches and Get errors so repeated scoped
+	// authorizers do not repeat the same lookup, while errors still propagate
+	// to the fail-closed HTTP path.
+	var nsLabelCache map[string]namespaceLabelCacheEntry
 
 	for i, webhookAuthorizer := range items {
 		// Skip namespace-scoped authorizers for non-resource or cluster-scoped SARs
@@ -536,13 +541,21 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 				continue
 			}
 			if nsLabelCache == nil {
-				nsLabelCache = make(map[string]*labels.Set)
+				nsLabelCache = make(map[string]namespaceLabelCacheEntry)
 			}
-			matched, err := wa.namespaceMatches(ctx, resourceNS, &webhookAuthorizer.Spec.NamespaceSelector, nsLabelCache)
+			matches, err := wa.namespaceMatches(ctx, resourceNS, &webhookAuthorizer.Spec.NamespaceSelector, nsLabelCache)
 			if err != nil {
-				return evaluationResult{}, fmt.Errorf("namespace match for authorizer %s: %w", webhookAuthorizer.Name, err)
+				return evaluationResult{
+					allowed:        false,
+					reason:         "internal evaluation error",
+					decision:       pkgmetrics.AuthorizerDecisionNoOpinion,
+					authorizerName: pkgmetrics.AuthorizerNameNone,
+					matchedRule:    -1,
+					evaluatedCount: evaluated,
+					skippedCount:   skipped,
+				}, err
 			}
-			if !matched {
+			if !matches {
 				wa.Log.V(2).Info("namespace selector did not match, skipping",
 					"authorizer", webhookAuthorizer.Name,
 					"namespace", resourceNS)
@@ -617,12 +630,11 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 }
 
 // namespaceMatches checks if the namespace matches the selector.
-// On API errors the error is returned so callers can fail-closed rather than
-// skipping the authorizer as if it were a non-match. nsCache is a per-request
-// map that avoids redundant Get calls when multiple scoped authorizers target
-// the same namespace within one SAR evaluation. A nil pointer value signals a
-// previously failed Get; callers must not share the map across requests.
-func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector, nsCache map[string]*labels.Set) (bool, error) {
+// nsCache is a per-request map that avoids redundant Get calls when multiple
+// scoped authorizers target the same namespace within one SAR evaluation.
+// Cached Get errors are returned to callers so selector evaluation fails
+// closed instead of silently skipping scoped authorizers.
+func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector, nsCache map[string]namespaceLabelCacheEntry) (bool, error) {
 	if wa.Tracer != nil {
 		var span trace.Span
 		ctx, span = wa.Tracer.Start(ctx, "webhook.NamespaceMatch",
@@ -635,29 +647,33 @@ func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, se
 	}
 
 	if cached, ok := nsCache[namespace]; ok {
-		if cached == nil {
-			return false, fmt.Errorf("get namespace %s: previous lookup failed", namespace)
+		if cached.err != nil {
+			return false, cached.err
 		}
 		labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 		if err != nil {
-			return false, fmt.Errorf("parse namespace label selector: %w", err)
+			wa.Log.Error(err, "Invalid label selector")
+			return false, err
 		}
-		return labelSelector.Matches(*cached), nil
+		return labelSelector.Matches(cached.labels), nil
 	}
 
 	var ns corev1.Namespace
 	getCtx, cancel := context.WithTimeout(ctx, authorizationv1alpha1.WebhookCacheTimeout)
 	defer cancel()
 	if err := wa.Client.Get(getCtx, types.NamespacedName{Name: namespace}, &ns); err != nil {
-		nsCache[namespace] = nil
-		return false, fmt.Errorf("get namespace %s: %w", namespace, err)
+		wrappedErr := fmt.Errorf("get namespace %q: %w", namespace, err)
+		wa.Log.Error(wrappedErr, "Failed to get namespace", "namespace", namespace)
+		nsCache[namespace] = namespaceLabelCacheEntry{err: wrappedErr}
+		return false, wrappedErr
 	}
 	nsLabels := labels.Set(ns.Labels)
-	nsCache[namespace] = &nsLabels
+	nsCache[namespace] = namespaceLabelCacheEntry{labels: nsLabels}
 
 	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
-		return false, fmt.Errorf("parse namespace label selector: %w", err)
+		wa.Log.Error(err, "Invalid label selector")
+		return false, err
 	}
 	return labelSelector.Matches(nsLabels), nil
 }

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -553,7 +553,7 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 					matchedRule:    -1,
 					evaluatedCount: evaluated,
 					skippedCount:   skipped,
-				}, err
+				}, fmt.Errorf("WebhookAuthorizer %q namespace selector: %w", webhookAuthorizer.Name, err)
 			}
 			if !matches {
 				wa.Log.V(2).Info("namespace selector did not match, skipping",
@@ -652,8 +652,7 @@ func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, se
 		}
 		labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 		if err != nil {
-			wa.Log.Error(err, "Invalid label selector")
-			return false, err
+			return false, fmt.Errorf("parse namespace selector for namespace %q: %w", namespace, err)
 		}
 		return labelSelector.Matches(cached.labels), nil
 	}
@@ -663,7 +662,6 @@ func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, se
 	defer cancel()
 	if err := wa.Client.Get(getCtx, types.NamespacedName{Name: namespace}, &ns); err != nil {
 		wrappedErr := fmt.Errorf("get namespace %q: %w", namespace, err)
-		wa.Log.Error(wrappedErr, "Failed to get namespace", "namespace", namespace)
 		nsCache[namespace] = namespaceLabelCacheEntry{err: wrappedErr}
 		return false, wrappedErr
 	}
@@ -672,8 +670,7 @@ func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, se
 
 	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
-		wa.Log.Error(err, "Invalid label selector")
-		return false, err
+		return false, fmt.Errorf("parse namespace selector for namespace %q: %w", namespace, err)
 	}
 	return labelSelector.Matches(nsLabels), nil
 }

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -1109,29 +1109,56 @@ func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
 		},
 	}
 
-	base := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(ns, &wa1, &wa2, &wa3).
-		Build()
+	t.Run("single Get per namespace when namespace exists", func(t *testing.T) {
+		base := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ns, &wa1, &wa2, &wa3).
+			Build()
 
-	counter := &namespaceGetCountingClient{Client: base}
-	handler := &Authorizer{Client: counter, Log: logr.Discard()}
+		counter := &namespaceGetCountingClient{Client: base}
+		handler := &Authorizer{Client: counter, Log: logr.Discard()}
 
-	sar := &authzv1.SubjectAccessReview{
-		Spec: authzv1.SubjectAccessReviewSpec{
-			User: "unknown",
-			ResourceAttributes: &authzv1.ResourceAttributes{
-				Namespace: "target-ns",
-				Verb:      "get",
-				Resource:  "pods",
+		sar := &authzv1.SubjectAccessReview{
+			Spec: authzv1.SubjectAccessReviewSpec{
+				User: "unknown",
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Namespace: "target-ns",
+					Verb:      "get",
+					Resource:  "pods",
+				},
 			},
-		},
-	}
+		}
 
-	handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3})
+		handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3})
 
-	got := counter.getCount.Load()
-	if got != 1 {
-		t.Errorf("expected exactly 1 namespace Get() call for 3 scoped authorizers targeting the same namespace, got %d", got)
-	}
+		if got := counter.getCount.Load(); got != 1 {
+			t.Errorf("expected exactly 1 namespace Get() for 3 authorizers targeting the same namespace, got %d", got)
+		}
+	})
+
+	t.Run("single Get per namespace when namespace is missing", func(t *testing.T) {
+		base := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		counter := &namespaceGetCountingClient{Client: base}
+		handler := &Authorizer{Client: counter, Log: logr.Discard()}
+
+		sar := &authzv1.SubjectAccessReview{
+			Spec: authzv1.SubjectAccessReviewSpec{
+				User: "unknown",
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Namespace: "missing-ns",
+					Verb:      "get",
+					Resource:  "pods",
+				},
+			},
+		}
+
+		handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3})
+
+		if got := counter.getCount.Load(); got != 1 {
+			t.Errorf("expected exactly 1 namespace Get() for missing namespace (negative cache), got %d", got)
+		}
+	})
 }

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -14,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"golang.org/x/time/rate"
 	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,6 +25,21 @@ import (
 	"github.com/telekom/auth-operator/pkg/indexer"
 	pkgmetrics "github.com/telekom/auth-operator/pkg/metrics"
 )
+
+// namespaceGetCountingClient wraps a client.Client and counts Get calls for
+// Namespace objects so tests can verify the per-request namespace label cache
+// eliminates redundant lookups.
+type namespaceGetCountingClient struct {
+	client.Client
+	getCount atomic.Int64
+}
+
+func (c *namespaceGetCountingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*corev1.Namespace); ok {
+		c.getCount.Add(1)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
 
 // capturingLogger returns a logr.Logger that appends every log line to buf.
 // verbosity controls which V-levels are visible (0 = Info only, 2 = all).
@@ -1032,5 +1049,89 @@ func TestServeHTTP_AcceptsNonResourceAttributes(t *testing.T) {
 	if resp.Status.Reason == reasonMissingAttrs ||
 		resp.Status.Reason == reasonEmptyIdentity {
 		t.Errorf("non-resource SAR should not be rejected by validation, but got reason: %s", resp.Status.Reason)
+	}
+}
+
+func newSchemeWithCore(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := authzv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add authzv1alpha1 to scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+	return s
+}
+
+func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
+	scheme := newSchemeWithCore(t)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "target-ns",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
+
+	selector := metav1.LabelSelector{
+		MatchLabels: map[string]string{"env": "prod"},
+	}
+
+	wa1 := authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-wa-1"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			NamespaceSelector: selector,
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "alice"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+		},
+	}
+	wa2 := authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-wa-2"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			NamespaceSelector: selector,
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "bob"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"list"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+		},
+	}
+	wa3 := authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-wa-3"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			NamespaceSelector: selector,
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "carol"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"delete"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+		},
+	}
+
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ns, &wa1, &wa2, &wa3).
+		Build()
+
+	counter := &namespaceGetCountingClient{Client: base}
+	handler := &Authorizer{Client: counter, Log: logr.Discard()}
+
+	sar := &authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: "unknown",
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Namespace: "target-ns",
+				Verb:      "get",
+				Resource:  "pods",
+			},
+		},
+	}
+
+	handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3})
+
+	got := counter.getCount.Load()
+	if got != 1 {
+		t.Errorf("expected exactly 1 namespace Get() call for 3 scoped authorizers targeting the same namespace, got %d", got)
 	}
 }

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -489,7 +489,7 @@ func TestEvaluateSAR_ResultFields(t *testing.T) {
 		}
 		res, err := handler.evaluateSAR(context.Background(), sar, waList.Items)
 		if err != nil {
-			t.Fatal("unexpected error:", err)
+			t.Fatalf("evaluateSAR returned unexpected error: %v", err)
 		}
 		if !res.allowed {
 			t.Fatal("expected allowed")
@@ -511,7 +511,7 @@ func TestEvaluateSAR_ResultFields(t *testing.T) {
 		}
 		res, err := handler.evaluateSAR(context.Background(), sar, waList.Items)
 		if err != nil {
-			t.Fatal("unexpected error:", err)
+			t.Fatalf("evaluateSAR returned unexpected error: %v", err)
 		}
 		if res.allowed {
 			t.Fatal("expected denied")
@@ -536,7 +536,7 @@ func TestEvaluateSAR_ResultFields(t *testing.T) {
 		}
 		res, err := handler.evaluateSAR(context.Background(), sar, waList.Items)
 		if err != nil {
-			t.Fatal("unexpected error:", err)
+			t.Fatalf("evaluateSAR returned unexpected error: %v", err)
 		}
 		if res.allowed {
 			t.Fatal("expected denied")
@@ -1516,7 +1516,9 @@ func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
 			},
 		}
 
-		handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3})
+		if _, err := handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3}); err != nil {
+			t.Fatalf("evaluateSAR returned unexpected error: %v", err)
+		}
 
 		if got := counter.getCount.Load(); got != 1 {
 			t.Errorf("expected exactly 1 namespace Get() for 3 authorizers targeting the same namespace, got %d", got)
@@ -1540,10 +1542,54 @@ func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
 			},
 		}
 
-		handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3})
+		if _, err := handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3}); err == nil {
+			t.Fatal("expected namespace lookup error, got nil")
+		}
 
 		if got := counter.getCount.Load(); got != 1 {
 			t.Errorf("expected exactly 1 namespace Get() for missing namespace (negative cache), got %d", got)
 		}
 	})
+}
+
+func TestServeHTTP_NamespaceLabelCacheError_Returns500(t *testing.T) {
+	scheme := newScheme(t)
+
+	wa := &authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-wa"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			NamespaceSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "alice"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+		},
+	}
+	cl := newIndexedClient(scheme, wa)
+	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+
+	sar := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: "alice",
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Namespace: "missing-ns",
+				Verb:      "get",
+				Resource:  "pods",
+			},
+		},
+	}
+	body, err := json.Marshal(sar)
+	if err != nil {
+		t.Fatalf("failed to marshal SAR: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/authorize", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d; body: %s", http.StatusInternalServerError, rec.Code, rec.Body.String())
+	}
 }

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -1533,7 +1533,7 @@ func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
 
 		cache := make(map[string]namespaceLabelCacheEntry)
 		selector := &wa1.Spec.NamespaceSelector
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			matches, err := handler.namespaceMatches(context.Background(), "missing-ns", selector, cache)
 			if err == nil {
 				t.Fatal("expected namespace lookup error, got nil")

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -58,6 +58,9 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	if err := authzv1alpha1.AddToScheme(s); err != nil {
 		t.Fatalf("failed to add authzv1alpha1 to scheme: %v", err)
 	}
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
 	return s
 }
 
@@ -1452,7 +1455,7 @@ func TestResourceRuleIndex_ResourceNamesMatching(t *testing.T) {
 }
 
 func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
-	scheme := newSchemeWithCore(t)
+	scheme := newScheme(t)
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1497,10 +1500,7 @@ func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
 	}
 
 	t.Run("single Get per namespace when namespace exists", func(t *testing.T) {
-		base := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(ns, &wa1, &wa2, &wa3).
-			Build()
+		base := newIndexedClient(scheme, ns, &wa1, &wa2, &wa3)
 
 		counter := &namespaceGetCountingClient{Client: base}
 		handler := &Authorizer{Client: counter, Log: logr.Discard()}
@@ -1524,9 +1524,7 @@ func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
 	})
 
 	t.Run("single Get per namespace when namespace is missing", func(t *testing.T) {
-		base := fake.NewClientBuilder().
-			WithScheme(scheme).
-			Build()
+		base := newIndexedClient(scheme)
 
 		counter := &namespaceGetCountingClient{Client: base}
 		handler := &Authorizer{Client: counter, Log: logr.Discard()}

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -1531,23 +1531,20 @@ func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
 		counter := &namespaceGetCountingClient{Client: base}
 		handler := &Authorizer{Client: counter, Log: logr.Discard()}
 
-		sar := &authzv1.SubjectAccessReview{
-			Spec: authzv1.SubjectAccessReviewSpec{
-				User: "unknown",
-				ResourceAttributes: &authzv1.ResourceAttributes{
-					Namespace: "missing-ns",
-					Verb:      "get",
-					Resource:  "pods",
-				},
-			},
-		}
-
-		if _, err := handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3}); err == nil {
-			t.Fatal("expected namespace lookup error, got nil")
+		cache := make(map[string]namespaceLabelCacheEntry)
+		selector := &wa1.Spec.NamespaceSelector
+		for i := 0; i < 2; i++ {
+			matches, err := handler.namespaceMatches(context.Background(), "missing-ns", selector, cache)
+			if err == nil {
+				t.Fatal("expected namespace lookup error, got nil")
+			}
+			if matches {
+				t.Fatal("namespaceMatches returned true for missing namespace")
+			}
 		}
 
 		if got := counter.getCount.Load(); got != 1 {
-			t.Errorf("expected exactly 1 namespace Get() for missing namespace (negative cache), got %d", got)
+			t.Errorf("expected exactly 1 namespace Get() for repeated missing namespace lookup, got %d", got)
 		}
 	})
 }

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -14,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"golang.org/x/time/rate"
 	authzv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -24,6 +26,21 @@ import (
 	"github.com/telekom/auth-operator/pkg/indexer"
 	pkgmetrics "github.com/telekom/auth-operator/pkg/metrics"
 )
+
+// namespaceGetCountingClient wraps a client.Client and counts Get calls for
+// Namespace objects so tests can verify the per-request namespace label cache
+// eliminates redundant lookups.
+type namespaceGetCountingClient struct {
+	client.Client
+	getCount atomic.Int64
+}
+
+func (c *namespaceGetCountingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*corev1.Namespace); ok {
+		c.getCount.Add(1)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
 
 // capturingLogger returns a logr.Logger that appends every log line to buf.
 // verbosity controls which V-levels are visible (0 = Info only, 2 = all).
@@ -1432,4 +1449,76 @@ func TestResourceRuleIndex_ResourceNamesMatching(t *testing.T) {
 			t.Errorf("expected rule index 0 for wildcard ResourceNames, got %d", idx)
 		}
 	})
+}
+
+func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
+	scheme := newSchemeWithCore(t)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "target-ns",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
+
+	selector := metav1.LabelSelector{
+		MatchLabels: map[string]string{"env": "prod"},
+	}
+
+	wa1 := authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-wa-1"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			NamespaceSelector: selector,
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "alice"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+		},
+	}
+	wa2 := authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-wa-2"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			NamespaceSelector: selector,
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "bob"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"list"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+		},
+	}
+	wa3 := authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-wa-3"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			NamespaceSelector: selector,
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "carol"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"delete"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+		},
+	}
+
+	base := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ns, &wa1, &wa2, &wa3).
+		Build()
+
+	counter := &namespaceGetCountingClient{Client: base}
+	handler := &Authorizer{Client: counter, Log: logr.Discard()}
+
+	sar := &authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: "unknown",
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Namespace: "target-ns",
+				Verb:      "get",
+				Resource:  "pods",
+			},
+		},
+	}
+
+	handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3})
+
+	got := counter.getCount.Load()
+	if got != 1 {
+		t.Errorf("expected exactly 1 namespace Get() call for 3 scoped authorizers targeting the same namespace, got %d", got)
+	}
 }

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -1496,29 +1496,56 @@ func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
 		},
 	}
 
-	base := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(ns, &wa1, &wa2, &wa3).
-		Build()
+	t.Run("single Get per namespace when namespace exists", func(t *testing.T) {
+		base := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ns, &wa1, &wa2, &wa3).
+			Build()
 
-	counter := &namespaceGetCountingClient{Client: base}
-	handler := &Authorizer{Client: counter, Log: logr.Discard()}
+		counter := &namespaceGetCountingClient{Client: base}
+		handler := &Authorizer{Client: counter, Log: logr.Discard()}
 
-	sar := &authzv1.SubjectAccessReview{
-		Spec: authzv1.SubjectAccessReviewSpec{
-			User: "unknown",
-			ResourceAttributes: &authzv1.ResourceAttributes{
-				Namespace: "target-ns",
-				Verb:      "get",
-				Resource:  "pods",
+		sar := &authzv1.SubjectAccessReview{
+			Spec: authzv1.SubjectAccessReviewSpec{
+				User: "unknown",
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Namespace: "target-ns",
+					Verb:      "get",
+					Resource:  "pods",
+				},
 			},
-		},
-	}
+		}
 
-	handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3})
+		handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3})
 
-	got := counter.getCount.Load()
-	if got != 1 {
-		t.Errorf("expected exactly 1 namespace Get() call for 3 scoped authorizers targeting the same namespace, got %d", got)
-	}
+		if got := counter.getCount.Load(); got != 1 {
+			t.Errorf("expected exactly 1 namespace Get() for 3 authorizers targeting the same namespace, got %d", got)
+		}
+	})
+
+	t.Run("single Get per namespace when namespace is missing", func(t *testing.T) {
+		base := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		counter := &namespaceGetCountingClient{Client: base}
+		handler := &Authorizer{Client: counter, Log: logr.Discard()}
+
+		sar := &authzv1.SubjectAccessReview{
+			Spec: authzv1.SubjectAccessReviewSpec{
+				User: "unknown",
+				ResourceAttributes: &authzv1.ResourceAttributes{
+					Namespace: "missing-ns",
+					Verb:      "get",
+					Resource:  "pods",
+				},
+			},
+		}
+
+		handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{wa1, wa2, wa3})
+
+		if got := counter.getCount.Load(); got != 1 {
+			t.Errorf("expected exactly 1 namespace Get() for missing namespace (negative cache), got %d", got)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- `wa.Client` is already informer-backed (no live API calls), but **multiple scoped authorizers targeting the same namespace** caused redundant deserialization and map traversal via `client.Get()` for each `namespaceMatches()` call within a single SAR evaluation.
- Adds a **per-request `map[string]*labels.Set`** initialized in `evaluateSAR` and passed down to `namespaceMatches()`. First lookup for a namespace calls `client.Get()`; subsequent lookups for the same namespace within the same SAR hit the local map. A `nil` map value records a failed lookup so missing namespaces are also cached for the rest of that SAR. The cache is scoped per-request and never shared across SARs to avoid stale label reads.
- Adds `TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace`: sets up 3 scoped authorizers all targeting the same namespace, calls `evaluateSAR`, and asserts `Get()` was called exactly once for that namespace.

## Implementation

The change passes `nsLabelCache map[string]*labels.Set` as a parameter rather than embedding it in a struct to keep the scope minimal and make the per-request lifetime explicit. `evaluateSAR` allocates the map and passes it; `namespaceMatches` checks the map before calling `wa.Client.Get`.

## Testing

```
make test   # all pass, coverage 81.6%
make lint   # 0 issues
```
