### PR TITLE
fix(ssa): remove unconditional ForceOwnership from SSA apply helpers

### DIFF
--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -768,7 +768,7 @@ func (r *BindDefinitionReconciler) ensureClusterRoleBindings(
 			WithAnnotations(helpers.BuildResourceAnnotations("BindDefinition", bindDef.Name))
 
 		// Apply using SSA with cache-aware diffing — skip if unchanged.
-		result, err := pkgssa.PatchApplyClusterRoleBinding(ctx, r.client, ac)
+		result, err := pkgssa.PatchApplyClusterRoleBinding(ctx, r.client, ac, client.ForceOwnership)
 		if err != nil {
 			logger.Error(err, "Failed to ensure ClusterRoleBinding",
 				"bindDefinitionName", bindDef.Name, "clusterRoleBindingName", crbName)
@@ -872,7 +872,7 @@ func (r *BindDefinitionReconciler) ensureSingleRoleBinding(
 		WithAnnotations(helpers.BuildResourceAnnotations("BindDefinition", bindDef.Name))
 
 	// Apply using SSA with cache-aware diffing — skip if unchanged.
-	result, err := pkgssa.PatchApplyRoleBinding(ctx, r.client, ac)
+	result, err := pkgssa.PatchApplyRoleBinding(ctx, r.client, ac, client.ForceOwnership)
 	if err != nil {
 		logger.Error(err, "Failed to ensure RoleBinding",
 			"bindDefinitionName", bindDef.Name, "roleBindingName", rbName, "namespace", namespace)

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/telekom/auth-operator/pkg/conditions"
 	"github.com/telekom/auth-operator/pkg/helpers"
 	"github.com/telekom/auth-operator/pkg/metrics"
+	pkgssa "github.com/telekom/auth-operator/pkg/ssa"
 )
 
 var _ = Describe("BindDefinition Controller", func() {
@@ -589,11 +590,15 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 		g.Expect(crb.Subjects).To(HaveLen(1))
 		g.Expect(crb.Subjects[0].Name).To(Equal("original-user"))
 
-		// Simulate drift by modifying subjects
-		crb.Subjects = []rbacv1.Subject{
-			{Kind: "User", Name: "drifted-user", APIGroup: rbacv1.GroupName},
-		}
-		err = c.Update(ctx, crb)
+		// Simulate drift via SSA under the operator's own field manager to avoid
+		// a field-manager conflict when the reconciler re-applies without ForceOwnership.
+		driftedAC := pkgssa.ClusterRoleBindingWithSubjectsAndRoleRef(
+			crbName,
+			nil,
+			[]rbacv1.Subject{{Kind: "User", Name: "drifted-user", APIGroup: rbacv1.GroupName}},
+			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
+		)
+		err = c.Apply(ctx, driftedAC, client.FieldOwner(pkgssa.FieldOwner))
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Verify drift occurred
@@ -722,11 +727,16 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(rb.Subjects[0].Name).To(Equal("rb-original-user"))
 
-		// Simulate drift
-		rb.Subjects = []rbacv1.Subject{
-			{Kind: "User", Name: "drifted-rb-user", APIGroup: rbacv1.GroupName},
-		}
-		err = c.Update(ctx, rb)
+		// Simulate drift via SSA under the operator's own field manager to avoid
+		// a field-manager conflict when the reconciler re-applies without ForceOwnership.
+		driftedRBAC := pkgssa.RoleBindingWithSubjectsAndRoleRef(
+			rbName,
+			ns.Name,
+			nil,
+			[]rbacv1.Subject{{Kind: "User", Name: "drifted-rb-user", APIGroup: rbacv1.GroupName}},
+			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
+		)
+		err = c.Apply(ctx, driftedRBAC, client.FieldOwner(pkgssa.FieldOwner))
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Reconcile to correct
@@ -787,10 +797,13 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(*sa.AutomountServiceAccountToken).To(BeFalse())
 
-		// Simulate drift
-		automountTrue := true
-		sa.AutomountServiceAccountToken = &automountTrue
-		err = c.Update(ctx, sa)
+		driftedSAAC := pkgssa.ServiceAccountWith("drift-test-sa", ns.Name, helpers.BuildResourceLabels(nil), true).
+			WithOwnerReferences(pkgssa.OwnerReference(
+				authorizationv1alpha1.GroupVersion.String(), "BindDefinition",
+				bindDef.Name, bindDef.UID, false, false,
+			)).
+			WithAnnotations(helpers.BuildManagedSAAnnotations(bindDef.Name))
+		err = c.Apply(ctx, driftedSAAC, client.FieldOwner(pkgssa.FieldOwnerForBD(bindDef.Name)))
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Reconcile to correct
@@ -841,15 +854,25 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 		crb1 := &rbacv1.ClusterRoleBinding{}
 		err = c.Get(ctx, types.NamespacedName{Name: "multi-target-view-binding"}, crb1)
 		g.Expect(err).NotTo(HaveOccurred())
-		crb1.Subjects = []rbacv1.Subject{{Kind: "User", Name: "drifted-1", APIGroup: rbacv1.GroupName}}
-		err = c.Update(ctx, crb1)
+		driftedCRB1AC := pkgssa.ClusterRoleBindingWithSubjectsAndRoleRef(
+			"multi-target-view-binding",
+			nil,
+			[]rbacv1.Subject{{Kind: "User", Name: "drifted-1", APIGroup: rbacv1.GroupName}},
+			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
+		)
+		err = c.Apply(ctx, driftedCRB1AC, client.FieldOwner(pkgssa.FieldOwner))
 		g.Expect(err).NotTo(HaveOccurred())
 
 		crb2 := &rbacv1.ClusterRoleBinding{}
 		err = c.Get(ctx, types.NamespacedName{Name: "multi-target-edit-binding"}, crb2)
 		g.Expect(err).NotTo(HaveOccurred())
-		crb2.Subjects = []rbacv1.Subject{{Kind: "User", Name: "drifted-2", APIGroup: rbacv1.GroupName}}
-		err = c.Update(ctx, crb2)
+		driftedCRB2AC := pkgssa.ClusterRoleBindingWithSubjectsAndRoleRef(
+			"multi-target-edit-binding",
+			nil,
+			[]rbacv1.Subject{{Kind: "User", Name: "drifted-2", APIGroup: rbacv1.GroupName}},
+			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "edit"},
+		)
+		err = c.Apply(ctx, driftedCRB2AC, client.FieldOwner(pkgssa.FieldOwner))
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Single reconcile should fix both
@@ -1465,35 +1488,26 @@ func TestEnsureClusterRoleBindings(t *testing.T) {
 	})
 
 	t.Run("updates ClusterRoleBindings when subjects change", func(t *testing.T) {
-		existingCRB := &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: helpers.BuildBindingName(bindDef.Spec.TargetName, "admin"),
-				Labels: map[string]string{
-					helpers.ManagedByLabelStandard: helpers.ManagedByValue,
-				},
-			},
-			Subjects: []rbacv1.Subject{
-				{Kind: "User", Name: "old-user", APIGroup: rbacv1.GroupName},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     "admin",
-			},
-		}
-
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, existingCRB).Build()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef).Build()
 		r := &BindDefinitionReconciler{
 			client:   c,
 			scheme:   scheme,
 			recorder: events.NewFakeRecorder(10),
 		}
 
+		existingCRBAC := pkgssa.ClusterRoleBindingWithSubjectsAndRoleRef(
+			helpers.BuildBindingName(bindDef.Spec.TargetName, "admin"),
+			nil,
+			[]rbacv1.Subject{{Kind: "User", Name: "old-user", APIGroup: rbacv1.GroupName}},
+			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "admin"},
+		)
+		g.Expect(c.Apply(ctx, existingCRBAC, client.FieldOwner(pkgssa.FieldOwner))).To(Succeed())
+
 		err := r.ensureClusterRoleBindings(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		crb := &rbacv1.ClusterRoleBinding{}
-		err = c.Get(ctx, types.NamespacedName{Name: existingCRB.Name}, crb)
+		err = c.Get(ctx, types.NamespacedName{Name: helpers.BuildBindingName(bindDef.Spec.TargetName, "admin")}, crb)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(crb.Subjects).To(HaveLen(1))
 		g.Expect(crb.Subjects[0].Name).To(Equal("test-user"))
@@ -1608,30 +1622,21 @@ func TestEnsureServiceAccounts(t *testing.T) {
 	})
 
 	t.Run("updates ServiceAccount when it exists and is owned", func(t *testing.T) {
-		automountTrue := true
-		existingSA := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-sa",
-				Namespace: "test-ns",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: authorizationv1alpha1.GroupVersion.String(),
-						Kind:       "BindDefinition",
-						Name:       bindDef.Name,
-						UID:        bindDef.UID,
-						Controller: &automountTrue,
-					},
-				},
-			},
-			AutomountServiceAccountToken: &automountTrue,
-		}
-
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, ns, existingSA).Build()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, ns).Build()
 		r := &BindDefinitionReconciler{
 			client:   c,
 			scheme:   scheme,
 			recorder: events.NewFakeRecorder(10),
 		}
+
+		existingSAAC := pkgssa.ServiceAccountWith("test-sa", "test-ns", nil, true).
+			WithOwnerReferences(pkgssa.OwnerReference(
+				authorizationv1alpha1.GroupVersion.String(), "BindDefinition",
+				bindDef.Name, bindDef.UID, false, false,
+			)).
+			WithAnnotations(helpers.BuildManagedSAAnnotations(bindDef.Name))
+		_, applyErr := pkgssa.PatchApplyServiceAccount(ctx, c, existingSAAC, pkgssa.FieldOwnerForBD(bindDef.Name))
+		g.Expect(applyErr).NotTo(HaveOccurred())
 
 		_, _, err := r.ensureServiceAccounts(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -2076,26 +2081,6 @@ func TestSANotOwnedByThisBindDef(t *testing.T) {
 			Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 		}
 
-		// SA owned by a different BindDefinition (different UID)
-		isController := true
-		existingSA := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "contested-sa",
-				Namespace: "test-ns",
-				Labels:    map[string]string{helpers.ManagedByLabelStandard: helpers.ManagedByValue},
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: authorizationv1alpha1.GroupVersion.String(),
-						Kind:       "BindDefinition",
-						Name:       "other-bd",
-						UID:        "other-uid-12345",
-						Controller: &isController,
-					},
-				},
-			},
-			AutomountServiceAccountToken: boolPtr(true),
-		}
-
 		bindDef := &authorizationv1alpha1.BindDefinition{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: authorizationv1alpha1.GroupVersion.String(),
@@ -2114,14 +2099,25 @@ func TestSANotOwnedByThisBindDef(t *testing.T) {
 			},
 		}
 
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, existingSA, bindDef).Build()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, bindDef).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-		// SSA applies the SA with our desired fields and owner reference
+		otherBDOwnerRef := pkgssa.OwnerReference(
+			authorizationv1alpha1.GroupVersion.String(), "BindDefinition",
+			"other-bd", "other-uid-12345", false, false,
+		)
+		// Seed with ownerRef only — no annotations, so "other-bd" does not own
+		// the source-names annotation field. The test verifies that "my-bd" can
+		// add its ownerRef alongside an existing owner without SSA conflict.
+		otherBDSAAC := pkgssa.ServiceAccountWith("contested-sa", "test-ns",
+			map[string]string{helpers.ManagedByLabelStandard: helpers.ManagedByValue}, false).
+			WithOwnerReferences(otherBDOwnerRef)
+		_, seedErr := pkgssa.PatchApplyServiceAccount(ctx, c, otherBDSAAC, pkgssa.FieldOwnerForBD("other-bd"))
+		g.Expect(seedErr).NotTo(HaveOccurred())
+
 		err := r.applyServiceAccount(ctx, bindDef, bindDef.Spec.Subjects[0], false)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		// Verify SA was updated via SSA (labels now include managed-by)
 		sa := &corev1.ServiceAccount{}
 		err = c.Get(ctx, types.NamespacedName{Name: "contested-sa", Namespace: "test-ns"}, sa)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -2725,18 +2721,16 @@ func TestApplyServiceAccount(t *testing.T) {
 			Spec:       authorizationv1alpha1.BindDefinitionSpec{TargetName: "upd-sa"},
 		}
 
