### PR TITLE
fix(webhook): propagate namespace Get errors instead of fail-open

### DIFF
--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -194,7 +194,18 @@ func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return strings.Compare(a.Name, b.Name)
 	})
 
-	result := wa.evaluateSAR(ctx, &sar, items)
+	result, evalErr := wa.evaluateSAR(ctx, &sar, items)
+	if evalErr != nil {
+		wa.Log.Error(evalErr, "failed to evaluate SubjectAccessReview",
+			"latency", time.Since(start).String())
+		if span := trace.SpanFromContext(ctx); span.IsRecording() {
+			span.RecordError(evalErr)
+			span.SetStatus(codes.Error, "evaluation error")
+		}
+		wa.recordErrorMetrics(start)
+		http.Error(w, "internal evaluation error", http.StatusInternalServerError)
+		return
+	}
 
 	// Count total rules across ALL WebhookAuthorizer resources (global + scoped)
 	// for the gauge. This is request-independent: even if a namespace-scoped
@@ -485,7 +496,7 @@ func isFieldIndexError(err error) bool {
 	return strings.Contains(msg, "does not exist") && strings.Contains(msg, "index")
 }
 
-func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAccessReview, items []authzv1alpha1.WebhookAuthorizer) evaluationResult {
+func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAccessReview, items []authzv1alpha1.WebhookAuthorizer) (evaluationResult, error) {
 	evaluated := 0
 	skipped := 0
 
@@ -505,7 +516,13 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 				skipped++
 				continue
 			}
-			if !wa.namespaceMatches(ctx, resourceNS, &webhookAuthorizer.Spec.NamespaceSelector) {
+			matched, err := wa.namespaceMatches(ctx, resourceNS, &webhookAuthorizer.Spec.NamespaceSelector)
+			if err != nil {
+				wa.Log.Error(err, "failed to match namespace for authorizer",
+					"authorizer", webhookAuthorizer.Name, "namespace", resourceNS)
+				return evaluationResult{}, fmt.Errorf("namespace match for authorizer %s: %w", webhookAuthorizer.Name, err)
+			}
+			if !matched {
 				wa.Log.V(2).Info("namespace selector did not match, skipping",
 					"authorizer", webhookAuthorizer.Name,
 					"namespace", resourceNS)
@@ -532,7 +549,7 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 				matchedField:   "deniedPrincipal",
 				evaluatedCount: evaluated,
 				skippedCount:   skipped,
-			}
+			}, nil
 		}
 
 		// Check AllowedPrincipals.
@@ -548,7 +565,7 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 						matchedField:   "resourceRule",
 						evaluatedCount: evaluated,
 						skippedCount:   skipped,
-					}
+					}, nil
 				}
 			}
 			if sar.Spec.NonResourceAttributes != nil {
@@ -562,7 +579,7 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 						matchedField:   "nonResourceRule",
 						evaluatedCount: evaluated,
 						skippedCount:   skipped,
-					}
+					}, nil
 				}
 			}
 		}
@@ -576,11 +593,13 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 		matchedRule:    -1,
 		evaluatedCount: evaluated,
 		skippedCount:   skipped,
-	}
+	}, nil
 }
 
 // namespaceMatches checks if the namespace matches the selector.
