### PR TITLE
test: keep CRD e2e namespace between specs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	golang.org/x/time v0.15.0
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -114,5 +115,4 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/telekom/auth-operator/test/utils"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -33,17 +35,8 @@ const (
 	crdStatusRunning = "Running"
 )
 
-var crdE2EFixtureResourceFiles = []string{
-	// Keep this in sync with test/e2e/fixtures/kustomization.yaml, excluding
-	// namespace_labeled.yaml because the CRD suite reuses the namespace between specs.
-	"roledefinition_clusterrole.yaml",
-	"roledefinition_role.yaml",
-	"binddefinition_clusterrolebinding.yaml",
-	"binddefinition_rolebinding.yaml",
-	"binddefinition_serviceaccount.yaml",
-	"webhookauthorizer_allow.yaml",
-	"webhookauthorizer_deny.yaml",
-	"webhookauthorizer_nonresource.yaml",
+type fixtureKustomization struct {
+	Resources []string `json:"resources"`
 }
 
 var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
@@ -648,15 +641,40 @@ func testNamespaceDeleted() (bool, error) {
 	return strings.TrimSpace(string(output)) == "", nil
 }
 
+func crdE2EFixtureResourceFiles() ([]string, error) {
+	kustomizationPath := filepath.Join(fixturesPath, "kustomization.yaml")
+	data, err := os.ReadFile(kustomizationPath)
+	if err != nil {
+		return nil, fmt.Errorf("read fixture kustomization: %w", err)
+	}
+
+	var kustomization fixtureKustomization
+	if err := yaml.Unmarshal(data, &kustomization); err != nil {
+		return nil, fmt.Errorf("parse fixture kustomization: %w", err)
+	}
+
+	resources := make([]string, 0, len(kustomization.Resources))
+	for _, resource := range kustomization.Resources {
+		if resource == "namespace_labeled.yaml" {
+			continue
+		}
+		resources = append(resources, resource)
+	}
+	return resources, nil
+}
+
 func cleanupCRDE2ETestState() {
 	const e2eLabelSelector = "app.kubernetes.io/component=e2e-test"
 	const managedByLabelSelector = "app.kubernetes.io/managed-by=auth-operator"
 
-	for _, fixtureFile := range crdE2EFixtureResourceFiles {
+	fixtureFiles, err := crdE2EFixtureResourceFiles()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to read CRD e2e fixture resources")
+
+	for _, fixtureFile := range fixtureFiles {
 		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "-f", filepath.Join(fixturesPath, fixtureFile),
 			"--ignore-not-found=true", "--wait=false", "--timeout=30s")
-		if output, err := utils.Run(cmd); err != nil {
-			_, _ = fmt.Fprintf(GinkgoWriter, "warning: failed to delete CRD e2e fixture %s: %v\n%s\n", fixtureFile, err, string(output))
+		if _, err := utils.Run(cmd); err != nil {
+			_, _ = fmt.Fprintf(GinkgoWriter, "warning: failed to delete CRD e2e fixture %s: %v\n", fixtureFile, err)
 		}
 	}
 

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -33,6 +33,17 @@ const (
 	crdStatusRunning = "Running"
 )
 
+var crdE2EFixtureResourceFiles = []string{
+	"roledefinition_clusterrole.yaml",
+	"roledefinition_role.yaml",
+	"binddefinition_clusterrolebinding.yaml",
+	"binddefinition_rolebinding.yaml",
+	"binddefinition_serviceaccount.yaml",
+	"webhookauthorizer_allow.yaml",
+	"webhookauthorizer_deny.yaml",
+	"webhookauthorizer_nonresource.yaml",
+}
+
 var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 
 	BeforeAll(func() {
@@ -639,8 +650,11 @@ func cleanupCRDE2ETestState() {
 	const e2eLabelSelector = "app.kubernetes.io/component=e2e-test"
 	const managedByLabelSelector = "app.kubernetes.io/managed-by=auth-operator"
 
-	cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "-k", fixturesPath, "--ignore-not-found=true", "--wait=false", "--timeout=30s")
-	_, _ = utils.Run(cmd)
+	for _, fixtureFile := range crdE2EFixtureResourceFiles {
+		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "-f", filepath.Join(fixturesPath, fixtureFile),
+			"--ignore-not-found=true", "--wait=false", "--timeout=30s")
+		_, _ = utils.Run(cmd)
+	}
 
 	utils.RemoveFinalizersForAll("roledefinition")
 	utils.RemoveFinalizersForAll("binddefinition")

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -642,7 +642,12 @@ func testNamespaceDeleted() (bool, error) {
 }
 
 func crdE2EFixtureResourceFiles() ([]string, error) {
-	kustomizationPath := filepath.Join(fixturesPath, "kustomization.yaml")
+	projectDir, err := utils.GetProjectDir()
+	if err != nil {
+		return nil, fmt.Errorf("locate project dir: %w", err)
+	}
+	fixtureDir := filepath.Join(projectDir, fixturesPath)
+	kustomizationPath := filepath.Join(fixtureDir, "kustomization.yaml")
 	data, err := os.ReadFile(kustomizationPath)
 	if err != nil {
 		return nil, fmt.Errorf("read fixture kustomization: %w", err)
@@ -658,7 +663,7 @@ func crdE2EFixtureResourceFiles() ([]string, error) {
 		if resource == "namespace_labeled.yaml" {
 			continue
 		}
-		resources = append(resources, resource)
+		resources = append(resources, filepath.Join(fixtureDir, resource))
 	}
 	return resources, nil
 }
@@ -671,8 +676,8 @@ func cleanupCRDE2ETestState() {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to read CRD e2e fixture resources")
 
 	for _, fixtureFile := range fixtureFiles {
-		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "-f", filepath.Join(fixturesPath, fixtureFile),
-			"--ignore-not-found=true", "--wait=false", "--timeout=30s")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "-f", fixtureFile,
+			"--ignore-not-found=true", "--wait=false")
 		if _, err := utils.Run(cmd); err != nil {
 			_, _ = fmt.Fprintf(GinkgoWriter, "warning: failed to delete CRD e2e fixture %s: %v\n", fixtureFile, err)
 		}

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -34,6 +34,8 @@ const (
 )
 
 var crdE2EFixtureResourceFiles = []string{
+	// Keep this in sync with test/e2e/fixtures/kustomization.yaml, excluding
+	// namespace_labeled.yaml because the CRD suite reuses the namespace between specs.
 	"roledefinition_clusterrole.yaml",
 	"roledefinition_role.yaml",
 	"binddefinition_clusterrolebinding.yaml",
@@ -653,7 +655,9 @@ func cleanupCRDE2ETestState() {
 	for _, fixtureFile := range crdE2EFixtureResourceFiles {
 		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "-f", filepath.Join(fixturesPath, fixtureFile),
 			"--ignore-not-found=true", "--wait=false", "--timeout=30s")
-		_, _ = utils.Run(cmd)
+		if output, err := utils.Run(cmd); err != nil {
+			_, _ = fmt.Fprintf(GinkgoWriter, "warning: failed to delete CRD e2e fixture %s: %v\n%s\n", fixtureFile, err, string(output))
+		}
 	}
 
 	utils.RemoveFinalizersForAll("roledefinition")


### PR DESCRIPTION
## Summary
- stop per-spec CRD e2e cleanup from deleting the shared `e2e-test-ns` namespace
- delete only the fixture CR resources between ordered specs
- leave namespace deletion to the existing final cleanup path

## CI failure addressed
- Addresses the PR #307 `E2E Full Chain (Popular CRDs)` failure where `AfterEach` deleted the fixture kustomization with `--wait=false`; because that kustomization includes `namespace_labeled.yaml`, the next `BeforeEach` could race with asynchronous namespace deletion and fail waiting for `e2e-test-ns`.

## Validation
- `go test -tags e2e ./test/e2e -run TestE2E -ginkgo.dry-run -ginkgo.label-filter="basic && crd" -timeout 5m`

## Not run
- Full kind-based `make test-e2e-full-chain` was not started locally.