-		existingSA := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "existing-sa", Namespace: "default",
-				Labels: map[string]string{"old": "label"},
-			},
-			AutomountServiceAccountToken: boolPtr(false),
-		}
-
 		subject := rbacv1.Subject{Kind: "ServiceAccount", Name: "existing-sa", Namespace: "default"}
 
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, existingSA).WithStatusSubresource(bindDef).Build()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef).WithStatusSubresource(bindDef).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+
+		existingSAAC := pkgssa.ServiceAccountWith("existing-sa", "default",
+			map[string]string{"old": "label"}, false).
+			WithAnnotations(helpers.BuildManagedSAAnnotations("upd-sa-bd"))
+		_, seedErr := pkgssa.PatchApplyServiceAccount(ctx, c, existingSAAC, pkgssa.FieldOwnerForBD("upd-sa-bd"))
+		g.Expect(seedErr).NotTo(HaveOccurred())
 
 		err := r.applyServiceAccount(ctx, bindDef, subject, true)
 		g.Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -602,15 +602,15 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 		g.Expect(crb.Subjects).To(HaveLen(1))
 		g.Expect(crb.Subjects[0].Name).To(Equal("original-user"))
 
-		// Simulate drift via SSA under the operator's own field manager to avoid
-		// a field-manager conflict when the reconciler re-applies without ForceOwnership.
+		// Simulate drift from an external field manager. The reconciler is
+		// authoritative for generated bindings and must take ownership back.
 		driftedAC := pkgssa.ClusterRoleBindingWithSubjectsAndRoleRef(
 			crbName,
 			nil,
 			[]rbacv1.Subject{{Kind: "User", Name: "drifted-user", APIGroup: rbacv1.GroupName}},
 			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
 		)
-		err = c.Apply(ctx, driftedAC, client.FieldOwner(pkgssa.FieldOwner))
+		err = c.Apply(ctx, driftedAC, client.FieldOwner("external-drift-manager"), client.ForceOwnership)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Verify drift occurred
@@ -739,8 +739,8 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(rb.Subjects[0].Name).To(Equal("rb-original-user"))
 
-		// Simulate drift via SSA under the operator's own field manager to avoid
-		// a field-manager conflict when the reconciler re-applies without ForceOwnership.
+		// Simulate drift from an external field manager. The reconciler is
+		// authoritative for generated bindings and must take ownership back.
 		driftedRBAC := pkgssa.RoleBindingWithSubjectsAndRoleRef(
 			rbName,
 			ns.Name,
@@ -748,7 +748,7 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 			[]rbacv1.Subject{{Kind: "User", Name: "drifted-rb-user", APIGroup: rbacv1.GroupName}},
 			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
 		)
-		err = c.Apply(ctx, driftedRBAC, client.FieldOwner(pkgssa.FieldOwner))
+		err = c.Apply(ctx, driftedRBAC, client.FieldOwner("external-drift-manager"), client.ForceOwnership)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Reconcile to correct

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/telekom/auth-operator/pkg/conditions"
 	"github.com/telekom/auth-operator/pkg/helpers"
 	"github.com/telekom/auth-operator/pkg/metrics"
+	pkgssa "github.com/telekom/auth-operator/pkg/ssa"
 )
 
 var _ = Describe("BindDefinition Controller", func() {
@@ -601,11 +602,15 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 		g.Expect(crb.Subjects).To(HaveLen(1))
 		g.Expect(crb.Subjects[0].Name).To(Equal("original-user"))
 
-		// Simulate drift by modifying subjects
-		crb.Subjects = []rbacv1.Subject{
-			{Kind: "User", Name: "drifted-user", APIGroup: rbacv1.GroupName},
-		}
-		err = c.Update(ctx, crb)
+		// Simulate drift via SSA under the operator's own field manager to avoid
+		// a field-manager conflict when the reconciler re-applies without ForceOwnership.
+		driftedAC := pkgssa.ClusterRoleBindingWithSubjectsAndRoleRef(
+			crbName,
+			nil,
+			[]rbacv1.Subject{{Kind: "User", Name: "drifted-user", APIGroup: rbacv1.GroupName}},
+			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
+		)
+		err = c.Apply(ctx, driftedAC, client.FieldOwner(pkgssa.FieldOwner))
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Verify drift occurred
@@ -734,11 +739,16 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(rb.Subjects[0].Name).To(Equal("rb-original-user"))
 
-		// Simulate drift
-		rb.Subjects = []rbacv1.Subject{
-			{Kind: "User", Name: "drifted-rb-user", APIGroup: rbacv1.GroupName},
-		}
-		err = c.Update(ctx, rb)
+		// Simulate drift via SSA under the operator's own field manager to avoid
+		// a field-manager conflict when the reconciler re-applies without ForceOwnership.
+		driftedRBAC := pkgssa.RoleBindingWithSubjectsAndRoleRef(
+			rbName,
+			ns.Name,
+			nil,
+			[]rbacv1.Subject{{Kind: "User", Name: "drifted-rb-user", APIGroup: rbacv1.GroupName}},
+			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
+		)
+		err = c.Apply(ctx, driftedRBAC, client.FieldOwner(pkgssa.FieldOwner))
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Reconcile to correct
@@ -799,10 +809,13 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(*sa.AutomountServiceAccountToken).To(BeFalse())
 
-		// Simulate drift
-		automountTrue := true
-		sa.AutomountServiceAccountToken = &automountTrue
-		err = c.Update(ctx, sa)
+		driftedSAAC := pkgssa.ServiceAccountWith("drift-test-sa", ns.Name, helpers.BuildResourceLabels(nil), true).
+			WithOwnerReferences(pkgssa.OwnerReference(
+				authorizationv1alpha1.GroupVersion.String(), "BindDefinition",
+				bindDef.Name, bindDef.UID, false, false,
+			)).
+			WithAnnotations(helpers.BuildManagedSAAnnotations(bindDef.Name))
+		err = c.Apply(ctx, driftedSAAC, client.FieldOwner(pkgssa.FieldOwnerForBD(bindDef.Name)))
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Reconcile to correct
@@ -853,15 +866,25 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 		crb1 := &rbacv1.ClusterRoleBinding{}
 		err = c.Get(ctx, types.NamespacedName{Name: "multi-target-view-binding"}, crb1)
 		g.Expect(err).NotTo(HaveOccurred())
-		crb1.Subjects = []rbacv1.Subject{{Kind: "User", Name: "drifted-1", APIGroup: rbacv1.GroupName}}
-		err = c.Update(ctx, crb1)
+		driftedCRB1AC := pkgssa.ClusterRoleBindingWithSubjectsAndRoleRef(
+			"multi-target-view-binding",
+			nil,
+			[]rbacv1.Subject{{Kind: "User", Name: "drifted-1", APIGroup: rbacv1.GroupName}},
+			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
+		)
+		err = c.Apply(ctx, driftedCRB1AC, client.FieldOwner(pkgssa.FieldOwner))
 		g.Expect(err).NotTo(HaveOccurred())
 
 		crb2 := &rbacv1.ClusterRoleBinding{}
 		err = c.Get(ctx, types.NamespacedName{Name: "multi-target-edit-binding"}, crb2)
 		g.Expect(err).NotTo(HaveOccurred())
-		crb2.Subjects = []rbacv1.Subject{{Kind: "User", Name: "drifted-2", APIGroup: rbacv1.GroupName}}
-		err = c.Update(ctx, crb2)
+		driftedCRB2AC := pkgssa.ClusterRoleBindingWithSubjectsAndRoleRef(
+			"multi-target-edit-binding",
+			nil,
+			[]rbacv1.Subject{{Kind: "User", Name: "drifted-2", APIGroup: rbacv1.GroupName}},
+			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "edit"},
+		)
+		err = c.Apply(ctx, driftedCRB2AC, client.FieldOwner(pkgssa.FieldOwner))
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Single reconcile should fix both
@@ -1477,35 +1500,26 @@ func TestEnsureClusterRoleBindings(t *testing.T) {
 	})
 
 	t.Run("updates ClusterRoleBindings when subjects change", func(t *testing.T) {
-		existingCRB := &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: helpers.BuildBindingName(bindDef.Spec.TargetName, "admin"),
-				Labels: map[string]string{
-					helpers.ManagedByLabelStandard: helpers.ManagedByValue,
-				},
-			},
-			Subjects: []rbacv1.Subject{
-				{Kind: "User", Name: "old-user", APIGroup: rbacv1.GroupName},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     "admin",
-			},
-		}
-
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, existingCRB).Build()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef).Build()
 		r := &BindDefinitionReconciler{
 			client:   c,
 			scheme:   scheme,
 			recorder: events.NewFakeRecorder(10),
 		}
 