-func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector) bool {
+// On API errors the error is returned so callers can fail-closed rather than
+// skipping the authorizer as if it were a non-match.
+func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, selector *metav1.LabelSelector) (bool, error) {
 	if wa.Tracer != nil {
 		var span trace.Span
 		ctx, span = wa.Tracer.Start(ctx, "webhook.NamespaceMatch",
@@ -589,20 +608,17 @@ func (wa *Authorizer) namespaceMatches(ctx context.Context, namespace string, se
 	}
 
 	if namespace == "" {
-		return false
+		return false, nil
 	}
 	var ns corev1.Namespace
-	err := wa.Client.Get(ctx, types.NamespacedName{Name: namespace}, &ns)
-	if err != nil {
-		wa.Log.Error(err, "Failed to get namespace", "namespace", namespace)
-		return false
+	if err := wa.Client.Get(ctx, types.NamespacedName{Name: namespace}, &ns); err != nil {
+		return false, fmt.Errorf("get namespace %s: %w", namespace, err)
 	}
 	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
-		wa.Log.Error(err, "Invalid label selector")
-		return false
+		return false, fmt.Errorf("parse namespace label selector: %w", err)
 	}
-	return labelSelector.Matches(labels.Set(ns.Labels))
+	return labelSelector.Matches(labels.Set(ns.Labels)), nil
 }
 
 // principalMatches checks if the user or groups match the principals.

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -518,8 +518,6 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 			}
 			matched, err := wa.namespaceMatches(ctx, resourceNS, &webhookAuthorizer.Spec.NamespaceSelector)
 			if err != nil {
-				wa.Log.Error(err, "failed to match namespace for authorizer",
-					"authorizer", webhookAuthorizer.Name, "namespace", resourceNS)
 				return evaluationResult{}, fmt.Errorf("namespace match for authorizer %s: %w", webhookAuthorizer.Name, err)
 			}
 			if !matched {

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -366,7 +366,10 @@ func TestEvaluateSAR_ResultFields(t *testing.T) {
 				ResourceAttributes: &authzv1.ResourceAttributes{Verb: "get", Group: "", Resource: "pods"},
 			},
 		}
-		res := handler.evaluateSAR(context.Background(), sar, waList.Items)
+		res, err := handler.evaluateSAR(context.Background(), sar, waList.Items)
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
 		if !res.allowed {
 			t.Fatal("expected allowed")
 		}
@@ -385,7 +388,10 @@ func TestEvaluateSAR_ResultFields(t *testing.T) {
 				ResourceAttributes: &authzv1.ResourceAttributes{Verb: "get", Resource: "pods"},
 			},
 		}
-		res := handler.evaluateSAR(context.Background(), sar, waList.Items)
+		res, err := handler.evaluateSAR(context.Background(), sar, waList.Items)
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
 		if res.allowed {
 			t.Fatal("expected denied")
 		}
@@ -407,7 +413,10 @@ func TestEvaluateSAR_ResultFields(t *testing.T) {
 				ResourceAttributes: &authzv1.ResourceAttributes{Verb: "get", Resource: "pods"},
 			},
 		}
-		res := handler.evaluateSAR(context.Background(), sar, waList.Items)
+		res, err := handler.evaluateSAR(context.Background(), sar, waList.Items)
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
 		if res.allowed {
 			t.Fatal("expected denied")
 		}

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -480,6 +480,68 @@ func TestEvaluateSAR_NamespaceGetError(t *testing.T) {
 	}
 }
 
+// TestServeHTTP_NamespaceGetError_Returns500 verifies that when evaluateSAR
+// returns an error (e.g. namespace Get fails), ServeHTTP responds with 500.
+func TestServeHTTP_NamespaceGetError_Returns500(t *testing.T) {
+	// Build a scheme that includes corev1 so the fake client recognises
+	// Namespace resources and returns a proper NotFound error.
+	s := runtime.NewScheme()
+	if err := authzv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add authzv1alpha1 to scheme: %v", err)
+	}
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add clientgoscheme to scheme: %v", err)
+	}
+
+	// WebhookAuthorizer with a NamespaceSelector so it becomes a scoped authorizer.
+	// evaluateSAR will call namespaceMatches, which calls Client.Get for the namespace.
+	wa := &authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-wa-500"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "alice"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+			NamespaceSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+		},
+	}
+
+	// Use an indexed client (matching real manager setup) with the WA but without
+	// the "missing-ns" Namespace object — Get will return NotFound.
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithIndex(
+			&authzv1alpha1.WebhookAuthorizer{},
+			indexer.WebhookAuthorizerHasNamespaceSelectorField,
+			indexer.WebhookAuthorizerHasNamespaceSelectorFunc,
+		).
+		WithObjects(wa).
+		Build()
+	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+
+	sar := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: "alice",
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Verb:      "get",
+				Resource:  "pods",
+				Namespace: "missing-ns",
+			},
+		},
+	}
+
+	body := marshalSAR(t, sar)
+	req := httptest.NewRequest(http.MethodPost, "/authorize", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected HTTP 500 when namespace Get fails, got %d", rec.Code)
+	}
+}
+
 func TestServeHTTP_OversizedBody(t *testing.T) {
 	var buf strings.Builder
 	logger := capturingLogger(&buf, 0)

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -16,6 +16,7 @@ import (
 	authzv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -430,6 +431,53 @@ func TestEvaluateSAR_ResultFields(t *testing.T) {
 			t.Errorf("expected matchedRule=-1, got %d", res.matchedRule)
 		}
 	})
