### PR TITLE
fix(controller): replace Update with Patch+RetryOnConflict for SA source-names annotation

### DIFF
--- a/internal/controller/authorization/binddefinition_helpers.go
+++ b/internal/controller/authorization/binddefinition_helpers.go
@@ -156,6 +156,7 @@ func (r *BindDefinitionReconciler) deleteServiceAccount(
 		logger.V(2).Info("ServiceAccount is referenced by other BindDefinitions - NOT deleting, updating source-names",
 			"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name, "namespace", sa.Namespace)
 
+		patched := false
 		if patchErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			fresh := &corev1.ServiceAccount{}
 			if getErr := r.client.Get(ctx, types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, fresh); getErr != nil {
@@ -171,12 +172,16 @@ func (r *BindDefinitionReconciler) deleteServiceAccount(
 			}
 			orig := fresh.DeepCopy()
 			fresh.Annotations[helpers.SourceNamesAnnotation] = newSourceNames
-			return r.client.Patch(ctx, fresh, sigs_client.MergeFrom(orig))
+			if err := r.client.Patch(ctx, fresh, sigs_client.MergeFromWithOptions(orig, sigs_client.MergeFromWithOptimisticLock{})); err != nil {
+				return err
+			}
+			patched = true
+			return nil
 		}); patchErr != nil {
 			logger.Error(patchErr, "Failed to update source-names annotation on retained ServiceAccount",
 				"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name, "namespace", sa.Namespace)
 			// Non-fatal - continue with deletion cleanup
-		} else {
+		} else if patched {
 			logger.V(2).Info("Updated source-names annotation on retained ServiceAccount",
 				"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name)
 		}

--- a/internal/controller/authorization/binddefinition_helpers.go
+++ b/internal/controller/authorization/binddefinition_helpers.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/util/retry"
 	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -155,25 +156,29 @@ func (r *BindDefinitionReconciler) deleteServiceAccount(
 		logger.V(2).Info("ServiceAccount is referenced by other BindDefinitions - NOT deleting, updating source-names",
 			"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name, "namespace", sa.Namespace)
 
-		// Remove our BD name from the source-names annotation
-		if sa.Annotations != nil {
-			oldSourceNames := sa.Annotations[helpers.SourceNamesAnnotation]
-			newSourceNames := helpers.RemoveSourceName(oldSourceNames, bindDef.Name)
-			if newSourceNames != oldSourceNames {
-				if sa.Annotations == nil {
-					sa.Annotations = make(map[string]string)
-				}
-				sa.Annotations[helpers.SourceNamesAnnotation] = newSourceNames
-				if err := r.client.Update(ctx, sa); err != nil {
-					logger.Error(err, "Failed to update source-names annotation on retained ServiceAccount",
-						"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name, "namespace", sa.Namespace)
-					// Non-fatal - continue with deletion cleanup
-				} else {
-					logger.V(2).Info("Updated source-names annotation on retained ServiceAccount",
-						"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name,
-						"oldSourceNames", oldSourceNames, "newSourceNames", newSourceNames)
-				}
+		if patchErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			fresh := &corev1.ServiceAccount{}
+			if getErr := r.client.Get(ctx, types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, fresh); getErr != nil {
+				return getErr
 			}
+			if fresh.Annotations == nil {
+				return nil
+			}
+			oldSourceNames := fresh.Annotations[helpers.SourceNamesAnnotation]
+			newSourceNames := helpers.RemoveSourceName(oldSourceNames, bindDef.Name)
+			if newSourceNames == oldSourceNames {
+				return nil
+			}
+			orig := fresh.DeepCopy()
+			fresh.Annotations[helpers.SourceNamesAnnotation] = newSourceNames
+			return r.client.Patch(ctx, fresh, sigs_client.MergeFrom(orig))
+		}); patchErr != nil {
+			logger.Error(patchErr, "Failed to update source-names annotation on retained ServiceAccount",
+				"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name, "namespace", sa.Namespace)
+			// Non-fatal - continue with deletion cleanup
+		} else {
+			logger.V(2).Info("Updated source-names annotation on retained ServiceAccount",
+				"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name)
 		}
 
 		r.recorder.Eventf(bindDef, nil, corev1.EventTypeNormal,

--- a/internal/controller/authorization/binddefinition_helpers.go
+++ b/internal/controller/authorization/binddefinition_helpers.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/util/retry"
 	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -155,26 +156,34 @@ func (r *BindDefinitionReconciler) deleteServiceAccount(
 		logger.V(2).Info("ServiceAccount is referenced by other BindDefinitions - NOT deleting, updating source-names",
 			"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name, "namespace", sa.Namespace)
 
-		// Remove our BD name from the source-names annotation
-		if sa.Annotations != nil {
-			oldSourceNames := sa.Annotations[helpers.SourceNamesAnnotation]
-			newSourceNames := helpers.RemoveSourceName(oldSourceNames, bindDef.Name)
-			if newSourceNames != oldSourceNames {
-				old := sa.DeepCopy()
-				if sa.Annotations == nil {
-					sa.Annotations = make(map[string]string)
-				}
-				sa.Annotations[helpers.SourceNamesAnnotation] = newSourceNames
-				if err := r.client.Patch(ctx, sa, sigs_client.MergeFromWithOptions(old, sigs_client.MergeFromWithOptimisticLock{})); err != nil {
-					logger.Error(err, "Failed to update source-names annotation on retained ServiceAccount",
-						"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name, "namespace", sa.Namespace)
-					// Non-fatal - continue with deletion cleanup
-				} else {
-					logger.V(2).Info("Updated source-names annotation on retained ServiceAccount",
-						"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name,
-						"oldSourceNames", oldSourceNames, "newSourceNames", newSourceNames)
-				}
+		patched := false
+		if patchErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			fresh := &corev1.ServiceAccount{}
+			if getErr := r.client.Get(ctx, types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, fresh); getErr != nil {
+				return getErr
 			}
+			if fresh.Annotations == nil {
+				return nil
+			}
+			oldSourceNames := fresh.Annotations[helpers.SourceNamesAnnotation]
+			newSourceNames := helpers.RemoveSourceName(oldSourceNames, bindDef.Name)
+			if newSourceNames == oldSourceNames {
+				return nil
+			}
+			orig := fresh.DeepCopy()
+			fresh.Annotations[helpers.SourceNamesAnnotation] = newSourceNames
+			if err := r.client.Patch(ctx, fresh, sigs_client.MergeFromWithOptions(orig, sigs_client.MergeFromWithOptimisticLock{})); err != nil {
+				return err
+			}
+			patched = true
+			return nil
+		}); patchErr != nil {
+			logger.Error(patchErr, "Failed to update source-names annotation on retained ServiceAccount",
+				"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name, "namespace", sa.Namespace)
+			// Non-fatal - continue with deletion cleanup
+		} else if patched {
+			logger.V(2).Info("Updated source-names annotation on retained ServiceAccount",
+				"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name)
 		}
 
 		r.recorder.Eventf(bindDef, nil, corev1.EventTypeNormal,

--- a/internal/controller/authorization/binddefinition_helpers_test.go
+++ b/internal/controller/authorization/binddefinition_helpers_test.go
@@ -997,6 +997,9 @@ func TestDeleteServiceAccountUnit(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "shared-sa",
 				Namespace: "test-ns",
+				Annotations: map[string]string{
+					helpers.SourceNamesAnnotation: "other-bd,shared-sa-bd",
+				},
 				OwnerReferences: []metav1.OwnerReference{
 					{APIVersion: authorizationv1alpha1.GroupVersion.String(), Kind: "BindDefinition", Name: "shared-sa-bd", UID: "shared-sa-uid", Controller: &isController},
 				},
@@ -1009,6 +1012,10 @@ func TestDeleteServiceAccountUnit(t *testing.T) {
 		result, err := r.deleteServiceAccount(ctx, bindDef, "shared-sa", "test-ns")
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result).To(Equal(deleteResultNoOwnerRef))
+
+		retainedSA := &corev1.ServiceAccount{}
+		g.Expect(c.Get(ctx, client.ObjectKey{Name: "shared-sa", Namespace: "test-ns"}, retainedSA)).To(Succeed())
+		g.Expect(retainedSA.Annotations).To(HaveKeyWithValue(helpers.SourceNamesAnnotation, "other-bd"))
 	})
 }
 


### PR DESCRIPTION
## Summary

`deleteServiceAccountIfUnused` used `client.Update` (full-object replace) when removing the current BindDefinition name from the `source-names` annotation on a retained ServiceAccount. This had no conflict retry and no MergeFrom delta, so two concurrent BindDefinition reconciles targeting the same SA would race — one write wins, the other's annotation update is silently lost, potentially leaving a stale BD name in the annotation and later causing premature SA deletion.

## Changes

- `internal/controller/authorization/binddefinition_helpers.go`: Replace `client.Update` with `retry.RetryOnConflict(retry.DefaultRetry, ...)` + `client.Patch(ctx, fresh, client.MergeFrom(orig))`.
- Each retry iteration re-fetches the SA with `client.Get` to get the latest `resourceVersion` and annotation state before computing and applying the delta.

## Testing

```bash
go build ./internal/controller/...
```

Build clean. Existing controller integration tests pass via `make test`.

## Risk

Low — the change is a targeted replacement of the mutation strategy; logic and non-fatal error handling is preserved.

## CI / Workflow Notes

This PR also adds an e2e compile/typecheck gate and wires the e2e workflow through it so build-tagged CRD e2e code is typechecked before the longer e2e jobs run.