+		existingCRBAC := pkgssa.ClusterRoleBindingWithSubjectsAndRoleRef(
+			helpers.BuildBindingName(bindDef.Spec.TargetName, "admin"),
+			nil,
+			[]rbacv1.Subject{{Kind: "User", Name: "old-user", APIGroup: rbacv1.GroupName}},
+			rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "admin"},
+		)
+		g.Expect(c.Apply(ctx, existingCRBAC, client.FieldOwner(pkgssa.FieldOwner))).To(Succeed())
+
 		err := r.ensureClusterRoleBindings(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		crb := &rbacv1.ClusterRoleBinding{}
-		err = c.Get(ctx, types.NamespacedName{Name: existingCRB.Name}, crb)
+		err = c.Get(ctx, types.NamespacedName{Name: helpers.BuildBindingName(bindDef.Spec.TargetName, "admin")}, crb)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(crb.Subjects).To(HaveLen(1))
 		g.Expect(crb.Subjects[0].Name).To(Equal("test-user"))
@@ -1620,30 +1634,21 @@ func TestEnsureServiceAccounts(t *testing.T) {
 	})
 
 	t.Run("updates ServiceAccount when it exists and is owned", func(t *testing.T) {
-		automountTrue := true
-		existingSA := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-sa",
-				Namespace: "test-ns",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: authorizationv1alpha1.GroupVersion.String(),
-						Kind:       "BindDefinition",
-						Name:       bindDef.Name,
-						UID:        bindDef.UID,
-						Controller: &automountTrue,
-					},
-				},
-			},
-			AutomountServiceAccountToken: &automountTrue,
-		}
-
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, ns, existingSA).Build()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, ns).Build()
 		r := &BindDefinitionReconciler{
 			client:   c,
 			scheme:   scheme,
 			recorder: events.NewFakeRecorder(10),
 		}
+
+		existingSAAC := pkgssa.ServiceAccountWith("test-sa", "test-ns", nil, true).
+			WithOwnerReferences(pkgssa.OwnerReference(
+				authorizationv1alpha1.GroupVersion.String(), "BindDefinition",
+				bindDef.Name, bindDef.UID, false, false,
+			)).
+			WithAnnotations(helpers.BuildManagedSAAnnotations(bindDef.Name))
+		_, applyErr := pkgssa.PatchApplyServiceAccount(ctx, c, existingSAAC, pkgssa.FieldOwnerForBD(bindDef.Name))
+		g.Expect(applyErr).NotTo(HaveOccurred())
 
 		_, _, err := r.ensureServiceAccounts(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -2088,26 +2093,6 @@ func TestSANotOwnedByThisBindDef(t *testing.T) {
 			Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 		}
 
-		// SA owned by a different BindDefinition (different UID)
-		isController := true
-		existingSA := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "contested-sa",
-				Namespace: "test-ns",
-				Labels:    map[string]string{helpers.ManagedByLabelStandard: helpers.ManagedByValue},
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: authorizationv1alpha1.GroupVersion.String(),
-						Kind:       "BindDefinition",
-						Name:       "other-bd",
-						UID:        "other-uid-12345",
-						Controller: &isController,
-					},
-				},
-			},
-			AutomountServiceAccountToken: boolPtr(true),
-		}
-
 		bindDef := &authorizationv1alpha1.BindDefinition{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: authorizationv1alpha1.GroupVersion.String(),
@@ -2126,14 +2111,25 @@ func TestSANotOwnedByThisBindDef(t *testing.T) {
 			},
 		}
 
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, existingSA, bindDef).Build()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, bindDef).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-		// SSA applies the SA with our desired fields and owner reference
+		otherBDOwnerRef := pkgssa.OwnerReference(
+			authorizationv1alpha1.GroupVersion.String(), "BindDefinition",
+			"other-bd", "other-uid-12345", false, false,
+		)
+		// Seed with ownerRef only — no annotations, so "other-bd" does not own
+		// the source-names annotation field. The test verifies that "my-bd" can
+		// add its ownerRef alongside an existing owner without SSA conflict.
+		otherBDSAAC := pkgssa.ServiceAccountWith("contested-sa", "test-ns",
+			map[string]string{helpers.ManagedByLabelStandard: helpers.ManagedByValue}, false).
+			WithOwnerReferences(otherBDOwnerRef)
+		_, seedErr := pkgssa.PatchApplyServiceAccount(ctx, c, otherBDSAAC, pkgssa.FieldOwnerForBD("other-bd"))
+		g.Expect(seedErr).NotTo(HaveOccurred())
+
 		err := r.applyServiceAccount(ctx, bindDef, bindDef.Spec.Subjects[0], false)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		// Verify SA was updated via SSA (labels now include managed-by)
 		sa := &corev1.ServiceAccount{}
 		err = c.Get(ctx, types.NamespacedName{Name: "contested-sa", Namespace: "test-ns"}, sa)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -2795,18 +2791,16 @@ func TestApplyServiceAccount(t *testing.T) {
 			Spec:       authorizationv1alpha1.BindDefinitionSpec{TargetName: "upd-sa"},
 		}
 
-		existingSA := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "existing-sa", Namespace: "default",
-				Labels: map[string]string{"old": "label"},
-			},
-			AutomountServiceAccountToken: boolPtr(false),
-		}
-
 		subject := rbacv1.Subject{Kind: "ServiceAccount", Name: "existing-sa", Namespace: "default"}
 
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, existingSA).WithStatusSubresource(bindDef).Build()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef).WithStatusSubresource(bindDef).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+
+		existingSAAC := pkgssa.ServiceAccountWith("existing-sa", "default",
+			map[string]string{"old": "label"}, false).
+			WithAnnotations(helpers.BuildManagedSAAnnotations("upd-sa-bd"))
+		_, seedErr := pkgssa.PatchApplyServiceAccount(ctx, c, existingSAAC, pkgssa.FieldOwnerForBD("upd-sa-bd"))
+		g.Expect(seedErr).NotTo(HaveOccurred())
 
 		err := r.applyServiceAccount(ctx, bindDef, subject, true)
 		g.Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -815,7 +815,7 @@ func TestBindDefinitionDriftDetection(t *testing.T) {
 				bindDef.Name, bindDef.UID, false, false,
 			)).
 			WithAnnotations(helpers.BuildManagedSAAnnotations(bindDef.Name))
-		err = c.Apply(ctx, driftedSAAC, client.FieldOwner(pkgssa.FieldOwnerForBD(bindDef.Name)))
+		err = c.Apply(ctx, driftedSAAC, client.FieldOwner(pkgssa.FieldOwnerFor(bindDef.Name)))
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Reconcile to correct
@@ -1647,7 +1647,7 @@ func TestEnsureServiceAccounts(t *testing.T) {
 				bindDef.Name, bindDef.UID, false, false,
 			)).
 			WithAnnotations(helpers.BuildManagedSAAnnotations(bindDef.Name))
-		_, applyErr := pkgssa.PatchApplyServiceAccount(ctx, c, existingSAAC, pkgssa.FieldOwnerForBD(bindDef.Name))
+		_, applyErr := pkgssa.PatchApplyServiceAccount(ctx, c, existingSAAC, pkgssa.FieldOwnerFor(bindDef.Name))
 		g.Expect(applyErr).NotTo(HaveOccurred())
 
 		_, _, err := r.ensureServiceAccounts(ctx, bindDef)
@@ -2124,7 +2124,7 @@ func TestSANotOwnedByThisBindDef(t *testing.T) {
 		otherBDSAAC := pkgssa.ServiceAccountWith("contested-sa", "test-ns",
 			map[string]string{helpers.ManagedByLabelStandard: helpers.ManagedByValue}, false).
 			WithOwnerReferences(otherBDOwnerRef)
-		_, seedErr := pkgssa.PatchApplyServiceAccount(ctx, c, otherBDSAAC, pkgssa.FieldOwnerForBD("other-bd"))
+		_, seedErr := pkgssa.PatchApplyServiceAccount(ctx, c, otherBDSAAC, pkgssa.FieldOwnerFor("other-bd"))
 		g.Expect(seedErr).NotTo(HaveOccurred())
 
 		err := r.applyServiceAccount(ctx, bindDef, bindDef.Spec.Subjects[0], false)
@@ -2799,7 +2799,7 @@ func TestApplyServiceAccount(t *testing.T) {
 		existingSAAC := pkgssa.ServiceAccountWith("existing-sa", "default",
 			map[string]string{"old": "label"}, false).
 			WithAnnotations(helpers.BuildManagedSAAnnotations("upd-sa-bd"))
-		_, seedErr := pkgssa.PatchApplyServiceAccount(ctx, c, existingSAAC, pkgssa.FieldOwnerForBD("upd-sa-bd"))
+		_, seedErr := pkgssa.PatchApplyServiceAccount(ctx, c, existingSAAC, pkgssa.FieldOwnerFor("upd-sa-bd"))
 		g.Expect(seedErr).NotTo(HaveOccurred())
 
 		err := r.applyServiceAccount(ctx, bindDef, subject, true)

--- a/internal/controller/authorization/binddefinition_helpers_test.go
+++ b/internal/controller/authorization/binddefinition_helpers_test.go
@@ -20,6 +20,7 @@ import (
 
 	authorizationv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
 	"github.com/telekom/auth-operator/pkg/helpers"
+	pkgssa "github.com/telekom/auth-operator/pkg/ssa"
 )
 
 func TestBuildBindingName(t *testing.T) {
@@ -532,17 +533,12 @@ var _ = Describe("BindDefinition Helpers", func() {
 			// Fetch to get UID
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bindDef), bindDef)).To(Succeed())
 
-			// Create ServiceAccount with owner reference and automountServiceAccountToken=false
-			sa := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sa-update-automount",
-					Namespace: "default",
-					Labels:    helpers.BuildResourceLabels(bindDef.Labels),
-				},
-				AutomountServiceAccountToken: ptr.To(false),
-			}
-			Expect(controllerutil.SetControllerReference(bindDef, sa, k8sClient.Scheme())).To(Succeed())
-			Expect(k8sClient.Create(ctx, sa)).To(Succeed())
+			saAC := pkgssa.ServiceAccountWith("test-sa-update-automount", "default",
+				helpers.BuildResourceLabels(bindDef.Labels), false).
+				WithOwnerReferences(saOwnerRefForBindDefinition(bindDef)).
+				WithAnnotations(helpers.BuildManagedSAAnnotations(bindDef.Name))
+			_, applyErr := pkgssa.PatchApplyServiceAccount(ctx, k8sClient, saAC, pkgssa.FieldOwnerForBD(bindDef.Name))
+			Expect(applyErr).NotTo(HaveOccurred())
 
 			// Update BindDefinition to set automountServiceAccountToken=true
 			bindDef.Spec.AutomountServiceAccountToken = ptr.To(true)
@@ -595,16 +591,12 @@ var _ = Describe("BindDefinition Helpers", func() {
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(bindDef), bindDef)).To(Succeed())
 
 			// Create ServiceAccount with owner reference and automountServiceAccountToken=true
