### PR TITLE
docs: refresh WebhookAuthorizer status guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Auth Operator provides three CRDs for managing RBAC:
 |-----|---------|
 | **RoleDefinition** | Generates ClusterRoles/Roles using deny-list pattern |
 | **BindDefinition** | Creates ClusterRoleBindings/RoleBindings for subjects |
-| **WebhookAuthorizer** | Configures webhook-based authorization *(planned)* |
+| **WebhookAuthorizer** | Configures webhook-based SubjectAccessReview authorization |
 
 ### 1. Create a RoleDefinition
 
@@ -218,11 +218,21 @@ Bindings are named as: `{targetName}-{roleName}-binding`
 
 ### WebhookAuthorizer
 
-Configures fine-grained authorization decisions via webhook-based authorization.
+Configures fine-grained SubjectAccessReview decisions for the webhook server.
+Within a WebhookAuthorizer, denied principals are rejected before allow rules
+are evaluated. Allowed principals must also match a resource or non-resource
+rule. When multiple authorizers match, they are evaluated deterministically by
+name; the first allow or deny decision is returned.
 
-*Not yet implemented.*
+**Key capabilities:**
+- **Resource and non-resource rules** - Match Kubernetes API requests or paths such as `/healthz`
+- **Allow and deny principals** - Match users, groups, or ServiceAccount identities
+- **Namespace scoping** - Use `namespaceSelector` to limit resource requests to matching namespaces
+- **Status reporting** - Sets `status.authorizerConfigured=true` and `Ready=True` after reconciliation
 
 ![WebhookAuthorizer](docs/images/authorizer.png)
+
+**Example:** See [config/samples/authorization_v1alpha1_webhookauthorizer.yaml](config/samples/authorization_v1alpha1_webhookauthorizer.yaml)
 
 ---
 

--- a/docs/condition-lifecycle.md
+++ b/docs/condition-lifecycle.md
@@ -231,8 +231,27 @@ the operator has cleaned up dependent resources.
 
 ## WebhookAuthorizer-Specific Conditions
 
