### PR TITLE
fix(chart): preserve webhook CA bundle during upgrades

### DIFF
--- a/chart/auth-operator/templates/_helpers.tpl
+++ b/chart/auth-operator/templates/_helpers.tpl
@@ -71,6 +71,37 @@ Image pull policy
 {{- end }}
 
 {{/*
+Resolve the current webhook CA bundle during Helm upgrades.
+
+The cert rotator owns webhook caBundle injection at runtime, but Helm upgrades
+render these webhook configurations again before waiting on the release. Reusing
+the live Secret or existing webhook caBundle prevents an upgrade from briefly
+removing the apiserver trust root before follow-up charts create auth CRs.
+*/}}
+{{- define "auth-operator.webhookCABundle" -}}
+{{- $root := .root -}}
+{{- $name := .name -}}
+{{- $kind := .kind -}}
+{{- $bundle := "" -}}
+{{- $secretName := printf "%s-webhook-certs" (include "auth-operator.fullname" $root) -}}
+{{- $secret := lookup "v1" "Secret" $root.Release.Namespace $secretName -}}
+{{- if and $secret $secret.data -}}
+{{- $bundle = (index $secret.data "ca.crt" | default "") -}}
+{{- end -}}
+{{- if not $bundle -}}
+{{- $webhookConfig := lookup "admissionregistration.k8s.io/v1" $kind "" $name -}}
+{{- if and $webhookConfig $webhookConfig.webhooks -}}
+{{- range $webhook := $webhookConfig.webhooks -}}
+{{- if and (not $bundle) $webhook.clientConfig $webhook.clientConfig.caBundle -}}
+{{- $bundle = $webhook.clientConfig.caBundle -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $bundle -}}
+{{- end }}
+
+{{/*
 Standard egress rules for operator pods (DNS + kube-apiserver).
 Both the controller-manager and the webhook-server need DNS resolution
 and kube-apiserver access, so this helper avoids duplicating the block.
@@ -108,5 +139,4 @@ limits the allowed ports.
 {{- toYaml .Values.networkPolicy.egress.additionalRules | nindent 0 }}
 {{- end }}
 {{- end }}
-
 

--- a/chart/auth-operator/templates/binder-validating-webhook-configuration.yaml
+++ b/chart/auth-operator/templates/binder-validating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{- $caBundle := include "auth-operator.webhookCABundle" (dict "root" . "kind" "ValidatingWebhookConfiguration" "name" (printf "%s-binder-validating-webhook-configuration" (include "auth-operator.fullname" .))) | trim }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -8,6 +9,9 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
+    {{- if $caBundle }}
+    caBundle: {{ $caBundle | quote }}
+    {{- end }}
     service:
       name: '{{ include "auth-operator.fullname" . }}-webhook-service'
       namespace: '{{ .Release.Namespace }}'
@@ -28,6 +32,9 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
+    {{- if $caBundle }}
+    caBundle: {{ $caBundle | quote }}
+    {{- end }}
     service:
       name: '{{ include "auth-operator.fullname" . }}-webhook-service'
       namespace: '{{ .Release.Namespace }}'
@@ -48,6 +55,9 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
+    {{- if $caBundle }}
+    caBundle: {{ $caBundle | quote }}
+    {{- end }}
     service:
       name: '{{ include "auth-operator.fullname" . }}-webhook-service'
       namespace: '{{ .Release.Namespace }}'

--- a/chart/auth-operator/templates/namespace-mutating-webhook-configuration.yaml
+++ b/chart/auth-operator/templates/namespace-mutating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{- $caBundle := include "auth-operator.webhookCABundle" (dict "root" . "kind" "MutatingWebhookConfiguration" "name" (printf "%s-namespace-mutating-webhook-configuration" (include "auth-operator.fullname" .))) | trim }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -8,6 +9,9 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
+    {{- if $caBundle }}
+    caBundle: {{ $caBundle | quote }}
+    {{- end }}
     service:
       name: '{{ include "auth-operator.fullname" . }}-webhook-service'
       namespace: '{{ .Release.Namespace }}'

--- a/chart/auth-operator/templates/namespace-validating-webhook-configuration.yaml
+++ b/chart/auth-operator/templates/namespace-validating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{- $caBundle := include "auth-operator.webhookCABundle" (dict "root" . "kind" "ValidatingWebhookConfiguration" "name" (printf "%s-namespace-validating-webhook-configuration" (include "auth-operator.fullname" .))) | trim }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -8,6 +9,9 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
+    {{- if $caBundle }}
+    caBundle: {{ $caBundle | quote }}
+    {{- end }}
     service:
       name: '{{ include "auth-operator.fullname" . }}-webhook-service'
       namespace: '{{ .Release.Namespace }}'


### PR DESCRIPTION
## Summary
- Preserve the live webhook CA bundle during Helm upgrades by rendering `caBundle` from the existing cert Secret, falling back to the existing webhook configuration.
- Apply the preserved bundle to the binder, namespace mutating, and namespace validating webhook configurations.
- Prevent Helm from briefly replacing trusted admission configs with configs that fall back to system roots before follow-up auth CR charts run.

Refs T-CAASTCAAS-1433.

## Testing
- `helm template auth-operator ./chart/auth-operator --debug`
- `helm lint chart/auth-operator --strict`
- `GOCACHE=/private/tmp/auth-operator-go-build-cache make helm`
- `GOCACHE=/private/tmp/auth-operator-go-build-cache make test`

Note: the first sandboxed `make test` attempt failed because envtest could not bind `127.0.0.1:0` (`operation not permitted`). The approved rerun outside the sandbox passed.