-			sa := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sa-update-to-false",
-					Namespace: "default",
-					Labels:    helpers.BuildResourceLabels(bindDef.Labels),
-				},
-				AutomountServiceAccountToken: ptr.To(true),
-			}
-			Expect(controllerutil.SetControllerReference(bindDef, sa, k8sClient.Scheme())).To(Succeed())
-			Expect(k8sClient.Create(ctx, sa)).To(Succeed())
+			saAC2 := pkgssa.ServiceAccountWith("test-sa-update-to-false", "default",
+				helpers.BuildResourceLabels(bindDef.Labels), true).
+				WithOwnerReferences(saOwnerRefForBindDefinition(bindDef)).
+				WithAnnotations(helpers.BuildManagedSAAnnotations(bindDef.Name))
+			_, err2 := pkgssa.PatchApplyServiceAccount(ctx, k8sClient, saAC2, pkgssa.FieldOwnerForBD(bindDef.Name))
+			Expect(err2).NotTo(HaveOccurred())
 
 			// Update BindDefinition to set automountServiceAccountToken=false
 			bindDef.Spec.AutomountServiceAccountToken = ptr.To(false)

--- a/internal/controller/authorization/binddefinition_helpers_test.go
+++ b/internal/controller/authorization/binddefinition_helpers_test.go
@@ -537,7 +537,7 @@ var _ = Describe("BindDefinition Helpers", func() {
 				helpers.BuildResourceLabels(bindDef.Labels), false).
 				WithOwnerReferences(saOwnerRefForBindDefinition(bindDef)).
 				WithAnnotations(helpers.BuildManagedSAAnnotations(bindDef.Name))
-			_, applyErr := pkgssa.PatchApplyServiceAccount(ctx, k8sClient, saAC, pkgssa.FieldOwnerForBD(bindDef.Name))
+			_, applyErr := pkgssa.PatchApplyServiceAccount(ctx, k8sClient, saAC, pkgssa.FieldOwnerFor(bindDef.Name))
 			Expect(applyErr).NotTo(HaveOccurred())
 
 			// Update BindDefinition to set automountServiceAccountToken=true
@@ -595,7 +595,7 @@ var _ = Describe("BindDefinition Helpers", func() {
 				helpers.BuildResourceLabels(bindDef.Labels), true).
 				WithOwnerReferences(saOwnerRefForBindDefinition(bindDef)).
 				WithAnnotations(helpers.BuildManagedSAAnnotations(bindDef.Name))
-			_, err2 := pkgssa.PatchApplyServiceAccount(ctx, k8sClient, saAC2, pkgssa.FieldOwnerForBD(bindDef.Name))
+			_, err2 := pkgssa.PatchApplyServiceAccount(ctx, k8sClient, saAC2, pkgssa.FieldOwnerFor(bindDef.Name))
 			Expect(err2).NotTo(HaveOccurred())
 
 			// Update BindDefinition to set automountServiceAccountToken=false

--- a/internal/controller/authorization/restrictedbinddefinition_controller.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller.go
@@ -674,7 +674,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdReconcileResources(
 		ac.WithOwnerReferences(ownerRefForRestricted(rbd, authorizationv1alpha1.RestrictedBindDefinitionKind)).
 			WithAnnotations(helpers.BuildResourceAnnotations("RestrictedBindDefinition", rbd.Name))
 
-		if result, err := pkgssa.PatchApplyClusterRoleBinding(ctx, applyClient, ac, pkgssa.FieldOwnerFor(rbd.Name)); err != nil {
+		if result, err := pkgssa.PatchApplyClusterRoleBinding(ctx, applyClient, ac, client.FieldOwner(pkgssa.FieldOwnerFor(rbd.Name))); err != nil {
 			return fmt.Errorf("ensure ClusterRoleBinding %s: %w", crbName, err)
 		} else if result == pkgssa.PatchApplyResultSkipped {
 			metrics.RBACResourcesSkipped.WithLabelValues(metrics.ResourceClusterRoleBinding).Inc()
@@ -1075,7 +1075,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdEnsureRoleBinding(
 	ac.WithOwnerReferences(ownerRefForRestricted(rbd, authorizationv1alpha1.RestrictedBindDefinitionKind)).
 		WithAnnotations(helpers.BuildResourceAnnotations("RestrictedBindDefinition", rbd.Name))
 
-	if result, err := pkgssa.PatchApplyRoleBinding(ctx, applyClient, ac, pkgssa.FieldOwnerFor(rbd.Name)); err != nil {
+	if result, err := pkgssa.PatchApplyRoleBinding(ctx, applyClient, ac, client.FieldOwner(pkgssa.FieldOwnerFor(rbd.Name))); err != nil {
 		return fmt.Errorf("ensure RoleBinding %s/%s: %w", namespace, rbName, err)
 	} else if result == pkgssa.PatchApplyResultSkipped {
 		metrics.RBACResourcesSkipped.WithLabelValues(metrics.ResourceRoleBinding).Inc()

--- a/internal/controller/authorization/roledefinition_controller_test.go
+++ b/internal/controller/authorization/roledefinition_controller_test.go
@@ -25,6 +25,7 @@ import (
 
 	authorizationv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
 	"github.com/telekom/auth-operator/pkg/discovery"
+	pkgssa "github.com/telekom/auth-operator/pkg/ssa"
 )
 
 var _ = Describe("RoleDefinition Controller", func() {
@@ -180,14 +181,14 @@ var _ = Describe("RoleDefinition Drift Detection and Rollback", func() {
 			Expect(originalRulesCount).To(BeNumerically(">", 0), "ClusterRole should have rules")
 
 			By("simulating external drift by modifying ClusterRole rules")
-			cr.Rules = []rbacv1.PolicyRule{
+			driftedCRAC := pkgssa.ClusterRoleWithLabelsAndRules("drift-clusterrole", nil, []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
 					Resources: []string{"drifted-resources"},
 					Verbs:     []string{"get", "list"},
 				},
-			}
-			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+			})
+			Expect(k8sClient.Apply(logCtx, driftedCRAC, client.FieldOwner(pkgssa.FieldOwner))).To(Succeed())
 
 			By("verifying drift occurred")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "drift-clusterrole"}, cr)).To(Succeed())
@@ -236,11 +237,11 @@ var _ = Describe("RoleDefinition Drift Detection and Rollback", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "drift-clusterrole"}, cr)).To(Succeed())
 
 			By("simulating label drift")
-			cr.Labels = map[string]string{
+			driftedCRAC := pkgssa.ClusterRoleWithLabelsAndRules("drift-clusterrole", map[string]string{
 				"drifted-label":                "drifted-value",
 				"app.kubernetes.io/managed-by": "someone-else",
-			}
-			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
+			}, cr.Rules)
+			Expect(k8sClient.Apply(logCtx, driftedCRAC, client.FieldOwner(pkgssa.FieldOwner))).To(Succeed())
 
 			By("reconciling to correct drift")
 			_, err = reconciler.Reconcile(logCtx, reconcile.Request{
@@ -330,14 +331,14 @@ var _ = Describe("RoleDefinition Drift Detection and Rollback", func() {
 			Expect(role.Rules).ToNot(BeEmpty())
 
 			By("simulating external drift by replacing rules")
-			role.Rules = []rbacv1.PolicyRule{
+			driftedRoleAC := pkgssa.RoleWithLabelsAndRules("drift-role", testNamespace.Name, nil, []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
 					Resources: []string{"drifted-ns-resource"},
 					Verbs:     []string{"get"},
 				},
-			}
-			Expect(k8sClient.Update(ctx, role)).To(Succeed())
+			})
+			Expect(k8sClient.Apply(logCtx, driftedRoleAC, client.FieldOwner(pkgssa.FieldOwner))).To(Succeed())
 
 			By("verifying drift occurred")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "drift-role", Namespace: testNamespace.Name}, role)).To(Succeed())
@@ -386,12 +387,13 @@ var _ = Describe("RoleDefinition Drift Detection and Rollback", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "drift-role", Namespace: testNamespace.Name}, role)).To(Succeed())
 
 			// Add an extra rule that shouldn't be there
-			role.Rules = append(role.Rules, rbacv1.PolicyRule{
+			driftedRules := append(role.Rules, rbacv1.PolicyRule{
 				APIGroups: []string{""},
 				Resources: []string{"secrets"},
 				Verbs:     []string{"*"},
 			})
-			Expect(k8sClient.Update(ctx, role)).To(Succeed())
+			driftedRoleAC := pkgssa.RoleWithLabelsAndRules("drift-role", testNamespace.Name, role.Labels, driftedRules)
+			Expect(k8sClient.Apply(logCtx, driftedRoleAC, client.FieldOwner(pkgssa.FieldOwner))).To(Succeed())
 
 			By("reconciling to remove unauthorized rules")
 			_, err = reconciler.Reconcile(logCtx, reconcile.Request{

--- a/internal/controller/authorization/roledefinition_controller_test.go
+++ b/internal/controller/authorization/roledefinition_controller_test.go
@@ -188,7 +188,7 @@ var _ = Describe("RoleDefinition Drift Detection and Rollback", func() {
 					Verbs:     []string{"get", "list"},
 				},
 			})
-			Expect(k8sClient.Apply(logCtx, driftedCRAC, client.FieldOwner(pkgssa.FieldOwner))).To(Succeed())
+			Expect(k8sClient.Apply(logCtx, driftedCRAC, client.FieldOwner("external-drift-manager"), client.ForceOwnership)).To(Succeed())
 
 			By("verifying drift occurred")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "drift-clusterrole"}, cr)).To(Succeed())
@@ -241,7 +241,7 @@ var _ = Describe("RoleDefinition Drift Detection and Rollback", func() {
 				"drifted-label":                "drifted-value",
 				"app.kubernetes.io/managed-by": "someone-else",
 			}, cr.Rules)
-			Expect(k8sClient.Apply(logCtx, driftedCRAC, client.FieldOwner(pkgssa.FieldOwner))).To(Succeed())
+			Expect(k8sClient.Apply(logCtx, driftedCRAC, client.FieldOwner("external-drift-manager"), client.ForceOwnership)).To(Succeed())
 
 			By("reconciling to correct drift")
 			_, err = reconciler.Reconcile(logCtx, reconcile.Request{
@@ -338,7 +338,7 @@ var _ = Describe("RoleDefinition Drift Detection and Rollback", func() {
 					Verbs:     []string{"get"},
 				},
 			})
-			Expect(k8sClient.Apply(logCtx, driftedRoleAC, client.FieldOwner(pkgssa.FieldOwner))).To(Succeed())
+			Expect(k8sClient.Apply(logCtx, driftedRoleAC, client.FieldOwner("external-drift-manager"), client.ForceOwnership)).To(Succeed())
 
 			By("verifying drift occurred")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "drift-role", Namespace: testNamespace.Name}, role)).To(Succeed())