-The WebhookAuthorizer controller (see issue #49) uses these conditions to
-report the health and validity of each WebhookAuthorizer resource.
+The WebhookAuthorizer controller reports reconciliation progress with the
+standard `Reconciling`, `Ready`, and `Stalled` conditions. It also updates
+`status.observedGeneration` and `status.authorizerConfigured`.
+
+The admission webhook rejects malformed rules and principal-free specs before
+they are reconciled. Runtime status is therefore focused on whether the
+controller accepted the spec and whether namespace selector validation
+succeeded.
+
+The API package still exports legacy WebhookAuthorizer condition constants such
+as `RulesValid`, `NamespaceSelectorValid`, and `PrincipalConfigured` for
+compatibility. The current controller does not set those conditions.
+
+### Reconciling
+
+| Status | Reason | Message |
+|--------|--------|---------|
+| `True` | `Progressing` | Controller is reconciling the resource |
+
+Set before validation and cleared when the resource becomes `Ready` or
+`Stalled`.
 
 ### Ready
 
@@ -240,45 +259,40 @@ Overall readiness of the WebhookAuthorizer.
 
 | Status | Reason | Message |
 |--------|--------|---------|
-| `True` | `AuthorizerReady` | All rules are valid and the authorizer is actively processing requests |
-| `False` | `InvalidRules` | One or more resource/non-resource rules are malformed: *\<detail\>* |
-| `False` | `InvalidNamespaceSelector` | The namespace selector cannot be parsed: *\<detail\>* |
-| `False` | `NoPrincipals` | Neither allowedPrincipals nor deniedPrincipals are defined |
+| `True` | `Reconciled` | Resource is fully reconciled |
+| `False` | `Progressing` | Controller is reconciling the resource |
+| `False` | `Error` | Error during reconciliation: check operator logs for details |
 
-### RulesValid
+When `Ready=True`, the controller also sets
+`status.authorizerConfigured=true`.
 
-Validation status of resource and non-resource rules.
+### Stalled
 
-| Status | Reason | Message |
-|--------|--------|---------|
-| `True` | `AllRulesValid` | All resourceRules and nonResourceRules are syntactically valid |
-| `False` | `InvalidResourceRule` | A resourceRule contains invalid API groups, resources, or verbs: *\<detail\>* |
-| `False` | `InvalidNonResourceRule` | A nonResourceRule contains invalid paths or verbs: *\<detail\>* |
-
-### NamespaceSelectorValid
-
-Status of the namespace selector.
+Permanent reconciliation failure. The current controller uses this when the
+namespace selector cannot be parsed.
 
 | Status | Reason | Message |
 |--------|--------|---------|
-| `True` | `SelectorValid` | Namespace selector is parseable and matches namespaces |
-| `True` | `SelectorEmpty` | No namespace selector defined (matches all namespaces) |
-| `False` | `SelectorInvalid` | Namespace selector cannot be parsed: *\<detail\>* |
+| `True` | `Error` | Error during reconciliation: check operator logs for details |
 
-### PrincipalConfigured
+When `Stalled=True`, the controller sets `status.authorizerConfigured=false`
+and waits for a spec change before reconciling again.
 
-Status of principal configuration.
+### authorizerConfigured
 
-| Status | Reason | Message |
-|--------|--------|---------|
-| `True` | `PrincipalsConfigured` | AllowedPrincipals and/or DeniedPrincipals are defined |
-| `False` | `NoPrincipalsConfigured` | No principals defined — authorizer will never match |
-| `Unknown` | `PrincipalOverlap` | A principal appears in both allowed and denied lists: *\<detail\>* |
+`status.authorizerConfigured` is a compact readiness flag for scripts and
+JSONPath checks:
 
-### Reconciliation Sequence (WebhookAuthorizer)
+| Value | Meaning |
+|-------|---------|
+| `true` | The controller reconciled the WebhookAuthorizer and marked it `Ready=True` |
+| `false` or unset | Reconciliation has not completed or the resource is stalled |
+
+### Reconciliation Sequence
 
 ```
-NamespaceSelectorValid → RulesValid → PrincipalConfigured → Ready
+Reconciling -> Ready
+Reconciling -> Stalled
 ```
 
 ---
@@ -327,15 +341,14 @@ kubectl get roledefinitions -o json | \
 
 ## Operational Guidance
 
-### What to Do When a Condition Is False
+### Status and Admission Signals
 
-| Condition | When False | Recommended Action |
-|-----------|-----------|-------------------|
-| `Ready` | Resource not fully reconciled | Check `Stalled` and `Reconciling` conditions for details |
-| `RoleRefsValid` | Referenced roles missing | Create the missing ClusterRole/Role, or remove the reference from the BindDefinition |
-| `RulesValid` | Invalid resource/non-resource rules | Fix the rule syntax in the WebhookAuthorizer spec |
-| `NamespaceSelectorValid` | Unparseable label selector | Fix the label selector expression in the spec |
-| `PrincipalConfigured` | No principals defined | Add `allowedPrincipals` or `deniedPrincipals` to the WebhookAuthorizer |
+| Signal | Meaning | Recommended Action |
+|--------|---------|-------------------|
+| `Ready=False` | Resource not fully reconciled | Check `Stalled` and `Reconciling` conditions for details |
+| `RoleRefsValid=False` | Referenced roles missing | Create the missing ClusterRole/Role, or remove the reference from the BindDefinition |
+| `Stalled=True` | WebhookAuthorizer namespace selector failed validation during reconciliation | Fix the label selector expression in the spec |
+| Admission rejection | Invalid WebhookAuthorizer rules or missing principals | Fix the rejected field from the API error and apply the resource again |
 
 ### What to Do When a Condition Is True (Abnormal-True)
 

--- a/docs/condition-lifecycle.md
+++ b/docs/condition-lifecycle.md
@@ -235,7 +235,8 @@ The WebhookAuthorizer controller reports reconciliation progress with the
 standard `Reconciling`, `Ready`, and `Stalled` conditions. It also updates
 `status.observedGeneration` and `status.authorizerConfigured`.
 
-The admission webhook rejects malformed rules and principal-free specs before
+Kubernetes admission rejects malformed rules and principal-free specs through
+CRD schema/CEL validation and the WebhookAuthorizer validation webhook before
 they are reconciled. Runtime status is therefore focused on whether the
 controller accepted the spec and whether namespace selector validation
 succeeded.

--- a/docs/metrics-and-alerting.md
+++ b/docs/metrics-and-alerting.md
@@ -105,7 +105,7 @@ resources:
 |--------|------|--------|-------------|
 | `auth_operator_authorizer_requests_total` | Counter | `decision`, `authorizer` | Total SubjectAccessReview evaluations. `decision`: `allowed`, `denied`, `no-opinion`, `error`. `authorizer`: WebhookAuthorizer CR name or `none`. |
 | `auth_operator_authorizer_request_duration_seconds` | Histogram | `decision` | Duration of SAR evaluation (seconds). |
-| `auth_operator_authorizer_active_rules` | Gauge | — | Total resource and non-resource rules across all WebhookAuthorizer resources (global + scoped). Updated on every request. |
+| `auth_operator_authorizer_active_rules` | Gauge | — | Total resource and non-resource rule entries across all WebhookAuthorizer resources. Includes global and namespace-scoped authorizers, even when a scoped authorizer is not evaluated for the current request. Updated on every request. |
 | `auth_operator_authorizer_denied_principal_hits_total` | Counter | `authorizer` | Number of SAR denials due to denied-principal matching. |
 | `auth_operator_authorizer_rate_limited_total` | Counter | — | SubjectAccessReview requests rejected due to rate limiting on the `/authorize` endpoint. A sustained non-zero rate indicates traffic exceeds `--authorize-rate-limit`. |
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -350,6 +350,9 @@ Key metrics:
 | `auth_operator_rbac_resources_applied_total` | Counter | RBAC resources created/updated |
 | `auth_operator_role_refs_missing` | Gauge | Missing role references |
 | `auth_operator_namespaces_active` | Gauge | Namespaces matching selectors |
+| `auth_operator_authorizer_requests_total` | Counter | WebhookAuthorizer SubjectAccessReview decisions by result and authorizer |
+| `auth_operator_authorizer_active_rules` | Gauge | Active WebhookAuthorizer resource and non-resource rule entries |
+| `auth_operator_authorizer_rate_limited_total` | Counter | SubjectAccessReview requests rejected by the `/authorize` rate limiter |
 
 ### Enable ServiceMonitor
 

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -68,6 +68,97 @@ func marshalSAR(t *testing.T, sar authzv1.SubjectAccessReview) []byte {
 	return body
 }
 
+func TestServeHTTP_EvaluatesMatchingAuthorizersByName(t *testing.T) {
+	scheme := newScheme(t)
+	sar := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: "alice",
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Verb:     "get",
+				Group:    "",
+				Resource: "pods",
+			},
+		},
+	}
+
+	newAllowAuthorizer := func(name string) authzv1alpha1.WebhookAuthorizer {
+		return authzv1alpha1.WebhookAuthorizer{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: authzv1alpha1.WebhookAuthorizerSpec{
+				AllowedPrincipals: []authzv1alpha1.Principal{{User: "alice"}},
+				ResourceRules: []authzv1.ResourceRule{
+					{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+				},
+			},
+		}
+	}
+	newDenyAuthorizer := func(name string) authzv1alpha1.WebhookAuthorizer {
+		return authzv1alpha1.WebhookAuthorizer{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: authzv1alpha1.WebhookAuthorizerSpec{
+				DeniedPrincipals: []authzv1alpha1.Principal{{User: "alice"}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		authorizer []authzv1alpha1.WebhookAuthorizer
+		wantAllow  bool
+		wantReason string
+	}{
+		{
+			name: "first authorizer allows before later deny",
+			authorizer: []authzv1alpha1.WebhookAuthorizer{
+				newDenyAuthorizer("zzz-deny"),
+				newAllowAuthorizer("aaa-allow"),
+			},
+			wantAllow:  true,
+			wantReason: "aaa-allow",
+		},
+		{
+			name: "first authorizer denies before later allow",
+			authorizer: []authzv1alpha1.WebhookAuthorizer{
+				newAllowAuthorizer("zzz-allow"),
+				newDenyAuthorizer("aaa-deny"),
+			},
+			wantAllow:  false,
+			wantReason: "aaa-deny",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := make([]client.Object, 0, len(tt.authorizer))
+			for i := range tt.authorizer {
+				objs = append(objs, &tt.authorizer[i])
+			}
+			handler := &Authorizer{
+				Client: newIndexedClient(scheme, objs...),
+				Log:    logr.Discard(),
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/authorize", bytes.NewReader(marshalSAR(t, sar)))
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rec.Code)
+			}
+
+			var resp authzv1.SubjectAccessReview
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if resp.Status.Allowed != tt.wantAllow {
+				t.Fatalf("expected allowed=%t, got %+v", tt.wantAllow, resp.Status)
+			}
+			if !strings.Contains(resp.Status.Reason, tt.wantReason) {
+				t.Fatalf("expected reason to mention %q, got %q", tt.wantReason, resp.Status.Reason)
+			}
+		})
+	}
+}
+
 func TestAuditLog_DenyDecisionAtV0(t *testing.T) {
 	var buf strings.Builder
 	logger := capturingLogger(&buf, 0)

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -341,7 +341,11 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			Eventually(func() error {
 				return checkResourceExists("webhookauthorizer", "e2e-test-authorizer-allow", "")
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
-			// Note: .status.authorizerConfigured is not implemented in the controller
+
+			By("Verifying WebhookAuthorizer status is configured")
+			Eventually(func() bool {
+				return checkWebhookAuthorizerConfigured("e2e-test-authorizer-allow")
+			}, reconcileTimeout, pollingInterval).Should(BeTrue())
 
 			By("Verifying WebhookAuthorizer spec is correct")
 			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "e2e-test-authorizer-allow",
@@ -359,7 +363,11 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			Eventually(func() error {
 				return checkResourceExists("webhookauthorizer", "e2e-test-authorizer-deny", "")
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
-			// Note: .status.authorizerConfigured is not implemented in the controller
+
+			By("Verifying WebhookAuthorizer status is configured")
+			Eventually(func() bool {
+				return checkWebhookAuthorizerConfigured("e2e-test-authorizer-deny")
+			}, reconcileTimeout, pollingInterval).Should(BeTrue())
 
 			By("Verifying WebhookAuthorizer has denied principals")
 			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "e2e-test-authorizer-deny",
@@ -377,7 +385,11 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			Eventually(func() error {
 				return checkResourceExists("webhookauthorizer", "e2e-test-authorizer-nonresource", "")
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
-			// Note: .status.authorizerConfigured is not implemented in the controller
+
+			By("Verifying WebhookAuthorizer status is configured")
+			Eventually(func() bool {
+				return checkWebhookAuthorizerConfigured("e2e-test-authorizer-nonresource")
+			}, reconcileTimeout, pollingInterval).Should(BeTrue())
 
 			By("Verifying WebhookAuthorizer has non-resource rules")
 			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "e2e-test-authorizer-nonresource",
@@ -564,6 +576,16 @@ func checkBindDefinitionReconciled(name string) bool {
 		return false
 	}
 	return string(output) == statusTrue
+}
+
+func checkWebhookAuthorizerConfigured(name string) bool {
+	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", name,
+		"-o", "jsonpath={.status.authorizerConfigured}")
+	output, err := utils.Run(cmd)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) == statusTrue
 }
 
 func ensureTestNamespace() {

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -585,7 +585,7 @@ func checkWebhookAuthorizerConfigured(name string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.TrimSpace(string(output)) == statusTrue
+	return strings.TrimSpace(string(output)) == "true"
 }
 
 func ensureTestNamespace() {

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -585,7 +585,7 @@ func checkWebhookAuthorizerConfigured(name string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.TrimSpace(string(output)) == "true"
+	return strings.TrimSpace(string(output)) == statusBoolTrue
 }
 
 func ensureTestNamespace() {

--- a/test/e2e/debug_report.go
+++ b/test/e2e/debug_report.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	// statusTrue is the status condition value for ready nodes.
+	// statusTrue is the Kubernetes condition status value used by readiness checks.
 	statusTrue = "True"
-	// statusBoolTrue is the lowercase boolean value emitted by kubectl JSONPath.
+	// statusBoolTrue is the lowercase boolean value used by JSONPath and env flag checks.
 	statusBoolTrue = "true"
 )
 

--- a/test/e2e/debug_report.go
+++ b/test/e2e/debug_report.go
@@ -16,8 +16,12 @@ import (
 	"github.com/telekom/auth-operator/test/utils"
 )
 
-// statusTrue is the status condition value for ready nodes.
-const statusTrue = "True"
+const (
+	// statusTrue is the status condition value for ready nodes.
+	statusTrue = "True"
+	// statusBoolTrue is the lowercase boolean value emitted by kubectl JSONPath.
+	statusBoolTrue = "true"
+)
 
 // DebugReport represents a structured test debug report.
 type DebugReport struct {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// skipClusterSetup allows skipping cluster setup when running against an existing cluster
-	skipClusterSetup = os.Getenv("SKIP_CLUSTER_SETUP") == "true"
+	skipClusterSetup = os.Getenv("SKIP_CLUSTER_SETUP") == statusBoolTrue
 	// kindClusterName is the name of the kind cluster to use
 	kindClusterName = getEnvOrDefault("KIND_CLUSTER", "auth-operator-e2e")
 	// projectImage is the operator image to test
@@ -151,7 +151,7 @@ var _ = AfterEach(func() {
 		report.FullText(), report.State, report.StartTime.UTC().Format(time.RFC3339), report.EndTime.UTC().Format(time.RFC3339), report.RunTime)
 	_ = utils.SaveDebugInfoToFile(outputDir, "summary.md", summary)
 
-	forceAll := os.Getenv("E2E_COLLECT_ALL_SPECS") == "true"
+	forceAll := os.Getenv("E2E_COLLECT_ALL_SPECS") == statusBoolTrue
 	if report.Failed() || forceAll {
 		prevOutputDir := os.Getenv("E2E_OUTPUT_DIR")
 		_ = os.Setenv("E2E_OUTPUT_DIR", outputDir)

--- a/test/e2e/helm_e2e_test.go
+++ b/test/e2e/helm_e2e_test.go
@@ -483,7 +483,11 @@ spec:
 			Eventually(func() error {
 				return checkResourceExists("webhookauthorizer", "helm-e2e-authorizer", "")
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
-			// Note: .status.authorizerConfigured is not implemented in the controller
+
+			By("Verifying WebhookAuthorizer status is configured")
+			Eventually(func() bool {
+				return checkWebhookAuthorizerConfigured("helm-e2e-authorizer")
+			}, reconcileTimeout, pollingInterval).Should(BeTrue())
 		})
 
 		It("should create WebhookAuthorizer with denied principals", func() {
@@ -515,7 +519,11 @@ spec:
 			Eventually(func() error {
 				return checkResourceExists("webhookauthorizer", "helm-e2e-authorizer-deny", "")
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
-			// Note: .status.authorizerConfigured is not implemented in the controller
+
+			By("Verifying WebhookAuthorizer status is configured")
+			Eventually(func() bool {
+				return checkWebhookAuthorizerConfigured("helm-e2e-authorizer-deny")
+			}, reconcileTimeout, pollingInterval).Should(BeTrue())
 		})
 
 		It("should create WebhookAuthorizer with non-resource rules", func() {
@@ -546,7 +554,11 @@ spec:
 			Eventually(func() error {
 				return checkResourceExists("webhookauthorizer", "helm-e2e-authorizer-nonresource", "")
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
-			// Note: .status.authorizerConfigured is not implemented in the controller
+
+			By("Verifying WebhookAuthorizer status is configured")
+			Eventually(func() bool {
+				return checkWebhookAuthorizerConfigured("helm-e2e-authorizer-nonresource")
+			}, reconcileTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
## Summary
- remove stale wording that described WebhookAuthorizer as planned
- document current Ready, Reconciling, Stalled, and authorizerConfigured behavior
- clarify deny-first behavior within one WebhookAuthorizer and deterministic first-match ordering across authorizers
- add E2E status assertions for created WebhookAuthorizer resources
- add a SAR unit regression for cross-authorizer ordering

## Tests
- make fmt
- make vet
- make lint
- go test ./internal/webhook/authorization -run TestServeHTTP_EvaluatesMatchingAuthorizersByName -count=1
- go test -tags e2e ./test/e2e/ -run TestE2E -ginkgo.dry-run -count=1
- git diff --check