+}
+
+func TestEvaluateSAR_NamespaceGetError(t *testing.T) {
+	// Build a scheme that includes corev1 so the fake client recognises
+	// Namespace resources and returns a proper NotFound error.
+	s := runtime.NewScheme()
+	if err := authzv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add authzv1alpha1 to scheme: %v", err)
+	}
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add clientgoscheme to scheme: %v", err)
+	}
+
+	// WebhookAuthorizer with a NamespaceSelector so evaluateSAR will call
+	// namespaceMatches, which in turn calls Client.Get for the namespace.
+	wa := &authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-wa"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "alice"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+			NamespaceSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+		},
+	}
+
+	// The fake client does NOT have the namespace "missing-ns" — Get will return NotFound.
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(wa).Build()
+	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+
+	sar := &authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: "alice",
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Verb:      "get",
+				Resource:  "pods",
+				Namespace: "missing-ns",
+			},
+		},
+	}
+
+	_, err := handler.evaluateSAR(context.Background(), sar, []authzv1alpha1.WebhookAuthorizer{*wa})
+	if err == nil {
+		t.Fatal("expected error from namespace Get failure, got nil")
+	}
 }
 
 func TestServeHTTP_OversizedBody(t *testing.T) {

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -443,8 +443,8 @@ func TestEvaluateSAR_ResultFields(t *testing.T) {
 }
 
 func TestEvaluateSAR_NamespaceGetError(t *testing.T) {
-	// Build a scheme that includes corev1 so the fake client recognises
-	// Namespace resources and returns a proper NotFound error.
+	// Build a scheme with Kubernetes built-in types so the fake client
+	// recognises Namespace resources and returns a proper NotFound error.
 	s := newSchemeWithCore(t)
 
 	// WebhookAuthorizer with a NamespaceSelector so evaluateSAR will call
@@ -486,8 +486,8 @@ func TestEvaluateSAR_NamespaceGetError(t *testing.T) {
 // TestServeHTTP_NamespaceGetError_Returns500 verifies that when evaluateSAR
 // returns an error (e.g. namespace Get fails), ServeHTTP responds with 500.
 func TestServeHTTP_NamespaceGetError_Returns500(t *testing.T) {
-	// Build a scheme that includes corev1 so the fake client recognises
-	// Namespace resources and returns a proper NotFound error.
+	// Build a scheme with Kubernetes built-in types so the fake client
+	// recognises Namespace resources and returns a proper NotFound error.
 	s := newSchemeWithCore(t)
 
 	// WebhookAuthorizer with a NamespaceSelector so it becomes a scoped authorizer.

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -44,6 +44,15 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
+func newSchemeWithCore(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := newScheme(t)
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add clientgoscheme to scheme: %v", err)
+	}
+	return s
+}
+
 // newIndexedClient builds a fake client with the WebhookAuthorizer
 // hasNamespaceSelector field index registered, matching the real manager setup.
 func newIndexedClient(scheme *runtime.Scheme, objs ...client.Object) client.Client {
@@ -436,13 +445,7 @@ func TestEvaluateSAR_ResultFields(t *testing.T) {
 func TestEvaluateSAR_NamespaceGetError(t *testing.T) {
 	// Build a scheme that includes corev1 so the fake client recognises
 	// Namespace resources and returns a proper NotFound error.
-	s := runtime.NewScheme()
-	if err := authzv1alpha1.AddToScheme(s); err != nil {
-		t.Fatalf("failed to add authzv1alpha1 to scheme: %v", err)
-	}
-	if err := clientgoscheme.AddToScheme(s); err != nil {
-		t.Fatalf("failed to add clientgoscheme to scheme: %v", err)
-	}
+	s := newSchemeWithCore(t)
 
 	// WebhookAuthorizer with a NamespaceSelector so evaluateSAR will call
 	// namespaceMatches, which in turn calls Client.Get for the namespace.
@@ -460,7 +463,7 @@ func TestEvaluateSAR_NamespaceGetError(t *testing.T) {
 	}
 
 	// The fake client does NOT have the namespace "missing-ns" — Get will return NotFound.
-	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(wa).Build()
+	cl := newIndexedClient(s, wa)
 	handler := &Authorizer{Client: cl, Log: logr.Discard()}
 
 	sar := &authzv1.SubjectAccessReview{
@@ -485,13 +488,7 @@ func TestEvaluateSAR_NamespaceGetError(t *testing.T) {
 func TestServeHTTP_NamespaceGetError_Returns500(t *testing.T) {
 	// Build a scheme that includes corev1 so the fake client recognises
 	// Namespace resources and returns a proper NotFound error.
-	s := runtime.NewScheme()
-	if err := authzv1alpha1.AddToScheme(s); err != nil {
-		t.Fatalf("failed to add authzv1alpha1 to scheme: %v", err)
-	}
-	if err := clientgoscheme.AddToScheme(s); err != nil {
-		t.Fatalf("failed to add clientgoscheme to scheme: %v", err)
-	}
+	s := newSchemeWithCore(t)
 
 	// WebhookAuthorizer with a NamespaceSelector so it becomes a scoped authorizer.
 	// evaluateSAR will call namespaceMatches, which calls Client.Get for the namespace.
@@ -510,15 +507,7 @@ func TestServeHTTP_NamespaceGetError_Returns500(t *testing.T) {
 
 	// Use an indexed client (matching real manager setup) with the WA but without
 	// the "missing-ns" Namespace object — Get will return NotFound.
-	cl := fake.NewClientBuilder().
-		WithScheme(s).
-		WithIndex(
-			&authzv1alpha1.WebhookAuthorizer{},
-			indexer.WebhookAuthorizerHasNamespaceSelectorField,
-			indexer.WebhookAuthorizerHasNamespaceSelectorFunc,
-		).
-		WithObjects(wa).
-		Build()
+	cl := newIndexedClient(s, wa)
 	handler := &Authorizer{Client: cl, Log: logr.Discard()}
 
 	sar := authzv1.SubjectAccessReview{


### PR DESCRIPTION
## Summary

`namespaceMatches` in the WebhookAuthorizer handler swallowed `Get` errors for Namespace objects (logging them but returning `false`). The `false` return caused the evaluator to silently skip a WebhookAuthorizer rule as if the namespace selector didn't match — a fail-open behavior that could allow unauthorized access during transient API errors or RBAC misconfiguration.

## Changes

- `internal/webhook/authorization/webhook_authorizer.go`:
  - `namespaceMatches` now returns `(bool, error)` and propagates both `Get` errors and `LabelSelectorAsSelector` errors.
  - `evaluateSAR` signature changed to `(evaluationResult, error)` to carry namespace errors to the HTTP handler.
  - `ServeHTTP` handles the new error return with `http.StatusInternalServerError`, consistent with other API error paths.
- `internal/webhook/authorization/webhook_authorizer_test.go`: Updated the three `evaluateSAR` call sites to handle the new return signature.

## Testing

```bash
go build ./...
go test ./internal/webhook/authorization/ -run TestEvaluateSAR_ResultFields -v
```

All 3 sub-tests pass.

## Risk

Low — behavior change only occurs on API error paths that previously silently skipped authorizer evaluation; happy path is unchanged.