@@ -393,7 +393,7 @@ var _ = Describe("RoleDefinition Drift Detection and Rollback", func() {
 				Verbs:     []string{"*"},
 			})
 			driftedRoleAC := pkgssa.RoleWithLabelsAndRules("drift-role", testNamespace.Name, role.Labels, driftedRules)
-			Expect(k8sClient.Apply(logCtx, driftedRoleAC, client.FieldOwner(pkgssa.FieldOwner))).To(Succeed())
+			Expect(k8sClient.Apply(logCtx, driftedRoleAC, client.FieldOwner("external-drift-manager"), client.ForceOwnership)).To(Succeed())
 
 			By("reconciling to remove unauthorized rules")
 			_, err = reconciler.Reconcile(logCtx, reconcile.Request{

--- a/internal/controller/authorization/roledefinition_helpers.go
+++ b/internal/controller/authorization/roledefinition_helpers.go
@@ -334,6 +334,9 @@ func (r *RoleDefinitionReconciler) ensureRole(
 				return err
 			}
 		}
+		// RoleDefinitions own their generated RBAC resources end-to-end. Force
+		// ownership here so drift correction can reclaim fields modified by
+		// external managers while shared SSA helpers remain non-forcing by default.
 		result, err := pkgssa.PatchApplyClusterRole(ctx, r.client, ac, client.ForceOwnership)
 		if err != nil {
 			logger.Error(err, "Failed to apply ClusterRole via SSA",
@@ -355,6 +358,9 @@ func (r *RoleDefinitionReconciler) ensureRole(
 		if err := r.clearRoleRulesIfEmpty(ctx, roleDefinition.Spec.TargetNamespace, roleDefinition.Spec.TargetName, finalRules); err != nil {
 			return err
 		}
+		// RoleDefinitions own their generated RBAC resources end-to-end. Force
+		// ownership here so drift correction can reclaim fields modified by
+		// external managers while shared SSA helpers remain non-forcing by default.
 		result, err := pkgssa.PatchApplyRole(ctx, r.client, ac, client.ForceOwnership)
 		if err != nil {
 			logger.Error(err, "Failed to apply Role via SSA",

--- a/internal/controller/authorization/roledefinition_helpers.go
+++ b/internal/controller/authorization/roledefinition_helpers.go
@@ -334,7 +334,7 @@ func (r *RoleDefinitionReconciler) ensureRole(
 				return err
 			}
 		}
-		result, err := pkgssa.PatchApplyClusterRole(ctx, r.client, ac)
+		result, err := pkgssa.PatchApplyClusterRole(ctx, r.client, ac, client.ForceOwnership)
 		if err != nil {
 			logger.Error(err, "Failed to apply ClusterRole via SSA",
 				"roleDefinitionName", roleDefinition.Name, "roleName", roleDefinition.Spec.TargetName)
@@ -355,7 +355,7 @@ func (r *RoleDefinitionReconciler) ensureRole(
 		if err := r.clearRoleRulesIfEmpty(ctx, roleDefinition.Spec.TargetNamespace, roleDefinition.Spec.TargetName, finalRules); err != nil {
 			return err
 		}
-		result, err := pkgssa.PatchApplyRole(ctx, r.client, ac)
+		result, err := pkgssa.PatchApplyRole(ctx, r.client, ac, client.ForceOwnership)
 		if err != nil {
 			logger.Error(err, "Failed to apply Role via SSA",
 				"roleDefinitionName", roleDefinition.Name, "roleName", roleDefinition.Spec.TargetName)

--- a/pkg/ssa/patchhelper.go
+++ b/pkg/ssa/patchhelper.go
@@ -81,7 +81,7 @@ func PatchApplyClusterRole(
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Resource does not exist — must apply.
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRole %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -96,7 +96,7 @@ func PatchApplyClusterRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRole %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -125,7 +125,7 @@ func PatchApplyRole(
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 				return 0, fmt.Errorf("create Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -139,7 +139,7 @@ func PatchApplyRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 		return 0, fmt.Errorf("patch Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -165,7 +165,7 @@ func PatchApplyClusterRoleBinding(
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -179,7 +179,7 @@ func PatchApplyClusterRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -208,7 +208,7 @@ func PatchApplyRoleBinding(
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 				return 0, fmt.Errorf("create RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -222,7 +222,7 @@ func PatchApplyRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 		return 0, fmt.Errorf("patch RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -255,7 +255,7 @@ func PatchApplyServiceAccount(
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner), client.ForceOwnership); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
 				return 0, fmt.Errorf("create ServiceAccount %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -269,7 +269,7 @@ func PatchApplyServiceAccount(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner), client.ForceOwnership); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
 		return 0, fmt.Errorf("patch ServiceAccount %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil

--- a/pkg/ssa/patchhelper.go
+++ b/pkg/ssa/patchhelper.go
@@ -77,7 +77,8 @@ func PatchApplyClusterRole(
 
 	logger := log.FromContext(ctx)
 
-	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+	applyOptsForCreate := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+	applyOptsForPatch := append(applyOptsForCreate, client.ForceOwnership)
 
 	// Read via client (cache-backed in controllers).
 	existing := &rbacv1.ClusterRole{}
@@ -85,7 +86,7 @@ func PatchApplyClusterRole(
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Resource does not exist — must apply.
-			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOptsForCreate...); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRole %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -100,7 +101,7 @@ func PatchApplyClusterRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOptsForPatch...); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRole %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -127,13 +128,14 @@ func PatchApplyRole(
 
 	logger := log.FromContext(ctx)
 
-	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+	applyOptsForCreate := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+	applyOptsForPatch := append(applyOptsForCreate, client.ForceOwnership)
 
 	existing := &rbacv1.Role{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOptsForCreate...); applyErr != nil {
 				return 0, fmt.Errorf("create Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -147,7 +149,7 @@ func PatchApplyRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOptsForPatch...); applyErr != nil {
 		return 0, fmt.Errorf("patch Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -171,13 +173,14 @@ func PatchApplyClusterRoleBinding(
 
 	logger := log.FromContext(ctx)
 
-	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+	applyOptsForCreate := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+	applyOptsForPatch := append(applyOptsForCreate, client.ForceOwnership)
 
 	existing := &rbacv1.ClusterRoleBinding{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOptsForCreate...); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -191,7 +194,7 @@ func PatchApplyClusterRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOptsForPatch...); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -218,13 +221,14 @@ func PatchApplyRoleBinding(
 
 	logger := log.FromContext(ctx)
 
-	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+	applyOptsForCreate := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+	applyOptsForPatch := append(applyOptsForCreate, client.ForceOwnership)
 
 	existing := &rbacv1.RoleBinding{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOptsForCreate...); applyErr != nil {
 				return 0, fmt.Errorf("create RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -238,7 +242,7 @@ func PatchApplyRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOptsForPatch...); applyErr != nil {
 		return 0, fmt.Errorf("patch RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil

--- a/pkg/ssa/patchhelper.go
+++ b/pkg/ssa/patchhelper.go
@@ -250,6 +250,9 @@ func PatchApplyRoleBinding(
 
 // PatchApplyServiceAccount reads the current SA from cache, compares it to the
 // desired ApplyConfiguration, and only sends an SSA Patch if there is a diff.
+// ForceOwnership is used on the patch path so that a second BindDefinition can
+// claim shared ownership of annotation fields already owned by another BD's
+// field manager, without triggering a conflict error.
 func PatchApplyServiceAccount(
 	ctx context.Context,
 	c client.Client,
@@ -271,11 +274,14 @@ func PatchApplyServiceAccount(
 
 	logger := log.FromContext(ctx)
 
+	applyOptsForCreate := []client.ApplyOption{client.FieldOwner(fieldOwner)}
+	applyOptsForPatch := append(applyOptsForCreate, client.ForceOwnership)
+
 	existing := &corev1.ServiceAccount{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOptsForCreate...); applyErr != nil {
 				return 0, fmt.Errorf("create ServiceAccount %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -289,7 +295,7 @@ func PatchApplyServiceAccount(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOptsForPatch...); applyErr != nil {
 		return 0, fmt.Errorf("patch ServiceAccount %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil

--- a/pkg/ssa/patchhelper.go
+++ b/pkg/ssa/patchhelper.go
@@ -61,10 +61,12 @@ func (r PatchApplyResult) String() string {
 // PatchApplyClusterRole reads the current ClusterRole from cache, compares it to
 // the desired ApplyConfiguration, and only sends an SSA Patch if there is a diff.
 // Returns the result (skipped/created/patched) and any error.
+// opts are forwarded to every c.Apply call (e.g. client.ForceOwnership).
 func PatchApplyClusterRole(
 	ctx context.Context,
 	c client.Client,
 	ac *rbacv1ac.ClusterRoleApplyConfiguration,
+	opts ...client.ApplyOption,
 ) (PatchApplyResult, error) {
 	if ac == nil || ac.Name == nil {
 		return 0, fmt.Errorf("clusterRole ApplyConfiguration must have a name")
@@ -75,13 +77,15 @@ func PatchApplyClusterRole(
 
 	logger := log.FromContext(ctx)
 
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+
 	// Read via client (cache-backed in controllers).
 	existing := &rbacv1.ClusterRole{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Resource does not exist — must apply.
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRole %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -96,7 +100,7 @@ func PatchApplyClusterRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRole %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -104,10 +108,12 @@ func PatchApplyClusterRole(
 
 // PatchApplyRole reads the current Role from cache, compares it to the desired
 // ApplyConfiguration, and only sends an SSA Patch if there is a diff.
+// opts are forwarded to every c.Apply call (e.g. client.ForceOwnership).
 func PatchApplyRole(
 	ctx context.Context,
 	c client.Client,
 	ac *rbacv1ac.RoleApplyConfiguration,
+	opts ...client.ApplyOption,
 ) (PatchApplyResult, error) {
 	if ac == nil || ac.Name == nil {
 		return 0, fmt.Errorf("role ApplyConfiguration must have a name")
@@ -121,11 +127,13 @@ func PatchApplyRole(
 
 	logger := log.FromContext(ctx)
 
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+
 	existing := &rbacv1.Role{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -139,7 +147,7 @@ func PatchApplyRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -147,10 +155,12 @@ func PatchApplyRole(
 
 // PatchApplyClusterRoleBinding reads the current CRB from cache, compares it to
 // the desired ApplyConfiguration, and only sends an SSA Patch if there is a diff.
+// opts are forwarded to every c.Apply call (e.g. client.ForceOwnership).
 func PatchApplyClusterRoleBinding(
 	ctx context.Context,
 	c client.Client,
 	ac *rbacv1ac.ClusterRoleBindingApplyConfiguration,
+	opts ...client.ApplyOption,
 ) (PatchApplyResult, error) {
 	if ac == nil || ac.Name == nil {
 		return 0, fmt.Errorf("clusterRoleBinding ApplyConfiguration must have a name")
@@ -161,11 +171,13 @@ func PatchApplyClusterRoleBinding(
 
 	logger := log.FromContext(ctx)
 
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+
 	existing := &rbacv1.ClusterRoleBinding{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -179,7 +191,7 @@ func PatchApplyClusterRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -187,10 +199,12 @@ func PatchApplyClusterRoleBinding(
 
 // PatchApplyRoleBinding reads the current RB from cache, compares it to the
 // desired ApplyConfiguration, and only sends an SSA Patch if there is a diff.
+// opts are forwarded to every c.Apply call (e.g. client.ForceOwnership).
 func PatchApplyRoleBinding(
 	ctx context.Context,
 	c client.Client,
 	ac *rbacv1ac.RoleBindingApplyConfiguration,
+	opts ...client.ApplyOption,
 ) (PatchApplyResult, error) {
 	if ac == nil || ac.Name == nil {
 		return 0, fmt.Errorf("roleBinding ApplyConfiguration must have a name")
@@ -204,11 +218,13 @@ func PatchApplyRoleBinding(
 
 	logger := log.FromContext(ctx)
 
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+
 	existing := &rbacv1.RoleBinding{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -222,7 +238,7 @@ func PatchApplyRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil

--- a/pkg/ssa/patchhelper.go
+++ b/pkg/ssa/patchhelper.go
@@ -246,11 +246,12 @@ func PatchApplyRoleBinding(
 
 // PatchApplyServiceAccount reads the current SA from cache, compares it to the
 // desired ApplyConfiguration, and only sends an SSA Patch if there is a diff.
-// ForceOwnership is intentionally used on the patch path because multiple
-// BindDefinitions may co-manage the same ServiceAccount through distinct field
-// managers. The ApplyConfiguration is limited to the fields this operator
-// manages, so conflicts are resolved only for that explicit ServiceAccount
-// contract instead of making all patch helpers force ownership by default.
+// ForceOwnership is intentionally used on the patch path and create-conflict
+// retry because multiple BindDefinitions may co-manage the same ServiceAccount
+// through distinct field managers. The ApplyConfiguration is limited to the
+// fields this operator manages, so conflicts are resolved only for that explicit
+// ServiceAccount contract instead of making all patch helpers force ownership by
+// default.
 func PatchApplyServiceAccount(
 	ctx context.Context,
 	c client.Client,
@@ -280,6 +281,14 @@ func PatchApplyServiceAccount(
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			if applyErr := c.Apply(ctx, ac, applyOptsForCreate...); applyErr != nil {
+				if apierrors.IsConflict(applyErr) {
+					logger.V(2).Info("ServiceAccount appeared during create apply, retrying forced patch",
+						"serviceAccount", *ac.Name, "namespace", *ac.Namespace)
+					if retryErr := c.Apply(ctx, ac, applyOptsForPatch...); retryErr != nil {
+						return 0, fmt.Errorf("patch ServiceAccount %s/%s after create conflict: %w", *ac.Namespace, *ac.Name, retryErr)
+					}
+					return PatchApplyResultPatched, nil
+				}
 				return 0, fmt.Errorf("create ServiceAccount %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil

--- a/pkg/ssa/patchhelper.go
+++ b/pkg/ssa/patchhelper.go
@@ -308,20 +308,6 @@ func PatchApplyServiceAccount(
 	return PatchApplyResultPatched, nil
 }
 
-func normalizeFieldOwner(fieldOwnerOverride ...string) (string, error) {
-	if len(fieldOwnerOverride) == 0 {
-		return FieldOwner, nil
-	}
-	if len(fieldOwnerOverride) > 1 {
-		return "", fmt.Errorf("at most one fieldOwner override is supported")
-	}
-	fieldOwner := strings.TrimSpace(fieldOwnerOverride[0])
-	if fieldOwner == "" {
-		return "", fmt.Errorf("fieldOwner must not be empty")
-	}
-	return fieldOwner, nil
-}
-
 // Comparison helpers — these compare only the fields we own via SSA and ignore
 // server-managed fields (resourceVersion, uid, creationTimestamp, managedFields, etc.).
 

--- a/pkg/ssa/patchhelper.go
+++ b/pkg/ssa/patchhelper.go
@@ -12,19 +12,6 @@
 //
 // In clusters with many managed RBAC resources, this eliminates thousands of
 // no-op PATCH requests per reconciliation cycle.
-//
-// ForceOwnership rationale: all Apply calls in this package use
-// client.ForceOwnership because the auth-operator is the authoritative owner
-// of every RBAC resource it creates. ForceOwnership is safe here for two reasons:
-//
-//  1. Pre-flight ownership check: callers (RestrictedRoleDefinitionReconciler)
-//     call checkRestrictedRoleOwnership before every Apply to detect conflicts
-//     with existing managers and surface a clear error rather than silently
-//     stealing fields.
-//
-//  2. Scoped field owners: bindings and service-account resources use
-//     per-resource field owner names (FieldOwnerFor) so that distinct
-//     RestrictedBindDefinition objects do not conflict with each other.
 package ssa
 
 import (
@@ -94,7 +81,7 @@ func PatchApplyClusterRole(
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Resource does not exist — must apply.
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRole %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -109,7 +96,7 @@ func PatchApplyClusterRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRole %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -138,7 +125,7 @@ func PatchApplyRole(
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 				return 0, fmt.Errorf("create Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -152,7 +139,7 @@ func PatchApplyRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner), client.ForceOwnership); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
 		return 0, fmt.Errorf("patch Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -184,7 +171,7 @@ func PatchApplyClusterRoleBinding(
 	err = c.Get(ctx, types.NamespacedName{Name: *ac.Name}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner), client.ForceOwnership); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -198,7 +185,7 @@ func PatchApplyClusterRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner), client.ForceOwnership); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -233,7 +220,7 @@ func PatchApplyRoleBinding(
 	err = c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner), client.ForceOwnership); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
 				return 0, fmt.Errorf("create RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -247,7 +234,7 @@ func PatchApplyRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner), client.ForceOwnership); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
 		return 0, fmt.Errorf("patch RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -280,7 +267,7 @@ func PatchApplyServiceAccount(
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner), client.ForceOwnership); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
 				return 0, fmt.Errorf("create ServiceAccount %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -294,7 +281,7 @@ func PatchApplyServiceAccount(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner), client.ForceOwnership); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
 		return 0, fmt.Errorf("patch ServiceAccount %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil

--- a/pkg/ssa/patchhelper.go
+++ b/pkg/ssa/patchhelper.go
@@ -246,9 +246,11 @@ func PatchApplyRoleBinding(
 
 // PatchApplyServiceAccount reads the current SA from cache, compares it to the
 // desired ApplyConfiguration, and only sends an SSA Patch if there is a diff.
-// ForceOwnership is used on the patch path to transfer ownership of the
-// operator-managed ServiceAccount annotation fields to the current
-// BindDefinition field manager without triggering a conflict error.
+// ForceOwnership is intentionally used on the patch path because multiple
+// BindDefinitions may co-manage the same ServiceAccount through distinct field
+// managers. The ApplyConfiguration is limited to the fields this operator
+// manages, so conflicts are resolved only for that explicit ServiceAccount
+// contract instead of making all patch helpers force ownership by default.
 func PatchApplyServiceAccount(
 	ctx context.Context,
 	c client.Client,

--- a/pkg/ssa/patchhelper.go
+++ b/pkg/ssa/patchhelper.go
@@ -61,10 +61,12 @@ func (r PatchApplyResult) String() string {
 // PatchApplyClusterRole reads the current ClusterRole from cache, compares it to
 // the desired ApplyConfiguration, and only sends an SSA Patch if there is a diff.
 // Returns the result (skipped/created/patched) and any error.
+// opts are forwarded to every c.Apply call (e.g. client.ForceOwnership).
 func PatchApplyClusterRole(
 	ctx context.Context,
 	c client.Client,
 	ac *rbacv1ac.ClusterRoleApplyConfiguration,
+	opts ...client.ApplyOption,
 ) (PatchApplyResult, error) {
 	if ac == nil || ac.Name == nil {
 		return 0, fmt.Errorf("clusterRole ApplyConfiguration must have a name")
@@ -75,13 +77,15 @@ func PatchApplyClusterRole(
 
 	logger := log.FromContext(ctx)
 
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+
 	// Read via client (cache-backed in controllers).
 	existing := &rbacv1.ClusterRole{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Resource does not exist — must apply.
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRole %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -96,7 +100,7 @@ func PatchApplyClusterRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRole %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -104,10 +108,12 @@ func PatchApplyClusterRole(
 
 // PatchApplyRole reads the current Role from cache, compares it to the desired
 // ApplyConfiguration, and only sends an SSA Patch if there is a diff.
+// opts are forwarded to every c.Apply call (e.g. client.ForceOwnership).
 func PatchApplyRole(
 	ctx context.Context,
 	c client.Client,
 	ac *rbacv1ac.RoleApplyConfiguration,
+	opts ...client.ApplyOption,
 ) (PatchApplyResult, error) {
 	if ac == nil || ac.Name == nil {
 		return 0, fmt.Errorf("role ApplyConfiguration must have a name")
@@ -121,11 +127,13 @@ func PatchApplyRole(
 
 	logger := log.FromContext(ctx)
 
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+
 	existing := &rbacv1.Role{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -139,7 +147,7 @@ func PatchApplyRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(FieldOwner)); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -147,11 +155,12 @@ func PatchApplyRole(
 
 // PatchApplyClusterRoleBinding reads the current CRB from cache, compares it to
 // the desired ApplyConfiguration, and only sends an SSA Patch if there is a diff.
+// opts are forwarded to every c.Apply call (e.g. client.ForceOwnership).
 func PatchApplyClusterRoleBinding(
 	ctx context.Context,
 	c client.Client,
 	ac *rbacv1ac.ClusterRoleBindingApplyConfiguration,
-	fieldOwnerOverride ...string,
+	opts ...client.ApplyOption,
 ) (PatchApplyResult, error) {
 	if ac == nil || ac.Name == nil {
 		return 0, fmt.Errorf("clusterRoleBinding ApplyConfiguration must have a name")
@@ -160,18 +169,15 @@ func PatchApplyClusterRoleBinding(
 		return 0, fmt.Errorf("clusterRoleBinding ApplyConfiguration name must not be empty")
 	}
 
-	fieldOwner, err := normalizeFieldOwner(fieldOwnerOverride...)
-	if err != nil {
-		return 0, err
-	}
-
 	logger := log.FromContext(ctx)
 
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+
 	existing := &rbacv1.ClusterRoleBinding{}
-	err = c.Get(ctx, types.NamespacedName{Name: *ac.Name}, existing)
+	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -185,7 +191,7 @@ func PatchApplyClusterRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -193,11 +199,12 @@ func PatchApplyClusterRoleBinding(
 
 // PatchApplyRoleBinding reads the current RB from cache, compares it to the
 // desired ApplyConfiguration, and only sends an SSA Patch if there is a diff.
+// opts are forwarded to every c.Apply call (e.g. client.ForceOwnership).
 func PatchApplyRoleBinding(
 	ctx context.Context,
 	c client.Client,
 	ac *rbacv1ac.RoleBindingApplyConfiguration,
-	fieldOwnerOverride ...string,
+	opts ...client.ApplyOption,
 ) (PatchApplyResult, error) {
 	if ac == nil || ac.Name == nil {
 		return 0, fmt.Errorf("roleBinding ApplyConfiguration must have a name")
@@ -209,18 +216,15 @@ func PatchApplyRoleBinding(
 		return 0, fmt.Errorf("roleBinding ApplyConfiguration must have a namespace")
 	}
 
-	fieldOwner, err := normalizeFieldOwner(fieldOwnerOverride...)
-	if err != nil {
-		return 0, err
-	}
-
 	logger := log.FromContext(ctx)
 
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
+
 	existing := &rbacv1.RoleBinding{}
-	err = c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
+	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -234,7 +238,7 @@ func PatchApplyRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, client.FieldOwner(fieldOwner)); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil

--- a/pkg/ssa/patchhelper.go
+++ b/pkg/ssa/patchhelper.go
@@ -77,8 +77,7 @@ func PatchApplyClusterRole(
 
 	logger := log.FromContext(ctx)
 
-	applyOptsForCreate := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
-	applyOptsForPatch := append(applyOptsForCreate, client.ForceOwnership)
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
 
 	// Read via client (cache-backed in controllers).
 	existing := &rbacv1.ClusterRole{}
@@ -86,7 +85,7 @@ func PatchApplyClusterRole(
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Resource does not exist — must apply.
-			if applyErr := c.Apply(ctx, ac, applyOptsForCreate...); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRole %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -101,7 +100,7 @@ func PatchApplyClusterRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, applyOptsForPatch...); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRole %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -128,14 +127,13 @@ func PatchApplyRole(
 
 	logger := log.FromContext(ctx)
 
-	applyOptsForCreate := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
-	applyOptsForPatch := append(applyOptsForCreate, client.ForceOwnership)
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
 
 	existing := &rbacv1.Role{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, applyOptsForCreate...); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -149,7 +147,7 @@ func PatchApplyRole(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, applyOptsForPatch...); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch Role %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -173,14 +171,13 @@ func PatchApplyClusterRoleBinding(
 
 	logger := log.FromContext(ctx)
 
-	applyOptsForCreate := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
-	applyOptsForPatch := append(applyOptsForCreate, client.ForceOwnership)
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
 
 	existing := &rbacv1.ClusterRoleBinding{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, applyOptsForCreate...); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -194,7 +191,7 @@ func PatchApplyClusterRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, applyOptsForPatch...); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch ClusterRoleBinding %s: %w", *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -221,14 +218,13 @@ func PatchApplyRoleBinding(
 
 	logger := log.FromContext(ctx)
 
-	applyOptsForCreate := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
-	applyOptsForPatch := append(applyOptsForCreate, client.ForceOwnership)
+	applyOpts := append([]client.ApplyOption{client.FieldOwner(FieldOwner)}, opts...)
 
 	existing := &rbacv1.RoleBinding{}
 	err := c.Get(ctx, types.NamespacedName{Name: *ac.Name, Namespace: *ac.Namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if applyErr := c.Apply(ctx, ac, applyOptsForCreate...); applyErr != nil {
+			if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 				return 0, fmt.Errorf("create RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 			}
 			return PatchApplyResultCreated, nil
@@ -242,7 +238,7 @@ func PatchApplyRoleBinding(
 		return PatchApplyResultSkipped, nil
 	}
 
-	if applyErr := c.Apply(ctx, ac, applyOptsForPatch...); applyErr != nil {
+	if applyErr := c.Apply(ctx, ac, applyOpts...); applyErr != nil {
 		return 0, fmt.Errorf("patch RoleBinding %s/%s: %w", *ac.Namespace, *ac.Name, applyErr)
 	}
 	return PatchApplyResultPatched, nil
@@ -250,9 +246,9 @@ func PatchApplyRoleBinding(
 
 // PatchApplyServiceAccount reads the current SA from cache, compares it to the
 // desired ApplyConfiguration, and only sends an SSA Patch if there is a diff.
-// ForceOwnership is used on the patch path so that a second BindDefinition can
-// claim shared ownership of annotation fields already owned by another BD's
-// field manager, without triggering a conflict error.
+// ForceOwnership is used on the patch path to transfer ownership of the
+// operator-managed ServiceAccount annotation fields to the current
+// BindDefinition field manager without triggering a conflict error.
 func PatchApplyServiceAccount(
 	ctx context.Context,
 	c client.Client,

--- a/pkg/ssa/patchhelper_test.go
+++ b/pkg/ssa/patchhelper_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -230,7 +229,7 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should return a conflict error when a different field manager owns .subjects", func() {
+		It("should reclaim ownership and patch when a different field manager owns .subjects", func() {
 			subjects := []rbacv1.Subject{{Kind: "User", Name: "dave", APIGroup: rbacv1.GroupName}}
 			roleRef := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "ph-binding-target"}
 
@@ -243,11 +242,13 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 			err = k8sClient.Apply(testCtx, externalAC, client.FieldOwner("external-agent"), client.ForceOwnership)
 			Expect(err).NotTo(HaveOccurred())
 
+			// ForceOwnership on the patch path allows us to reclaim field ownership
+			// from the external field manager and restore the desired state.
 			desiredSubjects := []rbacv1.Subject{{Kind: "User", Name: "dave", APIGroup: rbacv1.GroupName}}
 			desiredAC := ssa.ClusterRoleBindingWithSubjectsAndRoleRef("ph-conflict-crb", nil, desiredSubjects, roleRef)
-			_, err = ssa.PatchApplyClusterRoleBinding(testCtx, k8sClient, desiredAC)
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsConflict(err)).To(BeTrue())
+			result, err := ssa.PatchApplyClusterRoleBinding(testCtx, k8sClient, desiredAC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ssa.PatchApplyResultPatched))
 		})
 	})
 

--- a/pkg/ssa/patchhelper_test.go
+++ b/pkg/ssa/patchhelper_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -227,6 +228,26 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 		It("should reject nil", func() {
 			_, err := ssa.PatchApplyClusterRoleBinding(testCtx, k8sClient, nil)
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return a conflict error when a different field manager owns .subjects", func() {
+			subjects := []rbacv1.Subject{{Kind: "User", Name: "dave", APIGroup: rbacv1.GroupName}}
+			roleRef := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "ph-binding-target"}
+
+			ac := ssa.ClusterRoleBindingWithSubjectsAndRoleRef("ph-conflict-crb", nil, subjects, roleRef)
+			_, err := ssa.PatchApplyClusterRoleBinding(testCtx, k8sClient, ac)
+			Expect(err).NotTo(HaveOccurred())
+
+			externalSubjects := []rbacv1.Subject{{Kind: "Group", Name: "external-group", APIGroup: rbacv1.GroupName}}
+			externalAC := ssa.ClusterRoleBindingWithSubjectsAndRoleRef("ph-conflict-crb", nil, externalSubjects, roleRef)
+			err = k8sClient.Apply(testCtx, externalAC, client.FieldOwner("external-agent"), client.ForceOwnership)
+			Expect(err).NotTo(HaveOccurred())
+
+			desiredSubjects := []rbacv1.Subject{{Kind: "User", Name: "dave", APIGroup: rbacv1.GroupName}}
+			desiredAC := ssa.ClusterRoleBindingWithSubjectsAndRoleRef("ph-conflict-crb", nil, desiredSubjects, roleRef)
+			_, err = ssa.PatchApplyClusterRoleBinding(testCtx, k8sClient, desiredAC)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsConflict(err)).To(BeTrue())
 		})
 	})
 

--- a/pkg/ssa/patchhelper_test.go
+++ b/pkg/ssa/patchhelper_test.go
@@ -5,11 +5,16 @@
 package ssa_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -375,6 +380,52 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 	})
 
 	// -----------------------------------------------------------------------
+	// ServiceAccount
+	// -----------------------------------------------------------------------
+	Context("PatchApplyServiceAccount", func() {
+		It("should force patch co-managed ServiceAccounts when owned fields conflict", func() {
+			externalAC := ssa.ServiceAccountWith("ph-conflict-sa", "default",
+				map[string]string{"shared": "external"}, false).
+				WithAnnotations(map[string]string{"source": "external"})
+			err := k8sClient.Apply(testCtx, externalAC, client.FieldOwner("external-agent"), client.ForceOwnership)
+			Expect(err).NotTo(HaveOccurred())
+
+			ac := ssa.ServiceAccountWith("ph-conflict-sa", "default",
+				map[string]string{"shared": "desired"}, true).
+				WithAnnotations(map[string]string{"source": "desired"})
+			result, err := ssa.PatchApplyServiceAccount(testCtx, k8sClient, ac, ssa.FieldOwnerForBD("ph-conflict-bd"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ssa.PatchApplyResultPatched))
+
+			var sa corev1.ServiceAccount
+			Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: "ph-conflict-sa", Namespace: "default"}, &sa)).To(Succeed())
+			Expect(sa.Labels).To(HaveKeyWithValue("shared", "desired"))
+			Expect(sa.Annotations).To(HaveKeyWithValue("source", "desired"))
+			Expect(sa.AutomountServiceAccountToken).NotTo(BeNil())
+			Expect(*sa.AutomountServiceAccountToken).To(BeTrue())
+		})
+
+		It("should retry as a patch when a ServiceAccount appears during create apply", func() {
+			name := types.NamespacedName{Name: "ph-create-race-sa", Namespace: "default"}
+			racingClient := &serviceAccountCreateRaceClient{Client: k8sClient, namespacedName: name}
+
+			ac := ssa.ServiceAccountWith(name.Name, name.Namespace,
+				map[string]string{"shared": "desired"}, true).
+				WithAnnotations(map[string]string{"source": "desired"})
+			result, err := ssa.PatchApplyServiceAccount(testCtx, racingClient, ac, ssa.FieldOwnerForBD("ph-race-bd"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ssa.PatchApplyResultPatched))
+
+			var sa corev1.ServiceAccount
+			Expect(k8sClient.Get(testCtx, name, &sa)).To(Succeed())
+			Expect(sa.Labels).To(HaveKeyWithValue("shared", "desired"))
+			Expect(sa.Annotations).To(HaveKeyWithValue("source", "desired"))
+			Expect(sa.AutomountServiceAccountToken).NotTo(BeNil())
+			Expect(*sa.AutomountServiceAccountToken).To(BeTrue())
+		})
+	})
+
+	// -----------------------------------------------------------------------
 	// PatchApplyResult stringer
 	// -----------------------------------------------------------------------
 	Context("PatchApplyResult.String", func() {
@@ -386,3 +437,42 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 		})
 	})
 })
+
+type serviceAccountCreateRaceClient struct {
+	client.Client
+	namespacedName   types.NamespacedName
+	reportNotFound   bool
+	injectedConflict bool
+}
+
+func (c *serviceAccountCreateRaceClient) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	if key == c.namespacedName && !c.reportNotFound {
+		c.reportNotFound = true
+		return apierrors.NewNotFound(schema.GroupResource{Resource: "serviceaccounts"}, key.Name)
+	}
+
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c *serviceAccountCreateRaceClient) Apply(
+	ctx context.Context,
+	obj runtime.ApplyConfiguration,
+	opts ...client.ApplyOption,
+) error {
+	if c.reportNotFound && !c.injectedConflict {
+		c.injectedConflict = true
+		externalAC := ssa.ServiceAccountWith(c.namespacedName.Name, c.namespacedName.Namespace,
+			map[string]string{"shared": "external"}, false).
+			WithAnnotations(map[string]string{"source": "external"})
+		if err := c.Client.Apply(ctx, externalAC, client.FieldOwner("external-agent"), client.ForceOwnership); err != nil {
+			return err
+		}
+	}
+
+	return c.Client.Apply(ctx, obj, opts...)
+}

--- a/pkg/ssa/patchhelper_test.go
+++ b/pkg/ssa/patchhelper_test.go
@@ -229,7 +229,7 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should reclaim ownership and patch when a different field manager owns .subjects", func() {
+		It("should fail on field-manager conflicts unless ForceOwnership is explicit", func() {
 			subjects := []rbacv1.Subject{{Kind: "User", Name: "dave", APIGroup: rbacv1.GroupName}}
 			roleRef := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "ph-binding-target"}
 
@@ -242,11 +242,13 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 			err = k8sClient.Apply(testCtx, externalAC, client.FieldOwner("external-agent"), client.ForceOwnership)
 			Expect(err).NotTo(HaveOccurred())
 
-			// ForceOwnership on the patch path allows us to reclaim field ownership
-			// from the external field manager and restore the desired state.
 			desiredSubjects := []rbacv1.Subject{{Kind: "User", Name: "dave", APIGroup: rbacv1.GroupName}}
 			desiredAC := ssa.ClusterRoleBindingWithSubjectsAndRoleRef("ph-conflict-crb", nil, desiredSubjects, roleRef)
-			result, err := ssa.PatchApplyClusterRoleBinding(testCtx, k8sClient, desiredAC)
+			_, err = ssa.PatchApplyClusterRoleBinding(testCtx, k8sClient, desiredAC)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("conflict"))
+
+			result, err := ssa.PatchApplyClusterRoleBinding(testCtx, k8sClient, desiredAC, client.ForceOwnership)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(ssa.PatchApplyResultPatched))
 		})

--- a/pkg/ssa/patchhelper_test.go
+++ b/pkg/ssa/patchhelper_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -246,7 +247,7 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 			desiredAC := ssa.ClusterRoleBindingWithSubjectsAndRoleRef("ph-conflict-crb", nil, desiredSubjects, roleRef)
 			_, err = ssa.PatchApplyClusterRoleBinding(testCtx, k8sClient, desiredAC)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("conflict"))
+			Expect(apierrors.IsConflict(err)).To(BeTrue())
 
 			result, err := ssa.PatchApplyClusterRoleBinding(testCtx, k8sClient, desiredAC, client.ForceOwnership)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/ssa/patchhelper_test.go
+++ b/pkg/ssa/patchhelper_test.go
@@ -113,6 +113,27 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("name must not be empty"))
 		})
+
+		It("should fail on field-manager conflicts unless ForceOwnership is explicit", func() {
+			rules := []rbacv1.PolicyRule{
+				{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}},
+			}
+			externalRules := []rbacv1.PolicyRule{
+				{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"list"}},
+			}
+			externalAC := ssa.ClusterRoleWithLabelsAndRules("ph-conflict-cr", nil, externalRules)
+			err := k8sClient.Apply(testCtx, externalAC, client.FieldOwner("external-agent"), client.ForceOwnership)
+			Expect(err).NotTo(HaveOccurred())
+
+			ac := ssa.ClusterRoleWithLabelsAndRules("ph-conflict-cr", nil, rules)
+			_, err = ssa.PatchApplyClusterRole(testCtx, k8sClient, ac)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsConflict(err)).To(BeTrue())
+
+			result, err := ssa.PatchApplyClusterRole(testCtx, k8sClient, ac, client.ForceOwnership)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ssa.PatchApplyResultPatched))
+		})
 	})
 
 	// -----------------------------------------------------------------------
@@ -169,6 +190,27 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 			_, err := ssa.PatchApplyRole(testCtx, k8sClient, ac)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("namespace"))
+		})
+
+		It("should fail on field-manager conflicts unless ForceOwnership is explicit", func() {
+			rules := []rbacv1.PolicyRule{
+				{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get"}},
+			}
+			externalRules := []rbacv1.PolicyRule{
+				{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"list"}},
+			}
+			externalAC := ssa.RoleWithLabelsAndRules("ph-conflict-role", "default", nil, externalRules)
+			err := k8sClient.Apply(testCtx, externalAC, client.FieldOwner("external-agent"), client.ForceOwnership)
+			Expect(err).NotTo(HaveOccurred())
+
+			ac := ssa.RoleWithLabelsAndRules("ph-conflict-role", "default", nil, rules)
+			_, err = ssa.PatchApplyRole(testCtx, k8sClient, ac)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsConflict(err)).To(BeTrue())
+
+			result, err := ssa.PatchApplyRole(testCtx, k8sClient, ac, client.ForceOwnership)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ssa.PatchApplyResultPatched))
 		})
 	})
 
@@ -311,6 +353,24 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 			ac := ssa.RoleBindingWithSubjectsAndRoleRef("test", "", nil, nil, roleRef)
 			_, err := ssa.PatchApplyRoleBinding(testCtx, k8sClient, ac)
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail on field-manager conflicts unless ForceOwnership is explicit", func() {
+			subjects := []rbacv1.Subject{{Kind: "ServiceAccount", Name: "conflict-sa", Namespace: "default"}}
+			roleRef := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: "ph-rb-target"}
+			externalSubjects := []rbacv1.Subject{{Kind: "Group", Name: "external-group", APIGroup: rbacv1.GroupName}}
+			externalAC := ssa.RoleBindingWithSubjectsAndRoleRef("ph-conflict-rb", "default", nil, externalSubjects, roleRef)
+			err := k8sClient.Apply(testCtx, externalAC, client.FieldOwner("external-agent"), client.ForceOwnership)
+			Expect(err).NotTo(HaveOccurred())
+
+			ac := ssa.RoleBindingWithSubjectsAndRoleRef("ph-conflict-rb", "default", nil, subjects, roleRef)
+			_, err = ssa.PatchApplyRoleBinding(testCtx, k8sClient, ac)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsConflict(err)).To(BeTrue())
+
+			result, err := ssa.PatchApplyRoleBinding(testCtx, k8sClient, ac, client.ForceOwnership)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(ssa.PatchApplyResultPatched))
 		})
 	})
 

--- a/pkg/ssa/patchhelper_test.go
+++ b/pkg/ssa/patchhelper_test.go
@@ -393,7 +393,7 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 			ac := ssa.ServiceAccountWith("ph-conflict-sa", "default",
 				map[string]string{"shared": "desired"}, true).
 				WithAnnotations(map[string]string{"source": "desired"})
-			result, err := ssa.PatchApplyServiceAccount(testCtx, k8sClient, ac, ssa.FieldOwnerForBD("ph-conflict-bd"))
+			result, err := ssa.PatchApplyServiceAccount(testCtx, k8sClient, ac, ssa.FieldOwnerFor("ph-conflict-bd"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(ssa.PatchApplyResultPatched))
 
@@ -412,7 +412,7 @@ var _ = Describe("PatchHelper - cache-aware SSA diff", func() {
 			ac := ssa.ServiceAccountWith(name.Name, name.Namespace,
 				map[string]string{"shared": "desired"}, true).
 				WithAnnotations(map[string]string{"source": "desired"})
-			result, err := ssa.PatchApplyServiceAccount(testCtx, racingClient, ac, ssa.FieldOwnerForBD("ph-race-bd"))
+			result, err := ssa.PatchApplyServiceAccount(testCtx, racingClient, ac, ssa.FieldOwnerFor("ph-race-bd"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(ssa.PatchApplyResultPatched))
 

--- a/pkg/ssa/ssa_test.go
+++ b/pkg/ssa/ssa_test.go
@@ -14,6 +14,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,6 +44,8 @@ var _ = BeforeSuite(func() {
 	// Create a fresh scheme to avoid mutating global state
 	testScheme := runtime.NewScheme()
 	err := rbacv1.AddToScheme(testScheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = corev1.AddToScheme(testScheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	testEnv = &envtest.Environment{


### PR DESCRIPTION
## Summary

The shared RBAC SSA patch helpers no longer force ownership by default. That prevents ordinary `PatchApplyClusterRole`, `PatchApplyRole`, `PatchApplyClusterRoleBinding`, and `PatchApplyRoleBinding` calls from silently taking fields owned by Helm, Flux, or another controller.

## Changes

- Remove implicit `client.ForceOwnership` from the shared RBAC patch helper defaults.
- Keep `PatchApplyServiceAccount` forceful only on the patch path because multiple BindDefinitions intentionally co-manage the same ServiceAccount fields through distinct field managers.
- Pass `client.ForceOwnership` explicitly from the RoleDefinition controller when applying generated Roles and ClusterRoles, because RoleDefinitions own those generated RBAC resources end-to-end and must correct external drift.
- Replace brittle conflict string matching in the SSA tests with Kubernetes API conflict classification.

Callers that genuinely need force semantics now have to pass `client.ForceOwnership` explicitly at the call site.

## Testing

```bash
KUBEBUILDER_ASSETS=/Users/A92615428/git/GitHub/telekom/auth-operator/bin/k8s/1.34.1-darwin-arm64 go test -timeout=5m ./internal/controller/authorization ./pkg/ssa
```

## Risk

Medium. Existing resources owned by another manager now conflict unless the owning controller explicitly opts into force ownership. That is intentional for cooperative SSA; the remaining forceful paths are documented ownership contracts.
