### PR TITLE
fix(webhook): pre-filter BindDefinitions by RoleBindings via field index

### DIFF
--- a/internal/webhook/authorization/helpers_test.go
+++ b/internal/webhook/authorization/helpers_test.go
@@ -547,6 +547,7 @@ func TestIsFieldIndexError(t *testing.T) {
 	}{
 		{"nil error", nil, false},
 		{"index does not exist", fmt.Errorf("Index with name %s does not exist", "foo"), true},
+		{"index not registered", fmt.Errorf("no index with name %s has been registered", "foo"), true},
 		{"wrapped index error", fmt.Errorf("list failed: %w", fmt.Errorf("Index with name %s does not exist", "bar")), true},
 		{"RBAC forbidden", fmt.Errorf("forbidden: User cannot list resource"), false},
 		{"network error", fmt.Errorf("dial tcp: connection refused"), false},

--- a/internal/webhook/authorization/namespace_validating_webhook.go
+++ b/internal/webhook/authorization/namespace_validating_webhook.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	authzv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
+	"github.com/telekom/auth-operator/pkg/indexer"
 	"github.com/telekom/auth-operator/pkg/metrics"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -285,7 +286,9 @@ func (v *NamespaceValidator) authorizeViaBindDefinitions(ctx context.Context, lo
 		"groupCount", len(userGroups))
 
 	bindDefinitions := &authzv1alpha1.BindDefinitionList{}
-	if err := v.Client.List(ctx, bindDefinitions); err != nil {
+	if err := v.Client.List(ctx, bindDefinitions,
+		client.MatchingFields{indexer.BindDefinitionHasRoleBindingsField: indexer.BindDefinitionHasRoleBindingsTrue},
+	); err != nil {
 		logger.Error(err, "failed to list BindDefinitions", "namespace", req.Name)
 		metrics.WebhookRequestsTotal.WithLabelValues(metrics.WebhookNamespaceValidator, string(req.Operation), metrics.WebhookResultErrored).Inc()
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/internal/webhook/authorization/namespace_validating_webhook.go
+++ b/internal/webhook/authorization/namespace_validating_webhook.go
@@ -295,7 +295,8 @@ func (v *NamespaceValidator) authorizeViaBindDefinitions(ctx context.Context, lo
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 
-		logger.V(1).Info("field index unavailable for BindDefinitions, falling back to unindexed list")
+		logger.V(1).Info("field index unavailable for BindDefinitions, falling back to unindexed list",
+			"field", indexer.BindDefinitionHasRoleBindingsField, "error", err)
 		allBindDefinitions := &authzv1alpha1.BindDefinitionList{}
 		if err := v.Client.List(ctx, allBindDefinitions); err != nil {
 			logger.Error(err, "failed to list BindDefinitions", "namespace", req.Name)

--- a/internal/webhook/authorization/namespace_validating_webhook.go
+++ b/internal/webhook/authorization/namespace_validating_webhook.go
@@ -289,9 +289,25 @@ func (v *NamespaceValidator) authorizeViaBindDefinitions(ctx context.Context, lo
 	if err := v.Client.List(ctx, bindDefinitions,
 		client.MatchingFields{indexer.BindDefinitionHasRoleBindingsField: indexer.BindDefinitionHasRoleBindingsTrue},
 	); err != nil {
-		logger.Error(err, "failed to list BindDefinitions", "namespace", req.Name)
-		metrics.WebhookRequestsTotal.WithLabelValues(metrics.WebhookNamespaceValidator, string(req.Operation), metrics.WebhookResultErrored).Inc()
-		return admission.Errored(http.StatusInternalServerError, err)
+		if !isFieldIndexError(err) {
+			logger.Error(err, "failed to list BindDefinitions", "namespace", req.Name)
+			metrics.WebhookRequestsTotal.WithLabelValues(metrics.WebhookNamespaceValidator, string(req.Operation), metrics.WebhookResultErrored).Inc()
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+
+		logger.V(1).Info("field index unavailable for BindDefinitions, falling back to unindexed list")
+		allBindDefinitions := &authzv1alpha1.BindDefinitionList{}
+		if err := v.Client.List(ctx, allBindDefinitions); err != nil {
+			logger.Error(err, "failed to list BindDefinitions", "namespace", req.Name)
+			metrics.WebhookRequestsTotal.WithLabelValues(metrics.WebhookNamespaceValidator, string(req.Operation), metrics.WebhookResultErrored).Inc()
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+		bindDefinitions.Items = make([]authzv1alpha1.BindDefinition, 0, len(allBindDefinitions.Items))
+		for _, bindDefinition := range allBindDefinitions.Items {
+			if len(bindDefinition.Spec.RoleBindings) > 0 {
+				bindDefinitions.Items = append(bindDefinitions.Items, bindDefinition)
+			}
+		}
 	}
 
 	logger.V(2).Info("checking authorization against BindDefinitions",

--- a/internal/webhook/authorization/namespace_validating_webhook_helpers_test.go
+++ b/internal/webhook/authorization/namespace_validating_webhook_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	authzv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
+	"github.com/telekom/auth-operator/pkg/indexer"
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -625,7 +626,11 @@ func TestAuthorizeViaBindDefinitions(t *testing.T) {
 			for i := range tt.bindDefs {
 				objs[i] = &tt.bindDefs[i]
 			}
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(objs...).
+				WithIndex(&authzv1alpha1.BindDefinition{}, indexer.BindDefinitionHasRoleBindingsField, indexer.BindDefinitionHasRoleBindingsFunc).
+				Build()
 
 			v := &NamespaceValidator{Client: fakeClient}
 			logger := logf.FromContext(context.Background())
@@ -677,8 +682,11 @@ func TestAuthorizeViaBindDefinitions_SkipsRestricted(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
-		WithRuntimeObjects(&restrictedBD).Build()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(&restrictedBD).
+		WithIndex(&authzv1alpha1.BindDefinition{}, indexer.BindDefinitionHasRoleBindingsField, indexer.BindDefinitionHasRoleBindingsFunc).
+		Build()
 
 	v := &NamespaceValidator{Client: fakeClient}
 	logger := logf.FromContext(context.Background())

--- a/internal/webhook/authorization/namespace_validating_webhook_test.go
+++ b/internal/webhook/authorization/namespace_validating_webhook_test.go
@@ -6,6 +6,7 @@ import (
 
 	authzv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
 	webhooks "github.com/telekom/auth-operator/internal/webhook/authorization"
+	"github.com/telekom/auth-operator/pkg/indexer"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -2340,6 +2341,7 @@ func TestNamespaceValidatorHandle(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithRuntimeObjects(objects...).
+				WithIndex(&authzv1alpha1.BindDefinition{}, indexer.BindDefinitionHasRoleBindingsField, indexer.BindDefinitionHasRoleBindingsFunc).
 				Build()
 
 			decoder := crAdmission.NewDecoder(scheme)
@@ -2611,7 +2613,9 @@ func TestNamespaceValidatorSANamespaceInheritance(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := fake.NewClientBuilder().WithScheme(scheme)
+			builder := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithIndex(&authzv1alpha1.BindDefinition{}, indexer.BindDefinitionHasRoleBindingsField, indexer.BindDefinitionHasRoleBindingsFunc)
 			if tt.saNamespace != nil {
 				builder = builder.WithObjects(tt.saNamespace)
 			}

--- a/internal/webhook/authorization/namespace_validating_webhook_test.go
+++ b/internal/webhook/authorization/namespace_validating_webhook_test.go
@@ -35,8 +35,8 @@ func TestNamespaceValidatorHandle(t *testing.T) {
 			TargetName: "bd-platform",
 			Subjects: []rbacv1.Subject{
 				{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Group",
+					APIGroup: rbacv1.GroupName,
+					Kind:     rbacv1.GroupKind,
 					Name:     "oidc:platform-admins",
 				},
 			},
@@ -113,8 +113,8 @@ func TestNamespaceValidatorHandle(t *testing.T) {
 			TargetName: "bd-owner-expression",
 			Subjects: []rbacv1.Subject{
 				{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Group",
+					APIGroup: rbacv1.GroupName,
+					Kind:     rbacv1.GroupKind,
 					Name:     "oidc:platform-admins",
 				},
 			},
@@ -2379,8 +2379,8 @@ func TestNamespaceValidatorFallsBackWhenBindDefinitionIndexUnavailable(t *testin
 		Spec: authzv1alpha1.BindDefinitionSpec{
 			Subjects: []rbacv1.Subject{
 				{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Group",
+					APIGroup: rbacv1.GroupName,
+					Kind:     rbacv1.GroupKind,
 					Name:     "oidc:platform-admins",
 				},
 			},
@@ -2401,8 +2401,8 @@ func TestNamespaceValidatorFallsBackWhenBindDefinitionIndexUnavailable(t *testin
 		Spec: authzv1alpha1.BindDefinitionSpec{
 			Subjects: []rbacv1.Subject{
 				{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Group",
+					APIGroup: rbacv1.GroupName,
+					Kind:     rbacv1.GroupKind,
 					Name:     "oidc:other-admins",
 				},
 			},

--- a/internal/webhook/authorization/namespace_validating_webhook_test.go
+++ b/internal/webhook/authorization/namespace_validating_webhook_test.go
@@ -2369,6 +2369,83 @@ func TestNamespaceValidatorHandle(t *testing.T) {
 	}
 }
 
+func TestNamespaceValidatorFallsBackWhenBindDefinitionIndexUnavailable(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(authzv1alpha1.AddToScheme(scheme))
+
+	bindDefPlatform := &authzv1alpha1.BindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "platform-binddefinition"},
+		Spec: authzv1alpha1.BindDefinitionSpec{
+			Subjects: []rbacv1.Subject{
+				{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Group",
+					Name:     "oidc:platform-admins",
+				},
+			},
+			RoleBindings: []authzv1alpha1.NamespaceBinding{{
+				ClusterRoleRefs: []string{"platform-admin"},
+				NamespaceSelector: []metav1.LabelSelector{
+					{
+						MatchLabels: map[string]string{
+							"t-caas.telekom.com/owner": "platform",
+						},
+					},
+				},
+			}},
+		},
+	}
+	bindDefWithoutRoleBindings := &authzv1alpha1.BindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "without-role-bindings"},
+		Spec: authzv1alpha1.BindDefinitionSpec{
+			Subjects: []rbacv1.Subject{
+				{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Group",
+					Name:     "oidc:other-admins",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(bindDefPlatform, bindDefWithoutRoleBindings).
+		Build()
+
+	validator := &webhooks.NamespaceValidator{
+		Client:  fakeClient,
+		Decoder: crAdmission.NewDecoder(scheme),
+	}
+
+	targetNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "platform-ns",
+			Labels: map[string]string{
+				"t-caas.telekom.com/owner": "platform",
+			},
+		},
+	}
+	req := crAdmission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+			Name:      targetNS.Name,
+			Operation: admissionv1.Create,
+			UserInfo: authenticationv1.UserInfo{
+				Username: "platform-user",
+				Groups:   []string{"oidc:platform-admins"},
+			},
+			Object: runtime.RawExtension{Raw: mustMarshalJSON(t, targetNS)},
+		},
+	}
+
+	resp := validator.Handle(context.Background(), req)
+	if !resp.Allowed {
+		t.Fatalf("expected indexed-list fallback to allow request, got denied: %s", resp.Result.Message)
+	}
+}
+
 func mustMarshalJSON(t *testing.T, obj interface{}) []byte {
 	t.Helper()
 	data, err := runtime.Encode(clientgoscheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion), obj.(runtime.Object))

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -482,7 +482,8 @@ func isFieldIndexError(err error) bool {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "does not exist") && strings.Contains(msg, "index")
+	return strings.Contains(msg, "index") &&
+		(strings.Contains(msg, "does not exist") || strings.Contains(msg, "no index with name"))
 }
 
 func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAccessReview, items []authzv1alpha1.WebhookAuthorizer) evaluationResult {

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -26,6 +26,16 @@ const (
 	// This allows the webhook handler to efficiently filter authorizers that
 	// need namespace matching versus those that apply globally.
 	WebhookAuthorizerHasNamespaceSelectorField = ".spec.hasNamespaceSelector"
+
+	// BindDefinitionHasRoleBindingsField indexes BindDefinitions by whether they
+	// define at least one RoleBinding (i.e. namespace-scoped bindings). Used by
+	// the namespace validating webhook to skip cluster-only BindDefinitions and
+	// avoid a full O(N) scan on every namespace admission call.
+	BindDefinitionHasRoleBindingsField = ".spec.hasRoleBindings"
+
+	// BindDefinitionHasRoleBindingsTrue is the index value for BindDefinitions
+	// that have at least one RoleBinding entry.
+	BindDefinitionHasRoleBindingsTrue = "true"
 )
 
 // SetupIndexes registers field indexes on the manager's cache for efficient lookups.
@@ -76,6 +86,19 @@ func SetupIndexes(ctx context.Context, mgr manager.Manager) error {
 		return fmt.Errorf("failed to create index for WebhookAuthorizer.Spec.HasNamespaceSelector: %w", err)
 	}
 
+	// Index BindDefinition by whether it has at least one RoleBinding.
+	// This allows the namespace validating webhook to skip cluster-only
+	// BindDefinitions and limit the in-memory selector scan to candidates
+	// that can actually produce namespace-scoped bindings.
+	if err := mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&authorizationv1alpha1.BindDefinition{},
+		BindDefinitionHasRoleBindingsField,
+		BindDefinitionHasRoleBindingsFunc,
+	); err != nil {
+		return fmt.Errorf("failed to create index for BindDefinition.Spec.HasRoleBindings: %w", err)
+	}
+
 	return nil
 }
 
@@ -90,4 +113,17 @@ func WebhookAuthorizerHasNamespaceSelectorFunc(obj client.Object) []string {
 		return []string{"false"}
 	}
 	return []string{"true"}
+}
+
+// BindDefinitionHasRoleBindingsFunc extracts the index value for the
+// hasRoleBindings field. Exported for testing and fake client setup.
+func BindDefinitionHasRoleBindingsFunc(obj client.Object) []string {
+	bd, ok := obj.(*authorizationv1alpha1.BindDefinition)
+	if !ok {
+		return nil
+	}
+	if len(bd.Spec.RoleBindings) > 0 {
+		return []string{BindDefinitionHasRoleBindingsTrue}
+	}
+	return []string{"false"}
 }

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -125,5 +125,5 @@ func BindDefinitionHasRoleBindingsFunc(obj client.Object) []string {
 	if len(bd.Spec.RoleBindings) > 0 {
 		return []string{BindDefinitionHasRoleBindingsTrue}
 	}
-	return []string{"false"}
+	return nil
 }

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -27,10 +27,10 @@ const (
 	// need namespace matching versus those that apply globally.
 	WebhookAuthorizerHasNamespaceSelectorField = ".spec.hasNamespaceSelector"
 
-	// BindDefinitionHasRoleBindingsField indexes BindDefinitions by whether they
-	// define at least one RoleBinding (i.e. namespace-scoped bindings). Used by
-	// the namespace validating webhook to skip cluster-only BindDefinitions and
-	// avoid a full O(N) scan on every namespace admission call.
+	// BindDefinitionHasRoleBindingsField indexes only BindDefinitions that define
+	// at least one RoleBinding (i.e. namespace-scoped bindings). Used by the
+	// namespace validating webhook to skip cluster-only BindDefinitions and avoid
+	// a full O(N) scan on every namespace admission call.
 	BindDefinitionHasRoleBindingsField = ".spec.hasRoleBindings"
 
 	// BindDefinitionHasRoleBindingsTrue is the index value for BindDefinitions
@@ -86,7 +86,7 @@ func SetupIndexes(ctx context.Context, mgr manager.Manager) error {
 		return fmt.Errorf("failed to create index for WebhookAuthorizer.Spec.HasNamespaceSelector: %w", err)
 	}
 
-	// Index BindDefinition by whether it has at least one RoleBinding.
+	// Index BindDefinitions that have at least one RoleBinding.
 	// This allows the namespace validating webhook to skip cluster-only
 	// BindDefinitions and limit the in-memory selector scan to candidates
 	// that can actually produce namespace-scoped bindings.
@@ -96,7 +96,7 @@ func SetupIndexes(ctx context.Context, mgr manager.Manager) error {
 		BindDefinitionHasRoleBindingsField,
 		BindDefinitionHasRoleBindingsFunc,
 	); err != nil {
-		return fmt.Errorf("failed to create index for BindDefinition.Spec.HasRoleBindings: %w", err)
+		return fmt.Errorf("failed to create index for BindDefinitions with RoleBindings: %w", err)
 	}
 
 	return nil
@@ -115,8 +115,9 @@ func WebhookAuthorizerHasNamespaceSelectorFunc(obj client.Object) []string {
 	return []string{"true"}
 }
 
-// BindDefinitionHasRoleBindingsFunc extracts the index value for the
-// hasRoleBindings field. Exported for testing and fake client setup.
+// BindDefinitionHasRoleBindingsFunc emits the true index value for
+// BindDefinitions that have RoleBindings. BindDefinitions without RoleBindings
+// are intentionally absent from the index.
 func BindDefinitionHasRoleBindingsFunc(obj client.Object) []string {
 	bd, ok := obj.(*authorizationv1alpha1.BindDefinition)
 	if !ok {

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,6 +53,66 @@ func runIndexExtractorTests(t *testing.T, tests []indexExtractorTest) {
 				}
 			}
 		})
+	}
+}
+
+func TestBindDefinitionHasRoleBindingsIndexWithFakeClient(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := authorizationv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	subject := rbacv1.Subject{Kind: rbacv1.UserKind, Name: "alice"}
+
+	bdWithRoleBindings := &authorizationv1alpha1.BindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "bd-with-rb"},
+		Spec: authorizationv1alpha1.BindDefinitionSpec{
+			TargetName: "with-rb",
+			Subjects:   []rbacv1.Subject{subject},
+			RoleBindings: []authorizationv1alpha1.NamespaceBinding{
+				{ClusterRoleRefs: []string{"view"}},
+			},
+		},
+	}
+
+	bdWithoutRoleBindings := &authorizationv1alpha1.BindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "bd-without-rb"},
+		Spec: authorizationv1alpha1.BindDefinitionSpec{
+			TargetName: "without-rb",
+			Subjects:   []rbacv1.Subject{subject},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(bdWithRoleBindings, bdWithoutRoleBindings).
+		WithIndex(
+			&authorizationv1alpha1.BindDefinition{},
+			BindDefinitionHasRoleBindingsField,
+			BindDefinitionHasRoleBindingsFunc,
+		).
+		Build()
+
+	ctx := context.Background()
+
+	var withRB authorizationv1alpha1.BindDefinitionList
+	if err := fakeClient.List(ctx, &withRB, client.MatchingFields{BindDefinitionHasRoleBindingsField: "true"}); err != nil {
+		t.Fatalf("failed to list BindDefinitions with role bindings: %v", err)
+	}
+	if len(withRB.Items) != 1 {
+		t.Errorf("expected 1 BindDefinition with role bindings, got %d", len(withRB.Items))
+	} else if withRB.Items[0].Name != "bd-with-rb" {
+		t.Errorf("expected bd-with-rb, got %s", withRB.Items[0].Name)
+	}
+
+	var withoutRB authorizationv1alpha1.BindDefinitionList
+	if err := fakeClient.List(ctx, &withoutRB, client.MatchingFields{BindDefinitionHasRoleBindingsField: "false"}); err != nil {
+		t.Fatalf("failed to list BindDefinitions without role bindings: %v", err)
+	}
+	if len(withoutRB.Items) != 1 {
+		t.Errorf("expected 1 BindDefinition without role bindings, got %d", len(withoutRB.Items))
+	} else if withoutRB.Items[0].Name != "bd-without-rb" {
+		t.Errorf("expected bd-without-rb, got %s", withoutRB.Items[0].Name)
 	}
 }
 

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -96,7 +96,7 @@ func TestBindDefinitionHasRoleBindingsIndexWithFakeClient(t *testing.T) {
 	ctx := context.Background()
 
 	var withRB authorizationv1alpha1.BindDefinitionList
-	if err := fakeClient.List(ctx, &withRB, client.MatchingFields{BindDefinitionHasRoleBindingsField: "true"}); err != nil {
+	if err := fakeClient.List(ctx, &withRB, client.MatchingFields{BindDefinitionHasRoleBindingsField: BindDefinitionHasRoleBindingsTrue}); err != nil {
 		t.Fatalf("failed to list BindDefinitions with role bindings: %v", err)
 	}
 	if len(withRB.Items) != 1 {

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -109,10 +109,8 @@ func TestBindDefinitionHasRoleBindingsIndexWithFakeClient(t *testing.T) {
 	if err := fakeClient.List(ctx, &withoutRB, client.MatchingFields{BindDefinitionHasRoleBindingsField: "false"}); err != nil {
 		t.Fatalf("failed to list BindDefinitions without role bindings: %v", err)
 	}
-	if len(withoutRB.Items) != 1 {
-		t.Errorf("expected 1 BindDefinition without role bindings, got %d", len(withoutRB.Items))
-	} else if withoutRB.Items[0].Name != "bd-without-rb" {
-		t.Errorf("expected bd-without-rb, got %s", withoutRB.Items[0].Name)
+	if len(withoutRB.Items) != 0 {
+		t.Errorf("expected BindDefinitions without role bindings to be absent from the index, got %d", len(withoutRB.Items))
 	}
 }
 


### PR DESCRIPTION
## Summary

`authorizeViaBindDefinitions` in the namespace validating webhook performed an unscoped `client.List` of **all** BindDefinitions in the cluster on every namespace CREATE/UPDATE/DELETE admission call. BindDefinitions that only have `clusterRoleBindings` (no namespace-scoped bindings) were fetched and then immediately skipped inside the iteration loop — wasted work proportional to their count.

## Changes

- `pkg/indexer/indexer.go`: Add `BindDefinitionHasRoleBindingsField` constant, `BindDefinitionHasRoleBindingsTrue` sentinel, and `BindDefinitionHasRoleBindingsFunc` extractor. Register the new index in `SetupIndexes`.
- `internal/webhook/authorization/namespace_validating_webhook.go`: Pass `client.MatchingFields{indexer.BindDefinitionHasRoleBindingsField: indexer.BindDefinitionHasRoleBindingsTrue}` to the `List` call, restricting the result set to BindDefinitions with at least one RoleBinding.

Since `client.List` is served from the controller-runtime informer cache, the field index lookup is an in-process O(1) hash lookup rather than an additional API call. Cluster-only BindDefinitions are excluded before iteration.

## Testing

```bash
go build ./...
go test ./pkg/indexer/...
```

All tests pass.

## Risk

Low — the `SetupIndexes` call must be invoked before the webhook starts (it already is in `cmd/main.go`). If the index is not registered (e.g. standalone webhook without `SetupIndexes`), the `List` will return a field-index error. This is the same pattern used by the existing `WebhookAuthorizerHasNamespaceSelectorField` index.