### PR TITLE
fix: address auth security scan findings

### DIFF
--- a/.github/workflows/cleanup-pr-packages.yml
+++ b/.github/workflows/cleanup-pr-packages.yml
@@ -18,8 +18,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
-  pull-requests: read
 
 env:
   REGISTRY: ghcr.io
@@ -28,6 +26,10 @@ jobs:
   cleanup-container-images:
     name: Cleanup PR Container Images
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -210,6 +212,10 @@ jobs:
   cleanup-helm-charts:
     name: Cleanup PR Helm Charts
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  packages: write
-  id-token: write
-  security-events: write  # For uploading Trivy SARIF results
-  attestations: write     # For GitHub artifact attestations
+  contents: read
 
 env:
   REGISTRY: ghcr.io
@@ -452,7 +448,6 @@ jobs:
     continue-on-error: true  # Artifactory mirror is best-effort; must not block releases
     permissions:
       packages: read
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Login to GHCR

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 # Cancel in-progress runs when a new run is triggered for the same branch/PR
 concurrency:

--- a/test/e2e/cleanup.go
+++ b/test/e2e/cleanup.go
@@ -111,7 +111,6 @@ func resourcesGone(opts CleanupOptions) bool {
 	return true
 }
 
-// #nosec G204 -- resource kind and name are controlled test fixtures, not user input.
 func resourceExists(kind, name string) bool {
 	attemptCtx, attemptCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer attemptCancel()

--- a/test/e2e/cleanup.go
+++ b/test/e2e/cleanup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -48,11 +47,11 @@ func CleanupTestResources(opts CleanupOptions) {
 	}
 
 	for _, cr := range opts.ClusterRoles {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrole", cr, "--ignore-not-found=true")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrole", cr, "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 	}
 	for _, crb := range opts.ClusterRoleBindings {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrolebinding", crb, "--ignore-not-found=true")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrolebinding", crb, "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 	}
 
@@ -116,7 +115,7 @@ func resourcesGone(opts CleanupOptions) bool {
 func resourceExists(kind, name string) bool {
 	attemptCtx, attemptCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer attemptCancel()
-	cmd := exec.CommandContext(attemptCtx, "kubectl", "get", kind, name, "--ignore-not-found", "-o", "name")
+	cmd := utils.CommandContext(attemptCtx, "kubectl", "get", kind, name, "--ignore-not-found", "-o", "name")
 	out, err := utils.Run(cmd)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "warning: kubectl get %s %s failed: %v\n", kind, name, err)
@@ -129,7 +128,7 @@ func resourceExists(kind, name string) bool {
 func cleanupAllCRDs() {
 	resources := []string{"roledefinition", "binddefinition", "webhookauthorizer"}
 	for _, resource := range resources {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "delete", resource, "-A", "--all", "--ignore-not-found=true")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", resource, "-A", "--all", "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 	}
 }
@@ -213,15 +212,15 @@ func CleanupComplete(namespaces, clusterRoles, clusterRoleBindings []string, web
 // Use within tests for cleanup between test cases.
 func CleanupCRDsByName(roledefs, binddefs, webhookauthorizers []string) {
 	for _, name := range binddefs {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", name, "--ignore-not-found=true")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", name, "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 	}
 	for _, name := range roledefs {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", name, "--ignore-not-found=true")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", name, "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 	}
 	for _, name := range webhookauthorizers {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "webhookauthorizer", name, "--ignore-not-found=true")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "webhookauthorizer", name, "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 	}
 }
@@ -232,10 +231,10 @@ func CleanupAllCRDsInNamespace(namespace string) {
 	resources := []string{"binddefinition", "roledefinition", "webhookauthorizer"}
 	for _, resource := range resources {
 		if namespace != "" {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", resource, "--all", "-n", namespace, "--ignore-not-found=true")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", resource, "--all", "-n", namespace, "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		} else {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", resource, "--all", "--ignore-not-found=true")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", resource, "--all", "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		}
 	}
@@ -243,6 +242,6 @@ func CleanupAllCRDsInNamespace(namespace string) {
 
 // CleanupAllWebhookAuthorizersClusterWide deletes all WebhookAuthorizers (cluster-scoped).
 func CleanupAllWebhookAuthorizersClusterWide() {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "webhookauthorizer", "--all", "--ignore-not-found=true")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "webhookauthorizer", "--all", "--ignore-not-found=true")
 	_, _ = utils.Run(cmd)
 }

--- a/test/e2e/complex_e2e_test.go
+++ b/test/e2e/complex_e2e_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -55,13 +54,13 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 		teamBetaNsPath := filepath.Join(complexTestdataPath, "namespace-team-beta.yaml")
 
 		for _, nsPath := range []string{testNsPath, teamAlphaNsPath, teamBetaNsPath} {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", nsPath)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", nsPath)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create namespace from %s", nsPath)
 		}
 
 		By("Building the operator image")
-		cmd := exec.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+		cmd := utils.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
 		_, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to build operator image")
 
@@ -76,7 +75,7 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 			imageTag = defaultImageTag
 		}
 
-		cmd = exec.CommandContext(context.Background(), "helm", "upgrade", "--install", complexRelease, helmChartPath,
+		cmd = utils.CommandContext(context.Background(), "helm", "upgrade", "--install", complexRelease, helmChartPath,
 			"-n", complexNamespace,
 			"--create-namespace",
 			"--set", fmt.Sprintf("image.repository=%s", imageRepo),
@@ -97,7 +96,7 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 
 		By("Waiting for controller to be ready")
 		Eventually(func() error {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 				"-l", "control-plane=controller-manager",
 				"-n", complexNamespace,
 				"-o", "jsonpath={.items[*].status.phase}")
@@ -112,12 +111,12 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 		}, complexDeployTimeout, complexPollInterval).Should(Succeed())
 
 		By("Pre-installing multi-version CRD for dedup tests (allows tracker discovery before tests run)")
-		cmd = exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "test/e2e/testdata/complex/multiversion-crd.yaml")
+		cmd = utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "test/e2e/testdata/complex/multiversion-crd.yaml")
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to pre-install multi-version CRD")
 
 		Eventually(func() error {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "wait", "--for=condition=Established",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "wait", "--for=condition=Established",
 				"crd/multiwidgets.e2etest.auth-operator.io", "--timeout=30s")
 			_, err := utils.Run(cmd)
 			return err
@@ -144,7 +143,7 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 		Eventually(func() error {
 			for _, cr := range clusterRoles {
 				attemptCtx, attemptCancel := context.WithTimeout(context.Background(), 10*time.Second)
-				cmd := exec.CommandContext(attemptCtx, "kubectl", "get", "clusterrole", cr, "--ignore-not-found", "-o", "name")
+				cmd := utils.CommandContext(attemptCtx, "kubectl", "get", "clusterrole", cr, "--ignore-not-found", "-o", "name")
 				out, err := utils.Run(cmd)
 				attemptCancel()
 				if err != nil {
@@ -158,7 +157,7 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 
 		By("Uninstalling Helm release")
-		cmd := exec.CommandContext(context.Background(), "helm", "uninstall", complexRelease, "-n", complexNamespace, "--wait", "--timeout", "2m")
+		cmd := utils.CommandContext(context.Background(), "helm", "uninstall", complexRelease, "-n", complexNamespace, "--wait", "--timeout", "2m")
 		_, _ = utils.Run(cmd)
 
 		By("Cleaning up test namespaces")
@@ -167,18 +166,18 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 			"complex-e2e-ns-team-a", "complex-e2e-ns-team-b",
 		}
 		for _, ns := range testNamespaces {
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "ns", ns, "--ignore-not-found=true")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "ns", ns, "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		}
 
 		By("Cleaning up cluster-scoped resources")
-		cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrole",
+		cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrole",
 			"complex-filtered-role", "complex-multiversion-dedup-role", "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
-		cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "-f",
+		cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "-f",
 			"test/e2e/testdata/complex/multiversion-crd.yaml", "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
-		cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrolebinding",
+		cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrolebinding",
 			"-l", "app.kubernetes.io/managed-by=auth-operator", "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 	})
@@ -186,14 +185,14 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 	Context("RoleDefinition with ALL restrictions combined", func() {
 		It("should create ClusterRole excluding APIs, resources, and verbs", func() {
 			By("Applying complex RoleDefinition with all restrictions")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f",
 				filepath.Join(complexTestdataPath, "roledefinition-all-restrictions.yaml"))
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for RoleDefinition to be reconciled")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "roledefinition", "complex-all-restrictions",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "roledefinition", "complex-all-restrictions",
 					"-o", "jsonpath={.status.conditions[?(@.type=='Created')].status}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -204,13 +203,13 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 
 			By("Verifying ClusterRole was created")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "complex-filtered-role")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "complex-filtered-role")
 				_, err := utils.Run(cmd)
 				return err
 			}, complexReconcileTime, complexPollInterval).Should(Succeed())
 
 			By("Verifying excluded API groups are not present")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "complex-filtered-role", "-o", "json")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "complex-filtered-role", "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -287,14 +286,14 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 
 		It("should create namespaced Role with all restrictions", func() {
 			By("Applying complex namespaced RoleDefinition")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f",
 				filepath.Join(complexTestdataPath, "roledefinition-namespaced-all-restrictions.yaml"))
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for RoleDefinition to be reconciled")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "roledefinition", "complex-ns-all-restrictions",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "roledefinition", "complex-ns-all-restrictions",
 					"-o", "jsonpath={.status.conditions[?(@.type=='Created')].status}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -305,14 +304,14 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 
 			By("Verifying Role was created in target namespace")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "role", "complex-ns-filtered-role",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "role", "complex-ns-filtered-role",
 					"-n", "complex-e2e-test-ns")
 				_, err := utils.Run(cmd)
 				return err
 			}, complexReconcileTime, complexPollInterval).Should(Succeed())
 
 			By("Verifying Role only contains namespaced resources")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "role", "complex-ns-filtered-role",
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "role", "complex-ns-filtered-role",
 				"-n", "complex-e2e-test-ns", "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -341,14 +340,14 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 	Context("BindDefinition with multiple roles and namespaces", func() {
 		It("should create multiple ClusterRoleBindings from multiple clusterRoleRefs", func() {
 			By("Applying complex multi-binding BindDefinition")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f",
 				filepath.Join(complexTestdataPath, "binddefinition-multi-role-multi-ns.yaml"))
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for BindDefinition to be reconciled")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", "complex-multi-binding",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", "complex-multi-binding",
 					"-o", "jsonpath={.status.conditions[?(@.type=='Created')].status}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -359,7 +358,7 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 
 			By("Verifying ClusterRoleBinding for complex-filtered-role was created")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding",
 					"complex-multi-complex-filtered-role-binding")
 				_, err := utils.Run(cmd)
 				return err
@@ -367,14 +366,14 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 
 			By("Verifying ClusterRoleBinding for view role was created")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding",
 					"complex-multi-view-binding")
 				_, err := utils.Run(cmd)
 				return err
 			}, complexReconcileTime, complexPollInterval).Should(Succeed())
 
 			By("Verifying ClusterRoleBindings have all 4 subjects")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding",
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding",
 				"complex-multi-complex-filtered-role-binding", "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -401,7 +400,7 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 		It("should auto-create ServiceAccounts referenced in subjects", func() {
 			By("Verifying ServiceAccount was auto-created in test namespace")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "serviceaccount", "complex-app-sa",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "serviceaccount", "complex-app-sa",
 					"-n", "complex-e2e-test-ns")
 				_, err := utils.Run(cmd)
 				return err
@@ -409,14 +408,14 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 
 			By("Verifying ServiceAccount was auto-created in team-a namespace")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "serviceaccount", "complex-worker-sa",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "serviceaccount", "complex-worker-sa",
 					"-n", "complex-e2e-ns-team-a")
 				_, err := utils.Run(cmd)
 				return err
 			}, complexReconcileTime, complexPollInterval).Should(Succeed())
 
 			By("Verifying BindDefinition status shows generated ServiceAccounts")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", "complex-multi-binding",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", "complex-multi-binding",
 				"-o", "jsonpath={.status.generatedServiceAccounts}")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -426,7 +425,7 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 		It("should create RoleBindings in namespaces matching label selectors", func() {
 			By("Verifying RoleBinding was created in team-alpha namespace (matches team=alpha)")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "rolebinding",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "rolebinding",
 					"-n", "complex-e2e-ns-team-a",
 					"-l", "app.kubernetes.io/managed-by=auth-operator")
 				output, err := utils.Run(cmd)
@@ -441,7 +440,7 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 
 			By("Verifying RoleBinding was created in test namespace (matches team=alpha AND env=dev)")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "rolebinding",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "rolebinding",
 					"-n", "complex-e2e-test-ns",
 					"-l", "app.kubernetes.io/managed-by=auth-operator")
 				output, err := utils.Run(cmd)
@@ -458,7 +457,7 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 		It("should create RoleBinding for explicit namespace reference", func() {
 			By("Verifying RoleBinding for explicit namespace was created")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "rolebinding",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "rolebinding",
 					"-n", "complex-e2e-test-ns",
 					"-o", "jsonpath={.items[*].roleRef.name}")
 				output, err := utils.Run(cmd)
@@ -476,14 +475,14 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 	Context("BindDefinition with complex namespace selectors", func() {
 		It("should handle matchExpressions in namespaceSelector", func() {
 			By("Applying BindDefinition with complex namespace selector")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f",
 				filepath.Join(complexTestdataPath, "binddefinition-namespace-selector-complex.yaml"))
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for BindDefinition to be reconciled")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", "complex-ns-selector",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", "complex-ns-selector",
 					"-o", "jsonpath={.status.conditions[?(@.type=='Created')].status}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -494,7 +493,7 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 
 			By("Verifying RoleBinding was created in staging namespace (matches environment=staging)")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "rolebinding",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "rolebinding",
 					"-n", "complex-e2e-ns-team-b",
 					"-l", "app.kubernetes.io/managed-by=auth-operator")
 				output, err := utils.Run(cmd)
@@ -512,20 +511,20 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 	Context("WebhookAuthorizer with all features", func() {
 		It("should create WebhookAuthorizer with all features enabled", func() {
 			By("Applying full-featured WebhookAuthorizer")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f",
 				filepath.Join(complexTestdataPath, "webhookauthorizer-full-featured.yaml"))
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying WebhookAuthorizer was created")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "complex-full-authorizer")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "complex-full-authorizer")
 				_, err := utils.Run(cmd)
 				return err
 			}, complexReconcileTime, complexPollInterval).Should(Succeed())
 
 			By("Verifying WebhookAuthorizer spec is correct")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "complex-full-authorizer", "-o", "json")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "complex-full-authorizer", "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -569,7 +568,7 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 		// given ClusterRole contains a resource name more than once. Returns
 		// an error describing the first duplicate found, or nil.
 		checkClusterRoleHasNoDuplicateResources := func(clusterRoleName string) error {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", clusterRoleName, "-o", "json")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", clusterRoleName, "-o", "json")
 			output, err := utils.Run(cmd)
 			if err != nil {
 				return fmt.Errorf("failed to get ClusterRole %s: %w", clusterRoleName, err)
@@ -618,14 +617,14 @@ spec:
     - deletecollection
 `, dedupRoleDefName, dedupClusterRole)
 
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(roleDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for RoleDefinition to be reconciled")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "roledefinition", dedupRoleDefName,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "roledefinition", dedupRoleDefName,
 					"-o", "jsonpath={.status.conditions[?(@.type=='Created')].status}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -656,7 +655,7 @@ spec:
 				BeNumerically(">", 0), "API group should be present before CRD deletion")
 
 			By("Deleting the multi-version CRD")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "-f", multiversionCRDPath, "--ignore-not-found=true")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "-f", multiversionCRDPath, "--ignore-not-found=true")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -684,13 +683,13 @@ spec:
 
 		It("should not accumulate duplicates after CRD re-creation (install/uninstall cycle)", func() {
 			By("Re-installing the multi-version CRD")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", multiversionCRDPath)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", multiversionCRDPath)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for CRD to be established")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "wait", "--for=condition=Established",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "wait", "--for=condition=Established",
 					"crd/multiwidgets.e2etest.auth-operator.io", "--timeout=30s")
 				_, err := utils.Run(cmd)
 				return err
@@ -708,7 +707,7 @@ spec:
 
 		AfterAll(func() {
 			By("Cleaning up multi-version dedup test resources")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", dedupRoleDefName, "--ignore-not-found=true")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", dedupRoleDefName, "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 			Eventually(func() error {
 				err := checkResourceExists("clusterrole", dedupClusterRole, "")
@@ -717,9 +716,9 @@ spec:
 				}
 				return fmt.Errorf("ClusterRole %s still exists", dedupClusterRole)
 			}, complexReconcileTime, complexPollInterval).ShouldNot(HaveOccurred())
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrole", dedupClusterRole, "--ignore-not-found=true")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrole", dedupClusterRole, "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "-f", multiversionCRDPath, "--ignore-not-found=true")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "-f", multiversionCRDPath, "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		})
 	})
@@ -727,18 +726,18 @@ spec:
 	Context("Cleanup and Finalizers", func() {
 		It("should properly clean up child resources when RoleDefinition is deleted", func() {
 			By("Verifying ClusterRole exists")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "complex-filtered-role")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "complex-filtered-role")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Deleting the RoleDefinition")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", "complex-all-restrictions")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", "complex-all-restrictions")
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying ClusterRole was deleted by finalizer")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "complex-filtered-role")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "complex-filtered-role")
 				_, err := utils.Run(cmd)
 				if err != nil {
 					return nil // Resource not found = success
@@ -749,18 +748,18 @@ spec:
 
 		It("should properly clean up bindings when BindDefinition is deleted", func() {
 			By("Verifying ClusterRoleBindings exist")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", "complex-multi-view-binding")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", "complex-multi-view-binding")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Deleting the BindDefinition")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", "complex-multi-binding")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", "complex-multi-binding")
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying ClusterRoleBindings were deleted by finalizer")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", "complex-multi-view-binding")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", "complex-multi-view-binding")
 				_, err := utils.Run(cmd)
 				if err != nil {
 					return nil // Resource not found = success
@@ -788,7 +787,7 @@ func containsString(slice []string, s string) bool {
 //
 //nolint:unparam // clusterRoleName is intentionally a parameter for reusability.
 func countResourceInClusterRole(clusterRoleName, resourceName string) int {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", clusterRoleName, "-o", "json")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", clusterRoleName, "-o", "json")
 	output, err := utils.Run(cmd)
 	if err != nil {
 		return -1
@@ -817,7 +816,7 @@ func countResourceInClusterRole(clusterRoleName, resourceName string) int {
 // countAPIGroupInClusterRole counts how many rules reference a given API group
 // in the ClusterRole. Returns -1 if the ClusterRole cannot be fetched.
 func countAPIGroupInClusterRole(clusterRoleName, apiGroup string) int {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", clusterRoleName, "-o", "json")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", clusterRoleName, "-o", "json")
 	output, err := utils.Run(cmd)
 	if err != nil {
 		return -1

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -574,16 +574,43 @@ func ensureTestNamespace() {
 }
 
 func waitForTerminatingTestNamespace() {
-	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "namespace", testNamespace, "-o", "jsonpath={.metadata.deletionTimestamp}")
-	output, err := utils.Run(cmd)
-	if err != nil || strings.TrimSpace(string(output)) == "" {
+	var deletionTimestamp []byte
+	Eventually(func() error {
+		var err error
+		deletionTimestamp, err = getTestNamespaceDeletionTimestamp()
+		return err
+	}, shortTimeout, shortPollInterval).Should(Succeed())
+	if strings.TrimSpace(string(deletionTimestamp)) == "" {
 		return
 	}
 
 	By("Waiting for terminating test namespace to be deleted")
-	Eventually(func() bool {
-		return checkResourceExists("namespace", testNamespace, "") != nil
+	Eventually(func() (bool, error) {
+		return testNamespaceDeleted()
 	}, reconcileTimeout, pollingInterval).Should(BeTrue())
+}
+
+func getTestNamespaceDeletionTimestamp() ([]byte, error) {
+	cmd := utils.CommandContext(
+		context.Background(),
+		"kubectl",
+		"get",
+		"namespace",
+		testNamespace,
+		"--ignore-not-found=true",
+		"-o",
+		"jsonpath={.metadata.deletionTimestamp}",
+	)
+	return utils.Run(cmd)
+}
+
+func testNamespaceDeleted() (bool, error) {
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "namespace", testNamespace, "--ignore-not-found=true", "-o", "name")
+	output, err := utils.Run(cmd)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(output)) == "", nil
 }
 
 func cleanupCRDE2ETestState() {

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -5,7 +5,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -43,11 +42,11 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 		// cert-manager is installed in BeforeSuite, no need to install here
 
 		By("Creating operator namespace")
-		cmd := exec.CommandContext(context.Background(), "kubectl", "get", "ns", operatorNamespace, "-o", "name")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "get", "ns", operatorNamespace, "-o", "name")
 		if _, err := utils.Run(cmd); err != nil {
-			cmd = exec.CommandContext(context.Background(), "kubectl", "create", "ns", operatorNamespace, "--dry-run=client", "-o", "yaml")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "create", "ns", operatorNamespace, "--dry-run=client", "-o", "yaml")
 			output, _ := utils.Run(cmd)
-			cmd = exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(string(output))
 			_, _ = utils.Run(cmd)
 		}
@@ -57,22 +56,22 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 		} else {
 			// Always deploy fresh operator in dedicated cluster (no reuse)
 			By("Building the operator image")
-			cmd = exec.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+			cmd = utils.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
 			_, err := utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build operator image")
 
 			By("Loading image into kind cluster")
-			cmd = exec.CommandContext(context.Background(), "kind", "load", "docker-image", projectImage, "--name", kindClusterName)
+			cmd = utils.CommandContext(context.Background(), "kind", "load", "docker-image", projectImage, "--name", kindClusterName)
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load image into kind cluster")
 
 			By("Installing CRDs")
-			cmd = exec.CommandContext(context.Background(), "make", "install")
+			cmd = utils.CommandContext(context.Background(), "make", "install")
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to install CRDs")
 
 			By("Deploying the controller-manager")
-			cmd = exec.CommandContext(context.Background(), "make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
+			cmd = utils.CommandContext(context.Background(), "make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to deploy controller-manager")
 		}
@@ -114,7 +113,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 		}
 
 		By("Cleaning up test resources")
-		cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "-k", fixturesPath, "--ignore-not-found=true")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "-k", fixturesPath, "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 
 		// Use centralized cleanup
@@ -131,17 +130,17 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			utils.CleanupAllAuthOperatorWebhooks()
 
 			By("Undeploying controller-manager")
-			cmd = exec.CommandContext(context.Background(), "make", "undeploy", "ignore-not-found=true")
+			cmd = utils.CommandContext(context.Background(), "make", "undeploy", "ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 
 			By("Uninstalling CRDs")
-			cmd = exec.CommandContext(context.Background(), "make", "uninstall", "ignore-not-found=true")
+			cmd = utils.CommandContext(context.Background(), "make", "uninstall", "ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 
 			// cert-manager cleanup is handled in AfterSuite
 
 			By("Removing operator namespace")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "ns", operatorNamespace, "--ignore-not-found=true")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "ns", operatorNamespace, "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		}
 	})
@@ -152,7 +151,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			Expect(verifyControllerRunning()).To(Succeed())
 
 			By("Checking controller-manager logs for errors")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "logs",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "logs",
 				"-l", "control-plane=controller-manager",
 				"-n", operatorNamespace,
 				"--tail=50",
@@ -180,7 +179,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 
 			By("Verifying ClusterRole has expected rules (read-only)")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "e2e-cluster-reader", "-o", "jsonpath={.rules}")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "e2e-cluster-reader", "-o", "jsonpath={.rules}")
 				output, err := utils.Run(cmd)
 				if err != nil {
 					return false
@@ -222,7 +221,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
 
 			By("Verifying velero.io API group is excluded from ClusterRole")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "e2e-cluster-reader", "-o", "yaml")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "e2e-cluster-reader", "-o", "yaml")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(output)).NotTo(ContainSubstring("velero.io"))
@@ -253,7 +252,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			}, reconcileTimeout, pollingInterval).Should(BeTrue())
 
 			By("Verifying ClusterRoleBinding has correct subjects")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding",
 				"e2e-cluster-binding-e2e-cluster-reader-binding",
 				"-o", "jsonpath={.subjects}")
 			output, err := utils.Run(cmd)
@@ -282,7 +281,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			By("Waiting for RoleBinding to be created in labeled namespace")
 			Eventually(func() error {
 				// RoleBinding should be created in the e2e-test-ns namespace (labeled with e2e-test=true)
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "rolebinding",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "rolebinding",
 					"-l", "app.kubernetes.io/managed-by=auth-operator",
 					"-n", testNamespace,
 					"-o", "name")
@@ -321,7 +320,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 
 			By("Verifying BindDefinition status includes generated ServiceAccount")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", "e2e-test-sa-binding",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", "e2e-test-sa-binding",
 					"-o", "jsonpath={.status.generatedServiceAccounts}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -344,7 +343,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			// Note: .status.authorizerConfigured is not implemented in the controller
 
 			By("Verifying WebhookAuthorizer spec is correct")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "e2e-test-authorizer-allow",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "e2e-test-authorizer-allow",
 				"-o", "jsonpath={.spec.allowedPrincipals}")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -362,7 +361,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			// Note: .status.authorizerConfigured is not implemented in the controller
 
 			By("Verifying WebhookAuthorizer has denied principals")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "e2e-test-authorizer-deny",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "e2e-test-authorizer-deny",
 				"-o", "jsonpath={.spec.deniedPrincipals}")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -380,7 +379,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			// Note: .status.authorizerConfigured is not implemented in the controller
 
 			By("Verifying WebhookAuthorizer has non-resource rules")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "e2e-test-authorizer-nonresource",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "e2e-test-authorizer-nonresource",
 				"-o", "jsonpath={.spec.nonResourceRules}")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -402,7 +401,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			Expect(checkResourceExists("clusterrole", "e2e-cluster-reader", "")).To(Succeed())
 
 			By("Deleting the RoleDefinition")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", "e2e-test-cluster-reader")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", "e2e-test-cluster-reader")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -428,7 +427,7 @@ var _ = Describe("Auth Operator E2E", Ordered, Label("basic", "crd"), func() {
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
 
 			By("Deleting the BindDefinition")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", "e2e-test-cluster-binding", "--ignore-not-found=true")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", "e2e-test-cluster-binding", "--ignore-not-found=true")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -456,7 +455,7 @@ spec:
   targetName: invalid-role
   scopeNamespaced: false
 `
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(invalidYAML)
 			_, err := utils.Run(cmd)
 			// Should be rejected by validation webhook
@@ -481,7 +480,7 @@ spec:
     clusterRoleRefs:
       - non-existent-clusterrole
 `, bindDefName)
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(invalidBindYAML)
 			output, err := utils.Run(cmd)
 
@@ -493,7 +492,7 @@ spec:
 
 			By("Verifying the RoleRefValidCondition is set to False after reconciliation")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bindDefName,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bindDefName,
 					"-o", "jsonpath={.status.conditions[?(@.type=='RoleRefsValid')].status}")
 				statusOutput, err := utils.Run(cmd)
 				if err != nil {
@@ -504,7 +503,7 @@ spec:
 				"Expected RoleRefsValid condition to be False")
 
 			By("Cleanup")
-			cleanupCmd := exec.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", bindDefName, "--ignore-not-found=true")
+			cleanupCmd := utils.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", bindDefName, "--ignore-not-found=true")
 			_, _ = utils.Run(cleanupCmd)
 		})
 	})
@@ -513,7 +512,7 @@ spec:
 // Helper functions
 
 func verifyControllerRunning() error {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 		"-l", "control-plane=controller-manager",
 		"-n", operatorNamespace,
 		"-o", "jsonpath={.items[0].status.phase}")
@@ -529,7 +528,7 @@ func verifyControllerRunning() error {
 
 func applyFixture(filename string) {
 	fixturePath := filepath.Join(fixturesPath, filename)
-	cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", fixturePath)
+	cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", fixturePath)
 	output, err := utils.Run(cmd)
 	ExpectWithOffset(2, err).NotTo(HaveOccurred(), "Failed to apply fixture %s: %s", filename, string(output))
 }
@@ -539,14 +538,14 @@ func checkResourceExists(resourceType, name, namespace string) error {
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}
-	cmd := exec.CommandContext(context.Background(), "kubectl", args...)
+	cmd := utils.CommandContext(context.Background(), "kubectl", args...)
 	_, err := utils.Run(cmd)
 	return err
 }
 
 func checkRoleDefinitionReconciled(name string) bool {
 	// Check for the Created condition which indicates the role was created successfully
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "roledefinition", name,
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "roledefinition", name,
 		"-o", "jsonpath={.status.conditions[?(@.type=='Created')].status}")
 	output, err := utils.Run(cmd)
 	if err != nil {
@@ -557,7 +556,7 @@ func checkRoleDefinitionReconciled(name string) bool {
 
 func checkBindDefinitionReconciled(name string) bool {
 	// Check for the Created condition which indicates the binding was created successfully
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", name,
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", name,
 		"-o", "jsonpath={.status.conditions[?(@.type=='Created')].status}")
 	output, err := utils.Run(cmd)
 	if err != nil {
@@ -577,7 +576,7 @@ func cleanupCRDE2ETestState() {
 	const e2eLabelSelector = "app.kubernetes.io/component=e2e-test"
 	const managedByLabelSelector = "app.kubernetes.io/managed-by=auth-operator"
 
-	cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "-k", fixturesPath, "--ignore-not-found=true", "--wait=false", "--timeout=30s")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "-k", fixturesPath, "--ignore-not-found=true", "--wait=false", "--timeout=30s")
 	_, _ = utils.Run(cmd)
 
 	utils.RemoveFinalizersForAll("roledefinition")

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -566,10 +566,24 @@ func checkBindDefinitionReconciled(name string) bool {
 }
 
 func ensureTestNamespace() {
+	waitForTerminatingTestNamespace()
 	applyFixture("namespace_labeled.yaml")
 	Eventually(func() error {
 		return checkResourceExists("namespace", testNamespace, "")
 	}, shortTimeout, shortPollInterval).Should(Succeed())
+}
+
+func waitForTerminatingTestNamespace() {
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "namespace", testNamespace, "-o", "jsonpath={.metadata.deletionTimestamp}")
+	output, err := utils.Run(cmd)
+	if err != nil || strings.TrimSpace(string(output)) == "" {
+		return
+	}
+
+	By("Waiting for terminating test namespace to be deleted")
+	Eventually(func() bool {
+		return checkResourceExists("namespace", testNamespace, "") != nil
+	}, reconcileTimeout, pollingInterval).Should(BeTrue())
 }
 
 func cleanupCRDE2ETestState() {

--- a/test/e2e/debug_report.go
+++ b/test/e2e/debug_report.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -137,7 +136,7 @@ func collectClusterInfo() clusterInfo {
 	info := clusterInfo{}
 
 	// Get Kubernetes version
-	cmd := exec.CommandContext(context.Background(), "kubectl", "version", "-o", "json")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "version", "-o", "json")
 	output, err := utils.Run(cmd)
 	if err == nil {
 		var versionInfo map[string]interface{}
@@ -149,7 +148,7 @@ func collectClusterInfo() clusterInfo {
 	}
 
 	// Get node count and status
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "nodes", "-o", "jsonpath={.items[*].status.conditions[?(@.type=='Ready')].status}")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "nodes", "-o", "jsonpath={.items[*].status.conditions[?(@.type=='Ready')].status}")
 	output, err = utils.Run(cmd)
 	if err == nil {
 		statuses := strings.Fields(string(output))
@@ -169,7 +168,7 @@ func collectClusterInfo() clusterInfo {
 	}
 
 	// Check API server
-	cmd = exec.CommandContext(context.Background(), "kubectl", "cluster-info")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "cluster-info")
 	_, err = utils.Run(cmd)
 	info.APIServerReady = err == nil
 
@@ -180,49 +179,49 @@ func collectResourceSummary() resourceSummary {
 	summary := resourceSummary{}
 
 	// Count RoleDefinitions
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "roledefinitions", "-A", "-o", "jsonpath={.items[*].metadata.name}")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "roledefinitions", "-A", "-o", "jsonpath={.items[*].metadata.name}")
 	output, _ := utils.Run(cmd)
 	if strings.TrimSpace(string(output)) != "" {
 		summary.RoleDefinitions = len(strings.Fields(string(output)))
 	}
 
 	// Count BindDefinitions
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "binddefinitions", "-A", "-o", "jsonpath={.items[*].metadata.name}")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "binddefinitions", "-A", "-o", "jsonpath={.items[*].metadata.name}")
 	output, _ = utils.Run(cmd)
 	if strings.TrimSpace(string(output)) != "" {
 		summary.BindDefinitions = len(strings.Fields(string(output)))
 	}
 
 	// Count WebhookAuthorizers
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizers", "-A", "-o", "jsonpath={.items[*].metadata.name}")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizers", "-A", "-o", "jsonpath={.items[*].metadata.name}")
 	output, _ = utils.Run(cmd)
 	if strings.TrimSpace(string(output)) != "" {
 		summary.WebhookAuthorizers = len(strings.Fields(string(output)))
 	}
 
 	// Count generated ClusterRoles (labeled by auth-operator)
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterroles", "-l", "app.kubernetes.io/managed-by=auth-operator", "-o", "jsonpath={.items[*].metadata.name}")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterroles", "-l", "app.kubernetes.io/managed-by=auth-operator", "-o", "jsonpath={.items[*].metadata.name}")
 	output, _ = utils.Run(cmd)
 	if strings.TrimSpace(string(output)) != "" {
 		summary.GeneratedClusterRoles = len(strings.Fields(string(output)))
 	}
 
 	// Count generated Roles (labeled by auth-operator)
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "roles", "-A", "-l", "app.kubernetes.io/managed-by=auth-operator", "-o", "jsonpath={.items[*].metadata.name}")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "roles", "-A", "-l", "app.kubernetes.io/managed-by=auth-operator", "-o", "jsonpath={.items[*].metadata.name}")
 	output, _ = utils.Run(cmd)
 	if strings.TrimSpace(string(output)) != "" {
 		summary.GeneratedRoles = len(strings.Fields(string(output)))
 	}
 
 	// Get operator pod names
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "pods", "-A", "-l", "control-plane=controller-manager", "-o", "jsonpath={.items[*].metadata.name}")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "pods", "-A", "-l", "control-plane=controller-manager", "-o", "jsonpath={.items[*].metadata.name}")
 	output, _ = utils.Run(cmd)
 	if strings.TrimSpace(string(output)) != "" {
 		summary.OperatorPods = strings.Fields(string(output))
 	}
 
 	// Get webhook pod names
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "pods", "-A", "-l", "control-plane=webhook-server", "-o", "jsonpath={.items[*].metadata.name}")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "pods", "-A", "-l", "control-plane=webhook-server", "-o", "jsonpath={.items[*].metadata.name}")
 	output, _ = utils.Run(cmd)
 	if strings.TrimSpace(string(output)) != "" {
 		summary.WebhookPods = strings.Fields(string(output))
@@ -235,7 +234,7 @@ func collectRecentErrors() []errorEntry {
 	var errors []errorEntry
 
 	// Get warning/error events from last 10 minutes
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "events", "-A",
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "events", "-A",
 		"--field-selector=type!=Normal",
 		"-o", "jsonpath={range .items[*]}{.involvedObject.kind}/{.involvedObject.name}|{.message}|{.lastTimestamp}\n{end}")
 	output, _ := utils.Run(cmd)

--- a/test/e2e/dev_e2e_test.go
+++ b/test/e2e/dev_e2e_test.go
@@ -21,7 +21,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -51,7 +50,7 @@ var _ = Describe("Dev Flavor E2E - Kustomize Deploy", Ordered, Label("dev"), fun
 
 		// Always deploy fresh operator (no reuse)
 		By("Building the operator image")
-		cmd := exec.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+		cmd := utils.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
 		_, err := utils.Run(cmd)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build operator image")
 
@@ -60,12 +59,12 @@ var _ = Describe("Dev Flavor E2E - Kustomize Deploy", Ordered, Label("dev"), fun
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load image into kind cluster")
 
 		By("Installing CRDs via make install")
-		cmd = exec.CommandContext(context.Background(), "make", "install")
+		cmd = utils.CommandContext(context.Background(), "make", "install")
 		_, err = utils.Run(cmd)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to install CRDs")
 
 		By("Deploying the operator via make deploy")
-		cmd = exec.CommandContext(context.Background(), "make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
+		cmd = utils.CommandContext(context.Background(), "make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
 		_, err = utils.Run(cmd)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to deploy operator")
 
@@ -104,7 +103,7 @@ var _ = Describe("Dev Flavor E2E - Kustomize Deploy", Ordered, Label("dev"), fun
 		if utils.ShouldTeardown() {
 			Eventually(func() error {
 				attemptCtx, attemptCancel := context.WithTimeout(context.Background(), 10*time.Second)
-				cmd := exec.CommandContext(attemptCtx, "kubectl", "get", "clusterrole",
+				cmd := utils.CommandContext(attemptCtx, "kubectl", "get", "clusterrole",
 					"-l", "app.kubernetes.io/managed-by=auth-operator", "--ignore-not-found=true", "-o", "name")
 				out, err := utils.Run(cmd)
 				attemptCancel()
@@ -122,16 +121,16 @@ var _ = Describe("Dev Flavor E2E - Kustomize Deploy", Ordered, Label("dev"), fun
 			utils.CleanupAllAuthOperatorWebhooks()
 
 			By("Undeploying the operator")
-			cmd := exec.CommandContext(context.Background(), "make", "undeploy", "ignore-not-found=true")
+			cmd := utils.CommandContext(context.Background(), "make", "undeploy", "ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 
 			By("Uninstalling CRDs")
-			cmd = exec.CommandContext(context.Background(), "make", "uninstall", "ignore-not-found=true")
+			cmd = utils.CommandContext(context.Background(), "make", "uninstall", "ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		}
 
 		By("Cleaning up test namespace")
-		cleanupCmd := exec.CommandContext(context.Background(), "kubectl", "delete", "ns", devTestNamespace, "--ignore-not-found=true")
+		cleanupCmd := utils.CommandContext(context.Background(), "kubectl", "delete", "ns", devTestNamespace, "--ignore-not-found=true")
 		_, _ = utils.Run(cleanupCmd)
 	})
 
@@ -143,17 +142,17 @@ var _ = Describe("Dev Flavor E2E - Kustomize Deploy", Ordered, Label("dev"), fun
 
 		It("should have CRDs installed", func() {
 			By("Checking RoleDefinition CRD exists")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "crd", "roledefinitions.authorization.t-caas.telekom.com")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "crd", "roledefinitions.authorization.t-caas.telekom.com")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking BindDefinition CRD exists")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "crd", "binddefinitions.authorization.t-caas.telekom.com")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "crd", "binddefinitions.authorization.t-caas.telekom.com")
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking WebhookAuthorizer CRD exists")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "crd", "webhookauthorizers.authorization.t-caas.telekom.com")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "crd", "webhookauthorizers.authorization.t-caas.telekom.com")
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -177,7 +176,7 @@ spec:
     - delete
     - patch
 `
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(roleDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -189,7 +188,7 @@ spec:
 
 			By("Verifying ClusterRole has expected rules (read-only, no create/update/delete/patch)")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "dev-e2e-generated-clusterrole", "-o", "jsonpath={.rules}")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "dev-e2e-generated-clusterrole", "-o", "jsonpath={.rules}")
 				output, err := utils.Run(cmd)
 				if err != nil {
 					return false
@@ -233,7 +232,7 @@ spec:
     clusterRoleRefs:
       - dev-e2e-generated-clusterrole
 `
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(bindDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -245,14 +244,14 @@ spec:
 			}, reconcileTimeoutDv, pollingIntervalDev).Should(Succeed())
 
 			By("Verifying ClusterRoleBinding has correct subjects and roleRef")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", expectedCRBName, "-o", "jsonpath={.subjects}")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", expectedCRBName, "-o", "jsonpath={.subjects}")
 			subjectsOutput, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			subjects := string(subjectsOutput)
 			Expect(subjects).To(ContainSubstring("dev-e2e-user@example.com"), "ClusterRoleBinding should contain User subject")
 			Expect(subjects).To(ContainSubstring("dev-e2e-group"), "ClusterRoleBinding should contain Group subject")
 
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", expectedCRBName, "-o", "jsonpath={.roleRef.name}")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", expectedCRBName, "-o", "jsonpath={.roleRef.name}")
 			roleRefOutput, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(roleRefOutput)).To(Equal("dev-e2e-generated-clusterrole"), "ClusterRoleBinding should reference correct ClusterRole")
@@ -284,7 +283,7 @@ spec:
   allowedPrincipals:
     - user: dev-allowed-user
 `
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(authorizerYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -295,7 +294,7 @@ spec:
 			}, reconcileTimeoutDv, pollingIntervalDev).Should(Succeed())
 
 			By("Verifying WebhookAuthorizer has correct spec fields")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "dev-e2e-authorizer", "-o", "jsonpath={.spec.resourceRules}")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "dev-e2e-authorizer", "-o", "jsonpath={.spec.resourceRules}")
 			rulesOutput, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			rules := string(rulesOutput)
@@ -303,7 +302,7 @@ spec:
 			Expect(rules).To(ContainSubstring("get"), "WebhookAuthorizer should have get verb")
 			Expect(rules).To(ContainSubstring("list"), "WebhookAuthorizer should have list verb")
 
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "dev-e2e-authorizer", "-o", "jsonpath={.spec.allowedPrincipals}")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "dev-e2e-authorizer", "-o", "jsonpath={.spec.allowedPrincipals}")
 			principalsOutput, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(principalsOutput)).To(ContainSubstring("dev-allowed-user"), "WebhookAuthorizer should have correct allowedPrincipals")
@@ -316,7 +315,7 @@ spec:
 			Expect(checkResourceExists("clusterrole", "dev-e2e-generated-clusterrole", "")).To(Succeed())
 
 			By("Deleting the RoleDefinition")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", "dev-e2e-cluster-reader")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", "dev-e2e-cluster-reader")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -333,7 +332,7 @@ spec:
 })
 
 func verifyDevControllerRunning(namespace string) error {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 		"-l", "control-plane=controller-manager",
 		"-n", namespace,
 		"-o", "jsonpath={.items[0].status.phase}")
@@ -348,13 +347,13 @@ func verifyDevControllerRunning(namespace string) error {
 }
 
 func createDevTestNamespace(namespace string) {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "create", "ns", namespace, "--dry-run=client", "-o", "yaml")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "create", "ns", namespace, "--dry-run=client", "-o", "yaml")
 	output, _ := utils.Run(cmd)
 
-	cmd = exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 	cmd.Stdin = strings.NewReader(string(output))
 	_, _ = utils.Run(cmd)
 
-	cmd = exec.CommandContext(context.Background(), "kubectl", "label", "ns", namespace, "dev-e2e-test=true", "--overwrite")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "label", "ns", namespace, "dev-e2e-test=true", "--overwrite")
 	_, _ = utils.Run(cmd)
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -99,14 +98,14 @@ var _ = BeforeSuite(func() {
 
 	By("Waiting for cluster to be fully ready")
 	Eventually(func() error {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "cluster-info")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "cluster-info")
 		_, err := utils.Run(cmd)
 		return err
 	}, 2*time.Minute, 5*time.Second).Should(Succeed(), "Kubernetes cluster not available")
 
 	By("Waiting for API server to be ready")
 	Eventually(func() error {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "get", "nodes", "-o", "name")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "get", "nodes", "-o", "name")
 		_, err := utils.Run(cmd)
 		return err
 	}, 2*time.Minute, 5*time.Second).Should(Succeed(), "Cannot connect to API server")
@@ -240,25 +239,25 @@ func printEnvironmentInfo() {
 	}
 
 	// Print Go version
-	cmd := exec.CommandContext(context.Background(), "go", "version")
+	cmd := utils.CommandContext(context.Background(), "go", "version")
 	if output, err := cmd.CombinedOutput(); err == nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "  Go: %s", string(output))
 	}
 
 	// Print kubectl version
-	cmd = exec.CommandContext(context.Background(), "kubectl", "version", "--client", "--short")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "version", "--client", "--short")
 	if output, err := cmd.CombinedOutput(); err == nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "  kubectl: %s", string(output))
 	}
 
 	// Print kind version
-	cmd = exec.CommandContext(context.Background(), "kind", "version")
+	cmd = utils.CommandContext(context.Background(), "kind", "version")
 	if output, err := cmd.CombinedOutput(); err == nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "  kind: %s", string(output))
 	}
 
 	// Print docker version
-	cmd = exec.CommandContext(context.Background(), "docker", "version", "--format", "{{.Server.Version}}")
+	cmd = utils.CommandContext(context.Background(), "docker", "version", "--format", "{{.Server.Version}}")
 	if output, err := cmd.CombinedOutput(); err == nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "  docker: %s\n", string(output))
 	}
@@ -271,19 +270,19 @@ func printClusterState() {
 	_, _ = fmt.Fprintf(GinkgoWriter, "\n=== Initial Cluster State ===\n")
 
 	// Nodes
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "nodes", "-o", "wide")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "nodes", "-o", "wide")
 	if output, err := cmd.CombinedOutput(); err == nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Nodes:\n%s\n", string(output))
 	}
 
 	// Namespaces
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "namespaces")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "namespaces")
 	if output, err := cmd.CombinedOutput(); err == nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Namespaces:\n%s\n", string(output))
 	}
 
 	// CRDs
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "crds")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "crds")
 	if output, err := cmd.CombinedOutput(); err == nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "CRDs:\n%s\n", string(output))
 	}
@@ -301,7 +300,7 @@ func cleanupPreExistingInstallations() {
 	utils.CleanupAllAuthOperatorWebhooks()
 
 	// Check for helm releases
-	cmd := exec.CommandContext(context.Background(), "helm", "list", "-A", "-o", "json")
+	cmd := utils.CommandContext(context.Background(), "helm", "list", "-A", "-o", "json")
 	if output, err := cmd.CombinedOutput(); err == nil {
 		outputStr := string(output)
 		// Simple check for auth-operator releases
@@ -316,7 +315,7 @@ func cleanupPreExistingInstallations() {
 				{"auth-operator-ha", "auth-operator-ha"},
 			}
 			for _, r := range releases {
-				uninstallCmd := exec.CommandContext(context.Background(), "helm", "uninstall", r.name, "-n", r.ns)
+				uninstallCmd := utils.CommandContext(context.Background(), "helm", "uninstall", r.name, "-n", r.ns)
 				_, _ = uninstallCmd.CombinedOutput() // Ignore errors
 			}
 		}
@@ -341,14 +340,14 @@ func cleanupPreExistingInstallations() {
 		"complex-team-beta",
 	}
 	for _, ns := range testNamespaces {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "ns", ns, "--ignore-not-found=true", "--wait=false")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "ns", ns, "--ignore-not-found=true", "--wait=false")
 		_, _ = cmd.CombinedOutput()
 	}
 
 	Eventually(func() error {
 		for _, ns := range testNamespaces {
 			attemptCtx, attemptCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			cmd := exec.CommandContext(attemptCtx, "kubectl", "get", "ns", ns, "--ignore-not-found", "-o", "name")
+			cmd := utils.CommandContext(attemptCtx, "kubectl", "get", "ns", ns, "--ignore-not-found", "-o", "name")
 			out, err := cmd.Output()
 			attemptCancel()
 			if err != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -5,7 +5,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os/exec"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,27 +19,27 @@ var _ = Describe("Operator Setup", Ordered, Label("setup"), func() {
 
 	Context("Prerequisites", func() {
 		It("should have kubectl available", func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "version", "--client")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "version", "--client")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(output)).To(ContainSubstring("Client Version"))
 		})
 
 		It("should have kind available", func() {
-			cmd := exec.CommandContext(context.Background(), "kind", "version")
+			cmd := utils.CommandContext(context.Background(), "kind", "version")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(output)).To(ContainSubstring("kind"))
 		})
 
 		It("should have docker available", func() {
-			cmd := exec.CommandContext(context.Background(), "docker", "version", "--format", "{{.Server.Version}}")
+			cmd := utils.CommandContext(context.Background(), "docker", "version", "--format", "{{.Server.Version}}")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should have a running kind cluster", func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "cluster-info")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "cluster-info")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "No Kubernetes cluster available. Run 'make kind-create' first.")
 			Expect(string(output)).To(ContainSubstring("Kubernetes"))
@@ -49,7 +48,7 @@ var _ = Describe("Operator Setup", Ordered, Label("setup"), func() {
 
 	Context("CRDs", func() {
 		It("should have RoleDefinition CRD installed", func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "crd", "roledefinitions.authorization.t-caas.telekom.com")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "crd", "roledefinitions.authorization.t-caas.telekom.com")
 			_, err := utils.Run(cmd)
 			if err != nil {
 				Skip("CRDs not installed yet - run 'make install' first")
@@ -57,7 +56,7 @@ var _ = Describe("Operator Setup", Ordered, Label("setup"), func() {
 		})
 
 		It("should have BindDefinition CRD installed", func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "crd", "binddefinitions.authorization.t-caas.telekom.com")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "crd", "binddefinitions.authorization.t-caas.telekom.com")
 			_, err := utils.Run(cmd)
 			if err != nil {
 				Skip("CRDs not installed yet - run 'make install' first")
@@ -65,7 +64,7 @@ var _ = Describe("Operator Setup", Ordered, Label("setup"), func() {
 		})
 
 		It("should have WebhookAuthorizer CRD installed", func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "crd", "webhookauthorizers.authorization.t-caas.telekom.com")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "crd", "webhookauthorizers.authorization.t-caas.telekom.com")
 			_, err := utils.Run(cmd)
 			if err != nil {
 				Skip("CRDs not installed yet - run 'make install' first")
@@ -75,7 +74,7 @@ var _ = Describe("Operator Setup", Ordered, Label("setup"), func() {
 
 	Context("Operator Deployment", func() {
 		It("should have the controller-manager deployment", func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "deployment",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "deployment",
 				"-l", "control-plane=controller-manager",
 				"-n", "auth-operator-system",
 				"-o", "name")
@@ -87,7 +86,7 @@ var _ = Describe("Operator Setup", Ordered, Label("setup"), func() {
 		})
 
 		It("should have controller-manager pod running", func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 				"-l", "control-plane=controller-manager",
 				"-n", "auth-operator-system",
 				"-o", "jsonpath={.items[0].status.phase}")
@@ -102,7 +101,7 @@ var _ = Describe("Operator Setup", Ordered, Label("setup"), func() {
 
 var _ = Describe("API Versions", Label("api"), func() {
 	It("should support authorization.t-caas.telekom.com/v1alpha1", func() {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "api-resources",
+		cmd := utils.CommandContext(context.Background(), "kubectl", "api-resources",
 			"--api-group=authorization.t-caas.telekom.com",
 			"-o", "name")
 		output, err := utils.Run(cmd)
@@ -116,7 +115,7 @@ var _ = Describe("API Versions", Label("api"), func() {
 	})
 
 	It("should have correct short names", func() {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "api-resources",
+		cmd := utils.CommandContext(context.Background(), "kubectl", "api-resources",
 			"--api-group=authorization.t-caas.telekom.com",
 			"-o", "wide")
 		output, err := utils.Run(cmd)
@@ -156,18 +155,18 @@ var _ = Describe("Debug Info", Label("debug"), func() {
 		By("Getting all auth-operator resources")
 		resources := []string{"roledefinitions", "binddefinitions", "webhookauthorizers"}
 		for _, r := range resources {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", r, "-A", "-o", "wide")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", r, "-A", "-o", "wide")
 			output, _ := utils.Run(cmd)
 			_, _ = fmt.Fprintf(GinkgoWriter, "\n=== %s ===\n%s\n", r, string(output))
 		}
 
 		By("Getting operator pods in all namespaces")
-		cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods", "-A", "-l", "control-plane", "-o", "wide")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods", "-A", "-l", "control-plane", "-o", "wide")
 		output, _ := utils.Run(cmd)
 		_, _ = fmt.Fprintf(GinkgoWriter, "\n=== Operator Pods ===\n%s\n", string(output))
 
 		By("Getting recent events")
-		cmd = exec.CommandContext(context.Background(), "kubectl", "get", "events", "-A", "--sort-by=.lastTimestamp", "--field-selector=type!=Normal")
+		cmd = utils.CommandContext(context.Background(), "kubectl", "get", "events", "-A", "--sort-by=.lastTimestamp", "--field-selector=type!=Normal")
 		output, _ = utils.Run(cmd)
 		_, _ = fmt.Fprintf(GinkgoWriter, "\n=== Recent Warning/Error Events ===\n%s\n", string(output))
 	})

--- a/test/e2e/edge_case_e2e_test.go
+++ b/test/e2e/edge_case_e2e_test.go
@@ -11,7 +11,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -60,7 +59,7 @@ var _ = Describe("Edge Case - Deletion and Shared Resources", Ordered, Label("co
 			imageTag = defaultImageTag
 		}
 
-		cmd := exec.CommandContext(context.Background(), "helm", "upgrade", "--install", edgeCaseRelease, helmChartPath,
+		cmd := utils.CommandContext(context.Background(), "helm", "upgrade", "--install", edgeCaseRelease, helmChartPath,
 			"-n", edgeCaseOperatorNS,
 			"--create-namespace",
 			"--set", fmt.Sprintf("image.repository=%s", imageRepo),
@@ -81,7 +80,7 @@ var _ = Describe("Edge Case - Deletion and Shared Resources", Ordered, Label("co
 
 		By("Waiting for controller to be ready")
 		Eventually(func() error {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 				"-l", "control-plane=controller-manager",
 				"-n", edgeCaseOperatorNS,
 				"-o", "jsonpath={.items[*].status.phase}")
@@ -107,20 +106,20 @@ var _ = Describe("Edge Case - Deletion and Shared Resources", Ordered, Label("co
 		By("Cleaning up edge-case test resources")
 
 		for _, name := range []string{bdSharedA, bdSharedB, bdMissingRef, bdPreExistingSA} {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", name, "--ignore-not-found=true")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", name, "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		}
 
-		cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", healingRDName, "--ignore-not-found=true")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", healingRDName, "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 
-		cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "sa", sharedSAName, "-n", edgeCaseNS, "--ignore-not-found=true")
+		cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "sa", sharedSAName, "-n", edgeCaseNS, "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 
-		cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "sa", preExistingSAName, "-n", edgeCaseNS, "--ignore-not-found=true")
+		cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "sa", preExistingSAName, "-n", edgeCaseNS, "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 
-		cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrole", healingClusterRole, "--ignore-not-found=true")
+		cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrole", healingClusterRole, "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 
 		for _, crbSuffix := range []string{
@@ -129,18 +128,18 @@ var _ = Describe("Edge Case - Deletion and Shared Resources", Ordered, Label("co
 			fmt.Sprintf("e2e-missing-target-%s-binding", healingClusterRole),
 			"e2e-preexisting-target-view-binding",
 		} {
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrolebinding", crbSuffix, "--ignore-not-found=true")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrolebinding", crbSuffix, "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		}
 
 		// Clean up cluster-scoped RBAC resources created by this operator instance
-		cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrolebinding",
+		cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrolebinding",
 			"-l", "app.kubernetes.io/managed-by=auth-operator", "--ignore-not-found=true")
 		_, _ = utils.Run(cmd)
 
 		Eventually(func() error {
 			attemptCtx, attemptCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			cmd := exec.CommandContext(attemptCtx, "kubectl", "get", "clusterrolebinding",
+			cmd := utils.CommandContext(attemptCtx, "kubectl", "get", "clusterrolebinding",
 				"-l", "app.kubernetes.io/managed-by=auth-operator", "--ignore-not-found=true", "-o", "name")
 			out, err := utils.Run(cmd)
 			attemptCancel()
@@ -154,12 +153,12 @@ var _ = Describe("Edge Case - Deletion and Shared Resources", Ordered, Label("co
 		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 
 		By("Uninstalling edge-case Helm release")
-		cmd = exec.CommandContext(context.Background(), "helm", "uninstall", edgeCaseRelease, "-n", edgeCaseOperatorNS, "--wait", "--timeout", "2m")
+		cmd = utils.CommandContext(context.Background(), "helm", "uninstall", edgeCaseRelease, "-n", edgeCaseOperatorNS, "--wait", "--timeout", "2m")
 		_, _ = utils.Run(cmd)
 
 		By("Cleaning up edge-case namespaces")
 		for _, ns := range []string{edgeCaseOperatorNS, edgeCaseNS} {
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "ns", ns, "--ignore-not-found=true")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "ns", ns, "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		}
 	})
@@ -206,7 +205,7 @@ spec:
 			By("Waiting for both BDs to become Ready")
 			for _, bdName := range []string{bdSharedA, bdSharedB} {
 				Eventually(func() bool {
-					cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdName,
+					cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdName,
 						"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
 					output, err := utils.Run(cmd)
 					if err != nil {
@@ -218,18 +217,18 @@ spec:
 			}
 
 			By("Verifying shared SA exists")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "sa", sharedSAName, "-n", edgeCaseNS)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "sa", sharedSAName, "-n", edgeCaseNS)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Shared SA should exist")
 
 			By("Deleting BD-A while BD-B still references the same SA")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", bdSharedA)
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", bdSharedA)
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for BD-A to be fully deleted")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdSharedA)
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdSharedA)
 				_, err := utils.Run(cmd)
 				if err != nil {
 					return nil // NotFound = success
@@ -238,18 +237,18 @@ spec:
 			}, reconcileTimeout, pollInterval).Should(Succeed())
 
 			By("Verifying shared SA is PRESERVED because BD-B still references it")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "sa", sharedSAName, "-n", edgeCaseNS)
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "sa", sharedSAName, "-n", edgeCaseNS)
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Shared SA should be preserved when another BD still references it")
 
 			By("Deleting BD-B - now the SA should be removed")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", bdSharedB)
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", bdSharedB)
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying shared SA is now DELETED")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "sa", sharedSAName, "-n", edgeCaseNS)
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "sa", sharedSAName, "-n", edgeCaseNS)
 				_, err := utils.Run(cmd)
 				if err != nil {
 					return nil // NotFound = success
@@ -291,7 +290,7 @@ spec:
 
 			By("Waiting for BD to become Ready")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdPreExistingSA,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdPreExistingSA,
 					"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -301,14 +300,14 @@ spec:
 			}, reconcileTimeout, pollInterval).Should(BeTrue())
 
 			By("Deleting the BindDefinition")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", bdPreExistingSA)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", bdPreExistingSA)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the pre-existing SA is preserved (no OwnerRef)")
 			// The SA must never be deleted — use Consistently to verify stability over time
 			Consistently(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "sa", preExistingSAName, "-n", edgeCaseNS)
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "sa", preExistingSAName, "-n", edgeCaseNS)
 				_, err := utils.Run(cmd)
 				return err
 			}, 10*time.Second, 2*time.Second).Should(Succeed(), "Pre-existing SA must NOT be deleted by finalizer")
@@ -337,7 +336,7 @@ spec:
 
 			By("Verifying RoleRefsValid starts as False")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdMissingRef,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdMissingRef,
 					"-o", "jsonpath={.status.conditions[?(@.type=='RoleRefsValid')].status}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -348,7 +347,7 @@ spec:
 				"RoleRefsValid should be False when referenced ClusterRole does not exist")
 
 			By("Verifying Ready is True despite missing refs (controller still creates bindings)")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdMissingRef,
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdMissingRef,
 				"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -370,14 +369,14 @@ spec:
 
 			By("Waiting for the ClusterRole to be created by RoleDefinition")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", healingClusterRole)
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", healingClusterRole)
 				_, err := utils.Run(cmd)
 				return err
 			}, reconcileTimeout, pollInterval).Should(Succeed())
 
 			By("Verifying RoleRefsValid self-heals to True after the role is created")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdMissingRef,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", bdMissingRef,
 					"-o", "jsonpath={.status.conditions[?(@.type=='RoleRefsValid')].status}")
 				output, err := utils.Run(cmd)
 				if err != nil {

--- a/test/e2e/golden_e2e_test.go
+++ b/test/e2e/golden_e2e_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -56,27 +55,27 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 		Expect(testdataPath).To(BeADirectory(), "testdata directory must exist")
 
 		By("Creating test namespace")
-		cmd := exec.CommandContext(context.Background(), "kubectl", "create", "ns", goldenNamespace, "--dry-run=client", "-o", "yaml")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "create", "ns", goldenNamespace, "--dry-run=client", "-o", "yaml")
 		output, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred())
 
-		cmd = exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+		cmd = utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 		cmd.Stdin = strings.NewReader(string(output))
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Installing auth-operator via Helm")
 		// Build the docker image first
-		cmd = exec.CommandContext(context.Background(), "make", "docker-build", "IMG=auth-operator:e2e-test")
+		cmd = utils.CommandContext(context.Background(), "make", "docker-build", "IMG=auth-operator:e2e-test")
 		cmd.Dir = filepath.Join(testdataPath, "../..")
 		_, _ = utils.Run(cmd) // Ignore if already built
 
 		// Load image to kind
-		cmd = exec.CommandContext(context.Background(), "kind", "load", "docker-image", "auth-operator:e2e-test", "--name", kindClusterName)
+		cmd = utils.CommandContext(context.Background(), "kind", "load", "docker-image", "auth-operator:e2e-test", "--name", kindClusterName)
 		_, _ = utils.Run(cmd)
 
 		// Install Helm chart
-		cmd = exec.CommandContext(context.Background(), "helm", "upgrade", "--install", goldenRelease, helmChartPath,
+		cmd = utils.CommandContext(context.Background(), "helm", "upgrade", "--install", goldenRelease, helmChartPath,
 			"-n", goldenNamespace,
 			"--set", "image.repository=auth-operator",
 			"--set", "image.tag=e2e-test",
@@ -129,7 +128,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 		It("should generate ClusterRole with correct structure", func() {
 			By("Applying RoleDefinition input")
 			inputPath := filepath.Join(testdataPath, "roledefinition-clusterrole-input.yaml")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath, "-n", goldenNamespace)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath, "-n", goldenNamespace)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -140,13 +139,13 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 
 			By("Verifying ClusterRole was created")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "golden-cluster-reader", "-o", "json")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "golden-cluster-reader", "-o", "json")
 				_, err := utils.Run(cmd)
 				return err
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
 
 			By("Comparing generated ClusterRole structure")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "golden-cluster-reader", "-o", "json")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "golden-cluster-reader", "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -186,7 +185,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 		It("should generate Role in target namespace", func() {
 			By("Applying namespaced RoleDefinition input")
 			inputPath := filepath.Join(testdataPath, "roledefinition-namespaced-role-input.yaml")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath, "-n", goldenNamespace)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath, "-n", goldenNamespace)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -197,13 +196,13 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 
 			By("Verifying Role was created in target namespace")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "role", "golden-ns-reader", "-n", goldenNamespace, "-o", "json")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "role", "golden-ns-reader", "-n", goldenNamespace, "-o", "json")
 				_, err := utils.Run(cmd)
 				return err
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
 
 			By("Comparing generated Role structure")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "role", "golden-ns-reader", "-n", goldenNamespace, "-o", "json")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "role", "golden-ns-reader", "-n", goldenNamespace, "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -244,7 +243,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 		It("should generate ClusterRoleBinding with correct subjects", func() {
 			By("Applying BindDefinition input")
 			inputPath := filepath.Join(testdataPath, "binddefinition-input.yaml")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath, "-n", goldenNamespace)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath, "-n", goldenNamespace)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -257,7 +256,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 			// ClusterRoleBinding name format: {targetName}-{clusterRoleRef}-binding
 			crbName := "golden-bind-golden-cluster-reader-binding"
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "json")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "json")
 				_, err := utils.Run(cmd)
 				return err
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
@@ -267,7 +266,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 			expectedBytes, err := os.ReadFile(expectedPath)
 			Expect(err).NotTo(HaveOccurred())
 
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "json")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "json")
 			actualOutput, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -305,7 +304,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 		It("should exclude entire API groups from generated ClusterRole", func() {
 			By("Applying RoleDefinition with restrictedApis")
 			inputPath := filepath.Join(testdataPath, "golden/roledefinition-restricted-apis-input.yaml")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -316,13 +315,13 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 
 			By("Verifying ClusterRole was created")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "golden-restricted-apis-role", "-o", "json")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "golden-restricted-apis-role", "-o", "json")
 				_, err := utils.Run(cmd)
 				return err
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
 
 			By("Verifying excluded API groups are not present")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "golden-restricted-apis-role", "-o", "json")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", "golden-restricted-apis-role", "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -349,7 +348,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 		It("should exclude specific resources from generated Role", func() {
 			By("Applying RoleDefinition with restrictedResources")
 			inputPath := filepath.Join(testdataPath, "golden/roledefinition-restricted-resources-input.yaml")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -360,14 +359,14 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 
 			By("Verifying Role was created in namespace")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "role",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "role",
 					"golden-restricted-resources-role", "-n", goldenNamespace, "-o", "json")
 				_, err := utils.Run(cmd)
 				return err
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
 
 			By("Verifying excluded resources are not present")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "role", "golden-restricted-resources-role", "-n", goldenNamespace, "-o", "json")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "role", "golden-restricted-resources-role", "-n", goldenNamespace, "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -394,7 +393,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 		It("should create multiple ClusterRoleBindings", func() {
 			By("Applying BindDefinition with multiple clusterRoleRefs")
 			inputPath := filepath.Join(testdataPath, "golden/binddefinition-multi-clusterroles-input.yaml")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -411,7 +410,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 			}
 			for _, crbName := range expectedCRBs {
 				Eventually(func() error {
-					cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "name")
+					cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "name")
 					_, err := utils.Run(cmd)
 					return err
 				}, reconcileTimeout, pollingInterval).Should(Succeed(), fmt.Sprintf("ClusterRoleBinding %s should exist", crbName))
@@ -419,7 +418,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 
 			By("Verifying subjects are consistent across all bindings")
 			for _, crbName := range expectedCRBs {
-				cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "json")
+				cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "json")
 				output, err := utils.Run(cmd)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -450,7 +449,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 		It("should create ClusterRoleBinding with User, Group, and ServiceAccount subjects", func() {
 			By("Applying BindDefinition with mixed subjects")
 			inputPath := filepath.Join(testdataPath, "golden/binddefinition-mixed-subjects-input.yaml")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -462,13 +461,13 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 			By("Verifying ClusterRoleBinding was created")
 			crbName := "golden-mixed-golden-cluster-reader-binding"
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "json")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "json")
 				_, err := utils.Run(cmd)
 				return err
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
 
 			By("Verifying all subject types are present")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "json")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName, "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -493,7 +492,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 			serviceAccounts := []string{"golden-app-sa", "golden-worker-sa"}
 			for _, saName := range serviceAccounts {
 				Eventually(func() error {
-					cmd := exec.CommandContext(context.Background(), "kubectl", "get", "serviceaccount",
+					cmd := utils.CommandContext(context.Background(), "kubectl", "get", "serviceaccount",
 						saName, "-n", goldenNamespace, "-o", "name")
 					_, err := utils.Run(cmd)
 					return err
@@ -507,19 +506,19 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 		It("should create WebhookAuthorizer with group principals", func() {
 			By("Applying WebhookAuthorizer with group-based rules")
 			inputPath := filepath.Join(testdataPath, "golden/webhookauthorizer-group-based-input.yaml")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying WebhookAuthorizer was created")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-group-authorizer", "-o", "json")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-group-authorizer", "-o", "json")
 				_, err := utils.Run(cmd)
 				return err
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
 
 			By("Verifying spec has correct structure")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-group-authorizer", "-o", "json")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-group-authorizer", "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -550,19 +549,19 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 		It("should create WebhookAuthorizer with deny list", func() {
 			By("Applying WebhookAuthorizer with deniedPrincipals")
 			inputPath := filepath.Join(testdataPath, "golden/webhookauthorizer-deny-list-input.yaml")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying WebhookAuthorizer was created")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-deny-authorizer", "-o", "json")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-deny-authorizer", "-o", "json")
 				_, err := utils.Run(cmd)
 				return err
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
 
 			By("Verifying deniedPrincipals are set")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-deny-authorizer", "-o", "json")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-deny-authorizer", "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -580,19 +579,19 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 		It("should create WebhookAuthorizer with namespaceSelector", func() {
 			By("Applying WebhookAuthorizer with namespaceSelector")
 			inputPath := filepath.Join(testdataPath, "golden/webhookauthorizer-namespace-selector-input.yaml")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", inputPath)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying WebhookAuthorizer was created")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-ns-scoped-authorizer", "-o", "json")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-ns-scoped-authorizer", "-o", "json")
 				_, err := utils.Run(cmd)
 				return err
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
 
 			By("Verifying namespaceSelector is set")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-ns-scoped-authorizer", "-o", "json")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "golden-ns-scoped-authorizer", "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -612,7 +611,7 @@ var _ = Describe("Golden File Comparison Tests", Ordered, Label("golden"), func(
 // Helper functions
 
 func verifyGoldenControllerReady(namespace string) error {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 		"-l", "control-plane=controller-manager",
 		"-n", namespace,
 		"-o", "jsonpath={.items[*].status.phase}")
@@ -627,7 +626,7 @@ func verifyGoldenControllerReady(namespace string) error {
 }
 
 func checkGoldenRoleDefinitionCreated(name, namespace string) bool {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "roledefinition", name,
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "roledefinition", name,
 		"-n", namespace,
 		"-o", "jsonpath={.status.conditions[?(@.type=='Created')].status}")
 	output, err := utils.Run(cmd)
@@ -638,7 +637,7 @@ func checkGoldenRoleDefinitionCreated(name, namespace string) bool {
 }
 
 func checkGoldenBindDefinitionCreated(name, namespace string) bool {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", name,
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", name,
 		"-n", namespace,
 		"-o", "jsonpath={.status.conditions[?(@.type=='Created')].status}")
 	output, err := utils.Run(cmd)

--- a/test/e2e/ha_e2e_test.go
+++ b/test/e2e/ha_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -35,19 +34,19 @@ var _ = Describe("Leader Election and HA E2E", Ordered, Label("ha", "leader-elec
 
 		By("Creating HA test namespaces")
 		for _, ns := range []string{haNamespace, haTestNamespace} {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "create", "ns", ns, "--dry-run=client", "-o", "yaml")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "create", "ns", ns, "--dry-run=client", "-o", "yaml")
 			output, _ := utils.Run(cmd)
-			cmd = exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(string(output))
 			_, _ = utils.Run(cmd)
 		}
 
 		By("Labeling test namespace")
-		cmd := exec.CommandContext(context.Background(), "kubectl", "label", "ns", haTestNamespace, "e2e-ha-test=true", "--overwrite")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "label", "ns", haTestNamespace, "e2e-ha-test=true", "--overwrite")
 		_, _ = utils.Run(cmd)
 
 		By("Building the operator image")
-		cmd = exec.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+		cmd = utils.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
 		_, err = utils.Run(cmd)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build operator image")
 
@@ -72,12 +71,12 @@ var _ = Describe("Leader Election and HA E2E", Ordered, Label("ha", "leader-elec
 		CleanupForHelmTests(haNamespace, haHelmRelease)
 
 		By("Cleaning up Helm release")
-		cmd := exec.CommandContext(context.Background(), "helm", "uninstall", haHelmRelease, "-n", haNamespace, "--wait", "--timeout", "2m")
+		cmd := utils.CommandContext(context.Background(), "helm", "uninstall", haHelmRelease, "-n", haNamespace, "--wait", "--timeout", "2m")
 		_, _ = utils.Run(cmd)
 
 		By("Cleaning up namespaces")
 		for _, ns := range []string{haNamespace, haTestNamespace} {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "ns", ns, "--ignore-not-found=true")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "ns", ns, "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		}
 
@@ -90,7 +89,7 @@ var _ = Describe("Leader Election and HA E2E", Ordered, Label("ha", "leader-elec
 			imageRepo := strings.Split(projectImage, ":")[0]
 			imageTag := getImageTag()
 
-			cmd := exec.CommandContext(context.Background(), "helm", "install", haHelmRelease, helmChartPath,
+			cmd := utils.CommandContext(context.Background(), "helm", "install", haHelmRelease, helmChartPath,
 				"-n", haNamespace,
 				"--create-namespace",
 				"--set", fmt.Sprintf("image.repository=%s", imageRepo),
@@ -111,7 +110,7 @@ var _ = Describe("Leader Election and HA E2E", Ordered, Label("ha", "leader-elec
 		It("should have 3 controller pods running", func() {
 			By("Waiting for all 3 controller pods to be running")
 			Eventually(func() int {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 					"-l", "control-plane=controller-manager",
 					"-n", haNamespace,
 					"-o", "jsonpath={.items[*].status.phase}")
@@ -133,7 +132,7 @@ var _ = Describe("Leader Election and HA E2E", Ordered, Label("ha", "leader-elec
 		It("should have exactly one leader", func() {
 			By("Checking leader election lease")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "lease",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "lease",
 					"-n", haNamespace,
 					"-o", "jsonpath={.items[*].spec.holderIdentity}")
 				output, err := utils.Run(cmd)
@@ -144,7 +143,7 @@ var _ = Describe("Leader Election and HA E2E", Ordered, Label("ha", "leader-elec
 			}, reconcileTimeout, pollingInterval).Should(BeTrue())
 
 			By("Verifying leader logs show leadership acquired")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "logs",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "logs",
 				"-l", "control-plane=controller-manager",
 				"-n", haNamespace,
 				"--tail=100")
@@ -159,7 +158,7 @@ var _ = Describe("Leader Election and HA E2E", Ordered, Label("ha", "leader-elec
 		It("should have 3 webhook pods running", func() {
 			By("Waiting for all 3 webhook pods to be running")
 			Eventually(func() int {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 					"-l", "control-plane=webhook-server",
 					"-n", haNamespace,
 					"-o", "jsonpath={.items[*].status.phase}")
@@ -187,7 +186,7 @@ var _ = Describe("Leader Election and HA E2E", Ordered, Label("ha", "leader-elec
 		It("should have PodDisruptionBudgets configured correctly", func() {
 			By("Checking controller PDB")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pdb",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pdb",
 					"-l", "control-plane=controller-manager",
 					"-n", haNamespace,
 					"-o", "jsonpath={.items[0].spec.minAvailable}")
@@ -200,7 +199,7 @@ var _ = Describe("Leader Election and HA E2E", Ordered, Label("ha", "leader-elec
 
 			By("Checking webhook PDB")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pdb",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pdb",
 					"-l", "control-plane=webhook-server",
 					"-n", haNamespace,
 					"-o", "jsonpath={.items[0].spec.minAvailable}")
@@ -219,7 +218,7 @@ var _ = Describe("Leader Election and HA E2E", Ordered, Label("ha", "leader-elec
 		It("should identify the current leader", func() {
 			By("Getting the current leader identity")
 			Eventually(func() string {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "lease",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "lease",
 					"auth.t-caas.telekom.com",
 					"-n", haNamespace,
 					"-o", "jsonpath={.spec.holderIdentity}")
@@ -247,7 +246,7 @@ spec:
   restrictedVerbs:
     - delete
 `
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(roleDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -265,14 +264,14 @@ spec:
 			leaderParts := strings.Split(originalLeader, "_")
 			if len(leaderParts) > 0 {
 				leaderPod := leaderParts[0]
-				cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "pod", leaderPod,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "pod", leaderPod,
 					"-n", haNamespace, "--grace-period=0", "--force")
 				_, _ = utils.Run(cmd)
 			}
 
 			By("Waiting for a new leader to be elected")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "lease",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "lease",
 					"auth.t-caas.telekom.com",
 					"-n", haNamespace,
 					"-o", "jsonpath={.spec.holderIdentity}")
@@ -286,7 +285,7 @@ spec:
 
 			By("Verifying the system recovered")
 			Eventually(func() int {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 					"-l", "control-plane=controller-manager",
 					"-n", haNamespace,
 					"--field-selector=status.phase=Running",
@@ -321,7 +320,7 @@ spec:
   allowedPrincipals:
     - user: ha-user-%d
 `, i, i)
-				cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 				cmd.Stdin = strings.NewReader(authorizerYAML)
 				_, err := utils.Run(cmd)
 				Expect(err).NotTo(HaveOccurred())
@@ -329,7 +328,7 @@ spec:
 
 			By("Verifying all WebhookAuthorizers are configured")
 			Eventually(func() int {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "-o", "name")
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", "-o", "name")
 				output, err := utils.Run(cmd)
 				if err != nil {
 					return 0
@@ -346,7 +345,7 @@ spec:
 
 		It("should have all webhook pods serving requests", func() {
 			By("Checking webhook pod readiness")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 				"-l", "control-plane=webhook-server",
 				"-n", haNamespace,
 				"-o", "jsonpath={.items[*].status.containerStatuses[0].ready}")
@@ -363,7 +362,7 @@ spec:
 	Context("Resource Scaling", func() {
 		It("should scale down webhook replicas", func() {
 			By("Scaling webhook to 1 replica")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "scale", "deployment",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "scale", "deployment",
 				"-l", "control-plane=webhook-server",
 				"-n", haNamespace,
 				"--replicas=1")
@@ -372,7 +371,7 @@ spec:
 
 			By("Waiting for scale down")
 			Eventually(func() int {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 					"-l", "control-plane=webhook-server",
 					"-n", haNamespace,
 					"--field-selector=status.phase=Running",
@@ -387,7 +386,7 @@ spec:
 
 		It("should scale up webhook replicas", func() {
 			By("Scaling webhook back to 3 replicas")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "scale", "deployment",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "scale", "deployment",
 				"-l", "control-plane=webhook-server",
 				"-n", haNamespace,
 				"--replicas=3")
@@ -396,7 +395,7 @@ spec:
 
 			By("Waiting for scale up")
 			Eventually(func() int {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 					"-l", "control-plane=webhook-server",
 					"-n", haNamespace,
 					"--field-selector=status.phase=Running",
@@ -424,7 +423,7 @@ func dumpHAResources(haNamespace string) {
 }
 
 func dumpAllPodLogs(namespace, filename string) {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods", "-n", namespace, "-o", "name")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods", "-n", namespace, "-o", "name")
 	output, err := utils.Run(cmd)
 	if err != nil {
 		return
@@ -433,7 +432,7 @@ func dumpAllPodLogs(namespace, filename string) {
 	var allLogs strings.Builder
 	for _, podName := range utils.GetNonEmptyLines(string(output)) {
 		fmt.Fprintf(&allLogs, "\n=== Logs for %s ===\n", podName)
-		cmd := exec.CommandContext(context.Background(), "kubectl", "logs", podName, "-n", namespace, "--tail=200")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "logs", podName, "-n", namespace, "--tail=200")
 		logOutput, _ := utils.Run(cmd)
 		allLogs.Write(logOutput)
 		allLogs.WriteString("\n")
@@ -446,21 +445,21 @@ func createHASummary(namespace, timestamp string) {
 	fmt.Fprintf(&summary, "# HA/Leader Election Test Summary - %s\n\n", timestamp)
 
 	summary.WriteString("## Pod Status\n\n")
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods", "-n", namespace, "-o", "wide")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods", "-n", namespace, "-o", "wide")
 	output, _ := utils.Run(cmd)
 	summary.WriteString("```\n")
 	summary.WriteString(string(output))
 	summary.WriteString("```\n\n")
 
 	summary.WriteString("## Leader Election\n\n")
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "lease", "-n", namespace, "-o", "wide")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "lease", "-n", namespace, "-o", "wide")
 	output, _ = utils.Run(cmd)
 	summary.WriteString("```\n")
 	summary.WriteString(string(output))
 	summary.WriteString("```\n\n")
 
 	summary.WriteString("## PodDisruptionBudgets\n\n")
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "pdb", "-n", namespace, "-o", "wide")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "pdb", "-n", namespace, "-o", "wide")
 	output, _ = utils.Run(cmd)
 	summary.WriteString("```\n")
 	summary.WriteString(string(output))

--- a/test/e2e/helm_e2e_test.go
+++ b/test/e2e/helm_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -43,26 +42,26 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 		// cert-manager is installed in BeforeSuite, no need to install here
 
 		By("Creating Helm test namespace")
-		cmd := exec.CommandContext(context.Background(), "kubectl", "create", "ns", helmNamespace, "--dry-run=client", "-o", "yaml")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "create", "ns", helmNamespace, "--dry-run=client", "-o", "yaml")
 		output, _ := utils.Run(cmd)
-		cmd = exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+		cmd = utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 		cmd.Stdin = strings.NewReader(string(output))
 		_, _ = utils.Run(cmd)
 
 		By("Creating test namespace for CRD testing")
-		cmd = exec.CommandContext(context.Background(), "kubectl", "create", "ns", helmTestNamespace, "--dry-run=client", "-o", "yaml")
+		cmd = utils.CommandContext(context.Background(), "kubectl", "create", "ns", helmTestNamespace, "--dry-run=client", "-o", "yaml")
 		output, _ = utils.Run(cmd)
-		cmd = exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+		cmd = utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 		cmd.Stdin = strings.NewReader(string(output))
 		_, _ = utils.Run(cmd)
 
 		// Label the test namespace
-		cmd = exec.CommandContext(context.Background(), "kubectl", "label", "ns", helmTestNamespace,
+		cmd = utils.CommandContext(context.Background(), "kubectl", "label", "ns", helmTestNamespace,
 			"e2e-helm-test=true", "--overwrite")
 		_, _ = utils.Run(cmd)
 
 		By("Building the operator image")
-		cmd = exec.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+		cmd = utils.CommandContext(context.Background(), "make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
 		_, err = utils.Run(cmd)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build operator image")
 
@@ -83,7 +82,7 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 		}
 
 		By("Cleaning up Helm release")
-		cmd := exec.CommandContext(context.Background(), "helm", "uninstall", helmReleaseName, "-n", helmNamespace, "--wait", "--timeout", "2m")
+		cmd := utils.CommandContext(context.Background(), "helm", "uninstall", helmReleaseName, "-n", helmNamespace, "--wait", "--timeout", "2m")
 		_, _ = utils.Run(cmd)
 
 		// Use centralized cleanup utility (includes namespace deletion)
@@ -96,7 +95,7 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 	Context("Helm Chart Validation", func() {
 		It("should lint the Helm chart successfully", func() {
 			By("Running helm lint")
-			cmd := exec.CommandContext(context.Background(), "helm", "lint", helmChartPath, "--strict")
+			cmd := utils.CommandContext(context.Background(), "helm", "lint", helmChartPath, "--strict")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Helm lint failed: %s", string(output))
 		})
@@ -107,7 +106,7 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 				"-n", helmNamespace},
 				imageSetArgs()...,
 			)
-			cmd := exec.CommandContext(context.Background(), "helm", templateArgs...)
+			cmd := utils.CommandContext(context.Background(), "helm", templateArgs...)
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Helm template failed")
 			Expect(string(output)).To(ContainSubstring("Deployment"))
@@ -131,7 +130,7 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 				"--set", "webhookServer.podDisruptionBudget.enabled=true",
 				"--set", "metrics.serviceMonitor.enabled=true",
 			)
-			cmd := exec.CommandContext(context.Background(), "helm", templateArgs...)
+			cmd := utils.CommandContext(context.Background(), "helm", templateArgs...)
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Helm template with all features failed: %s", string(output))
 			Expect(string(output)).To(ContainSubstring("PodDisruptionBudget"))
@@ -161,7 +160,7 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 				"--set-string", "podAnnotations.prometheus\\.io/scrape=true",
 				"--set-string", "podLabels.environment=test",
 			)
-			cmd := exec.CommandContext(context.Background(), "helm", templateArgs...)
+			cmd := utils.CommandContext(context.Background(), "helm", templateArgs...)
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Helm template with scheduling constraints failed: %s", string(output))
 
@@ -212,7 +211,7 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 				"--wait",
 				"--timeout", "5m",
 			)
-			cmd := exec.CommandContext(context.Background(), "helm", installArgs...)
+			cmd := utils.CommandContext(context.Background(), "helm", installArgs...)
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Helm install failed: %s", string(output))
 		})
@@ -234,38 +233,38 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 
 		It("should have CRDs installed", func() {
 			By("Checking RoleDefinition CRD exists")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "crd", "roledefinitions.authorization.t-caas.telekom.com")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "crd", "roledefinitions.authorization.t-caas.telekom.com")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking BindDefinition CRD exists")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "crd", "binddefinitions.authorization.t-caas.telekom.com")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "crd", "binddefinitions.authorization.t-caas.telekom.com")
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking WebhookAuthorizer CRD exists")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "crd", "webhookauthorizers.authorization.t-caas.telekom.com")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "crd", "webhookauthorizers.authorization.t-caas.telekom.com")
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should have RBAC resources created", func() {
 			By("Checking ClusterRole exists")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole",
 				"-l", fmt.Sprintf("app.kubernetes.io/instance=%s", helmReleaseName))
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(output)).To(ContainSubstring(helmReleaseName))
 
 			By("Checking ClusterRoleBinding exists")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding",
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding",
 				"-l", fmt.Sprintf("app.kubernetes.io/instance=%s", helmReleaseName))
 			output, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(output)).To(ContainSubstring(helmReleaseName))
 
 			By("Checking ServiceAccount exists")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "get", "serviceaccount", "-n", helmNamespace,
+			cmd = utils.CommandContext(context.Background(), "kubectl", "get", "serviceaccount", "-n", helmNamespace,
 				"-l", fmt.Sprintf("app.kubernetes.io/instance=%s", helmReleaseName))
 			output, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -291,7 +290,7 @@ spec:
     - delete
     - patch
 `
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(roleDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -323,7 +322,7 @@ spec:
     - create
     - delete
 `, helmTestNamespace)
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(roleDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -354,7 +353,7 @@ spec:
     clusterRoleRefs:
       - helm-e2e-generated-clusterrole
 `
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(bindDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -363,7 +362,7 @@ spec:
 			// ClusterRoleBinding name format: {targetName}-{clusterRoleRef}-binding
 			expectedCRBName := "helm-e2e-binding-helm-e2e-generated-clusterrole-binding"
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", expectedCRBName)
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", expectedCRBName)
 				_, err := utils.Run(cmd)
 				return err
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
@@ -394,7 +393,7 @@ spec:
         - matchLabels:
             e2e-helm-test: "true"
 `
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(bindDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -403,7 +402,7 @@ spec:
 			// RoleBinding name format: {targetName}-{clusterRoleRef}-binding
 			expectedRBName := "helm-e2e-ns-binding-helm-e2e-generated-clusterrole-binding"
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "rolebinding", expectedRBName,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "rolebinding", expectedRBName,
 					"-n", helmTestNamespace)
 				_, err := utils.Run(cmd)
 				return err
@@ -427,7 +426,7 @@ spec:
     clusterRoleRefs:
       - helm-e2e-generated-clusterrole
 `, helmTestNamespace)
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(bindDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -439,7 +438,7 @@ spec:
 
 			By("Verifying BindDefinition status includes generated ServiceAccount")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "binddefinition", "helm-e2e-sa-binding",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "binddefinition", "helm-e2e-sa-binding",
 					"-o", "jsonpath={.status.generatedServiceAccounts}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -474,7 +473,7 @@ spec:
     matchLabels:
       e2e-helm-test: "true"
 `
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(authorizerYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -506,7 +505,7 @@ spec:
     - groups:
         - helm-denied-group
 `
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(authorizerYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -537,7 +536,7 @@ spec:
   allowedPrincipals:
     - user: helm-health-user
 `
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(authorizerYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -568,7 +567,7 @@ spec:
 				"--wait",
 				"--timeout", "7m",
 			)
-			cmd := exec.CommandContext(context.Background(), "helm", upgradeArgs...)
+			cmd := utils.CommandContext(context.Background(), "helm", upgradeArgs...)
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Helm upgrade failed: %s", string(output))
 		})
@@ -576,7 +575,7 @@ spec:
 		It("should have PodDisruptionBudget created", func() {
 			By("Checking PodDisruptionBudget exists")
 			Eventually(func() error {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pdb", "-n", helmNamespace)
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pdb", "-n", helmNamespace)
 				output, err := utils.Run(cmd)
 				if err != nil {
 					return err
@@ -591,7 +590,7 @@ spec:
 		It("should have scaled replicas", func() {
 			By("Checking controller has 2 replicas")
 			Eventually(func() int {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "deployment",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "deployment",
 					"-l", "control-plane=controller-manager",
 					"-n", helmNamespace,
 					"-o", "jsonpath={.items[0].spec.replicas}")
@@ -674,7 +673,7 @@ func helmFullName() string {
 }
 
 func verifyHelmPodRunning(labelSelector, namespace string) error {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 		"-l", labelSelector,
 		"-n", namespace,
 		"-o", "jsonpath={.items[0].status.phase}")
@@ -748,7 +747,7 @@ func dumpResource(resourceType, namespace, filename string) {
 		args = append(args, "-A")
 	}
 
-	cmd := exec.CommandContext(context.Background(), "kubectl", args...)
+	cmd := utils.CommandContext(context.Background(), "kubectl", args...)
 	output, err := utils.Run(cmd)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Failed to dump %s: %v\n", resourceType, err)
@@ -765,7 +764,7 @@ func dumpResourceWithLabel(resourceType, namespace, labelSelector, filename stri
 		args = append(args, "-A")
 	}
 
-	cmd := exec.CommandContext(context.Background(), "kubectl", args...)
+	cmd := utils.CommandContext(context.Background(), "kubectl", args...)
 	output, err := utils.Run(cmd)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Failed to dump %s with label %s: %v\n", resourceType, labelSelector, err)
@@ -780,7 +779,7 @@ func dumpLogs(labelSelector, namespace, filename string) {
 		args = append(args, "-n", namespace)
 	}
 
-	cmd := exec.CommandContext(context.Background(), "kubectl", args...)
+	cmd := utils.CommandContext(context.Background(), "kubectl", args...)
 	output, _ := utils.Run(cmd)
 	saveOutput(filename, output)
 }
@@ -806,7 +805,7 @@ func createResourceSummary(timestamp string) {
 	// Operator status
 	summary.WriteString("\n## Operator Status\n\n")
 	if helmNamespace != "" {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods", "-n", helmNamespace, "-o", "wide")
+		cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods", "-n", helmNamespace, "-o", "wide")
 		output, _ := utils.Run(cmd)
 		summary.WriteString("```\n")
 		summary.WriteString(string(output))
@@ -818,14 +817,14 @@ func createResourceSummary(timestamp string) {
 }
 
 func countResource(summary *strings.Builder, name, resourceType string) {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", resourceType, "-o", "name")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", resourceType, "-o", "name")
 	output, _ := utils.Run(cmd)
 	count := len(utils.GetNonEmptyLines(string(output)))
 	fmt.Fprintf(summary, "- %s: %d\n", name, count)
 }
 
 func countResourceWithLabel(summary *strings.Builder, name, resourceType string) {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", resourceType, "-l", authOperatorLabel, "-A", "-o", "name")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", resourceType, "-l", authOperatorLabel, "-A", "-o", "name")
 	output, _ := utils.Run(cmd)
 	count := len(utils.GetNonEmptyLines(string(output)))
 	fmt.Fprintf(summary, "- %s: %d\n", name, count)

--- a/test/e2e/integration_e2e_test.go
+++ b/test/e2e/integration_e2e_test.go
@@ -21,7 +21,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -67,14 +66,14 @@ var _ = Describe("Integration Tests - Complex Multi-CRD Scenarios", Ordered, Lab
 		})
 
 		By("Installing auth-operator via Helm")
-		cmd := exec.CommandContext(context.Background(), "make", "docker-build", "IMG=auth-operator:e2e-test")
+		cmd := utils.CommandContext(context.Background(), "make", "docker-build", "IMG=auth-operator:e2e-test")
 		// Run make from project root
 		_, _ = utils.Run(cmd)
 
-		cmd = exec.CommandContext(context.Background(), "kind", "load", "docker-image", "auth-operator:e2e-test", "--name", kindClusterName)
+		cmd = utils.CommandContext(context.Background(), "kind", "load", "docker-image", "auth-operator:e2e-test", "--name", kindClusterName)
 		_, _ = utils.Run(cmd)
 
-		cmd = exec.CommandContext(context.Background(), "helm", "upgrade", "--install", integrationRelease, helmChartPathInt,
+		cmd = utils.CommandContext(context.Background(), "helm", "upgrade", "--install", integrationRelease, helmChartPathInt,
 			"-n", integrationNamespace,
 			"--set", "image.repository=auth-operator",
 			"--set", "image.tag=e2e-test",
@@ -281,7 +280,7 @@ spec:
 
 			By("Verifying ClusterRoleBindings have correct subjects")
 			for _, crbName := range expectedCRBs {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName,
 					"-o", "jsonpath={.subjects}")
 				output, err := utils.Run(cmd)
 				Expect(err).NotTo(HaveOccurred())
@@ -407,7 +406,7 @@ spec:
 			}, reconcileTimeoutInt, pollingIntervalInt).Should(Succeed())
 
 			By("Verifying ClusterRoleBinding has both ServiceAccount subjects")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName,
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName,
 				"-o", "jsonpath={.subjects}")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -444,7 +443,7 @@ spec:
 			}, reconcileTimeoutInt, pollingIntervalInt).Should(Succeed())
 
 			By("Verifying ClusterRoleBinding references the view ClusterRole")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName,
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebinding", crbName,
 				"-o", "jsonpath={.roleRef.name}")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -463,7 +462,7 @@ spec:
 			}
 
 			By("Deleting the multi-role BindDefinition")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", "int-binddefinition-multi-role")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "binddefinition", "int-binddefinition-multi-role")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -487,7 +486,7 @@ spec:
 			Expect(checkResourceExists("role", "int-ns-configmap-reader", testNS1)).To(Succeed())
 
 			By("Deleting the namespaced RoleDefinition")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", "int-roledefinition-ns-configmap")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", "int-roledefinition-ns-configmap")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -504,7 +503,7 @@ spec:
 })
 
 func verifyIntegrationControllerReady(namespace string) error {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 		"-l", "control-plane=controller-manager",
 		"-n", namespace,
 		"-o", "jsonpath={.items[*].status.phase}")
@@ -519,10 +518,10 @@ func verifyIntegrationControllerReady(namespace string) error {
 }
 
 func createNamespaceIfNotExists(name string, labels map[string]string) {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "create", "ns", name, "--dry-run=client", "-o", "yaml")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "create", "ns", name, "--dry-run=client", "-o", "yaml")
 	output, _ := utils.Run(cmd)
 
-	cmd = exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+	cmd = utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 	cmd.Stdin = strings.NewReader(string(output))
 	_, _ = utils.Run(cmd)
 
@@ -532,13 +531,13 @@ func createNamespaceIfNotExists(name string, labels map[string]string) {
 		for k, v := range labels {
 			labelArgs = append(labelArgs, fmt.Sprintf("%s=%s", k, v))
 		}
-		cmd = exec.CommandContext(context.Background(), "kubectl", labelArgs...)
+		cmd = utils.CommandContext(context.Background(), "kubectl", labelArgs...)
 		_, _ = utils.Run(cmd)
 	}
 }
 
 func applyYAML(yaml string) {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 	cmd.Stdin = strings.NewReader(yaml)
 	output, err := utils.Run(cmd)
 	ExpectWithOffset(2, err).NotTo(HaveOccurred(), "Failed to apply YAML: %s\nOutput: %s", yaml, string(output))

--- a/test/e2e/kustomize_e2e_test.go
+++ b/test/e2e/kustomize_e2e_test.go
@@ -20,7 +20,6 @@ package e2e
 
 import (
 	"context"
-	"os/exec"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,7 +33,7 @@ var _ = Describe("Kustomize Overlay Validation", Label("kustomize"), func() {
 	Context("Default Overlay", func() {
 		It("should build without errors", func() {
 			By("Building the default kustomize overlay")
-			cmd := exec.CommandContext(context.Background(), "kustomize", "build", "config/default")
+			cmd := utils.CommandContext(context.Background(), "kustomize", "build", "config/default")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Kustomize build failed for config/default")
 			Expect(string(output)).NotTo(BeEmpty())
@@ -49,7 +48,7 @@ var _ = Describe("Kustomize Overlay Validation", Label("kustomize"), func() {
 
 		It("should have valid YAML syntax", func() {
 			By("Building and validating YAML with kustomize")
-			cmd := exec.CommandContext(context.Background(), "kustomize", "build", "config/default")
+			cmd := utils.CommandContext(context.Background(), "kustomize", "build", "config/default")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -72,7 +71,7 @@ var _ = Describe("Kustomize Overlay Validation", Label("kustomize"), func() {
 	Context("CRD Overlay", func() {
 		It("should build without errors", func() {
 			By("Building the CRD kustomize overlay")
-			cmd := exec.CommandContext(context.Background(), "kustomize", "build", "config/crd")
+			cmd := utils.CommandContext(context.Background(), "kustomize", "build", "config/crd")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Kustomize build failed for config/crd")
 			Expect(string(output)).NotTo(BeEmpty())
@@ -92,7 +91,7 @@ var _ = Describe("Kustomize Overlay Validation", Label("kustomize"), func() {
 	Context("RBAC Overlay", func() {
 		It("should build without errors", func() {
 			By("Building the RBAC kustomize overlay")
-			cmd := exec.CommandContext(context.Background(), "kustomize", "build", "config/rbac")
+			cmd := utils.CommandContext(context.Background(), "kustomize", "build", "config/rbac")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Kustomize build failed for config/rbac")
 			Expect(string(output)).NotTo(BeEmpty())
@@ -108,7 +107,7 @@ var _ = Describe("Kustomize Overlay Validation", Label("kustomize"), func() {
 	Context("Manager Overlay", func() {
 		It("should build without errors", func() {
 			By("Building the manager kustomize overlay")
-			cmd := exec.CommandContext(context.Background(), "kustomize", "build", "config/manager")
+			cmd := utils.CommandContext(context.Background(), "kustomize", "build", "config/manager")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Kustomize build failed for config/manager")
 			Expect(string(output)).NotTo(BeEmpty())
@@ -122,7 +121,7 @@ var _ = Describe("Kustomize Overlay Validation", Label("kustomize"), func() {
 	Context("Webhook Overlay", func() {
 		It("should build without errors", func() {
 			By("Building the webhook kustomize overlay")
-			cmd := exec.CommandContext(context.Background(), "kustomize", "build", "config/webhook")
+			cmd := utils.CommandContext(context.Background(), "kustomize", "build", "config/webhook")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Kustomize build failed for config/webhook")
 			Expect(string(output)).NotTo(BeEmpty())
@@ -136,7 +135,7 @@ var _ = Describe("Kustomize Overlay Validation", Label("kustomize"), func() {
 	Context("Cert-Manager Overlay", func() {
 		It("should build without errors", func() {
 			By("Building the cert-manager kustomize overlay")
-			cmd := exec.CommandContext(context.Background(), "kustomize", "build", "config/certmanager")
+			cmd := utils.CommandContext(context.Background(), "kustomize", "build", "config/certmanager")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Kustomize build failed for config/certmanager")
 			Expect(string(output)).NotTo(BeEmpty())
@@ -151,7 +150,7 @@ var _ = Describe("Kustomize Overlay Validation", Label("kustomize"), func() {
 	Context("Prometheus Overlay", func() {
 		It("should build without errors", func() {
 			By("Building the prometheus kustomize overlay")
-			cmd := exec.CommandContext(context.Background(), "kustomize", "build", "config/prometheus")
+			cmd := utils.CommandContext(context.Background(), "kustomize", "build", "config/prometheus")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Kustomize build failed for config/prometheus")
 			Expect(string(output)).NotTo(BeEmpty())
@@ -165,7 +164,7 @@ var _ = Describe("Kustomize Overlay Validation", Label("kustomize"), func() {
 	Context("Manifest Consistency", func() {
 		It("should have matching CRD versions across overlays", func() {
 			By("Building CRD overlay")
-			crdCmd := exec.CommandContext(context.Background(), "kustomize", "build", "config/crd")
+			crdCmd := utils.CommandContext(context.Background(), "kustomize", "build", "config/crd")
 			crdOutput, err := utils.Run(crdCmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -175,7 +174,7 @@ var _ = Describe("Kustomize Overlay Validation", Label("kustomize"), func() {
 
 		It("should have consistent namespace references", func() {
 			By("Building default overlay")
-			cmd := exec.CommandContext(context.Background(), "kustomize", "build", "config/default")
+			cmd := utils.CommandContext(context.Background(), "kustomize", "build", "config/default")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/leak_detector.go
+++ b/test/e2e/leak_detector.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
@@ -27,7 +26,7 @@ func TakeSnapshot() (*ResourceSnapshot, error) {
 	snapshot := &ResourceSnapshot{}
 
 	// Capture namespaces (excluding system namespaces)
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "ns", "-o", "jsonpath={.items[*].metadata.name}")
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "ns", "-o", "jsonpath={.items[*].metadata.name}")
 	output, err := utils.Run(cmd)
 	if err == nil {
 		allNS := strings.Fields(string(output))
@@ -44,7 +43,7 @@ func TakeSnapshot() (*ResourceSnapshot, error) {
 	}
 
 	// Capture ClusterRoles (only auth-operator created)
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterroles",
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterroles",
 		"-l", "app.kubernetes.io/managed-by=auth-operator",
 		"-o", "jsonpath={.items[*].metadata.name}")
 	output, err = utils.Run(cmd)
@@ -53,7 +52,7 @@ func TakeSnapshot() (*ResourceSnapshot, error) {
 	}
 
 	// Capture ClusterRoleBindings (only auth-operator created)
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "clusterrolebindings",
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "clusterrolebindings",
 		"-l", "app.kubernetes.io/managed-by=auth-operator",
 		"-o", "jsonpath={.items[*].metadata.name}")
 	output, err = utils.Run(cmd)
@@ -62,7 +61,7 @@ func TakeSnapshot() (*ResourceSnapshot, error) {
 	}
 
 	// Capture RoleDefinitions
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "roledefinitions", "-A",
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "roledefinitions", "-A",
 		"-o", "jsonpath={range .items[*]}{.metadata.namespace}/{.metadata.name}{\" \"}{end}")
 	output, err = utils.Run(cmd)
 	if err == nil {
@@ -70,7 +69,7 @@ func TakeSnapshot() (*ResourceSnapshot, error) {
 	}
 
 	// Capture BindDefinitions
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "binddefinitions", "-A",
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "binddefinitions", "-A",
 		"-o", "jsonpath={range .items[*]}{.metadata.namespace}/{.metadata.name}{\" \"}{end}")
 	output, err = utils.Run(cmd)
 	if err == nil {
@@ -78,7 +77,7 @@ func TakeSnapshot() (*ResourceSnapshot, error) {
 	}
 
 	// Capture WebhookAuthorizers
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizers", "-A",
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizers", "-A",
 		"-o", "jsonpath={range .items[*]}{.metadata.namespace}/{.metadata.name}{\" \"}{end}")
 	output, err = utils.Run(cmd)
 	if err == nil {
@@ -86,7 +85,7 @@ func TakeSnapshot() (*ResourceSnapshot, error) {
 	}
 
 	// Capture ValidatingWebhookConfigurations (auth-operator related)
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "validatingwebhookconfigurations",
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "validatingwebhookconfigurations",
 		"-o", "jsonpath={.items[?(@.metadata.name=~\".*auth-operator.*\")].metadata.name}")
 	output, err = utils.Run(cmd)
 	if err == nil {
@@ -94,7 +93,7 @@ func TakeSnapshot() (*ResourceSnapshot, error) {
 	}
 
 	// Capture MutatingWebhookConfigurations (auth-operator related)
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "mutatingwebhookconfigurations",
+	cmd = utils.CommandContext(context.Background(), "kubectl", "get", "mutatingwebhookconfigurations",
 		"-o", "jsonpath={.items[?(@.metadata.name=~\".*auth-operator.*\")].metadata.name}")
 	output, err = utils.Run(cmd)
 	if err == nil {

--- a/test/e2e/resilience_e2e_test.go
+++ b/test/e2e/resilience_e2e_test.go
@@ -11,7 +11,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -62,7 +61,7 @@ var _ = Describe("Resilience - Webhook Failure Injection", Ordered, Label("compl
 			"--wait",
 			"--timeout", "5m",
 		)
-		cmd := exec.CommandContext(context.Background(), "helm", helmArgs...)
+		cmd := utils.CommandContext(context.Background(), "helm", helmArgs...)
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install Helm chart for webhook-failure tests")
 
@@ -83,7 +82,7 @@ var _ = Describe("Resilience - Webhook Failure Injection", Ordered, Label("compl
 
 		By("Cleaning up webhook failure test resources")
 		By("Uninstalling webhook failure Helm release")
-		cmd := exec.CommandContext(context.Background(), "helm", "uninstall", whResilienceRelease,
+		cmd := utils.CommandContext(context.Background(), "helm", "uninstall", whResilienceRelease,
 			"-n", whResilienceNS, "--wait", "--timeout", "2m")
 		_, _ = utils.Run(cmd)
 
@@ -102,7 +101,7 @@ var _ = Describe("Resilience - Webhook Failure Injection", Ordered, Label("compl
 			whDeployName := whResilienceRelease + "-webhook-server"
 
 			By("Identifying the webhook TLS secret")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get", "secrets",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get", "secrets",
 				"-n", whResilienceNS,
 				"-l", "authorization.t-caas.telekom.com/component=webhook",
 				"-o", "jsonpath={.items[*].metadata.name}")
@@ -117,14 +116,14 @@ var _ = Describe("Resilience - Webhook Failure Injection", Ordered, Label("compl
 			_, _ = fmt.Fprintf(GinkgoWriter, "Found TLS secret: %s\n", tlsSecretName)
 
 			By("Scaling webhook deployment to zero to avoid dual-pod conflicts during cert reset")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "scale", "deployment",
+			cmd = utils.CommandContext(context.Background(), "kubectl", "scale", "deployment",
 				whDeployName, "-n", whResilienceNS, "--replicas=0")
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for all webhook pods to terminate")
 			Eventually(func() int {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 					"-l", "control-plane=webhook-server",
 					"-n", whResilienceNS,
 					"-o", "name")
@@ -141,14 +140,14 @@ var _ = Describe("Resilience - Webhook Failure Injection", Ordered, Label("compl
 				"All webhook pods should be terminated before cert invalidation")
 
 			By("Clearing TLS data from the secret to invalidate certs and trigger rotation")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "patch", "secret", tlsSecretName,
+			cmd = utils.CommandContext(context.Background(), "kubectl", "patch", "secret", tlsSecretName,
 				"-n", whResilienceNS,
 				"--type=merge", "-p", `{"data":{"tls.crt":"","tls.key":"","ca.crt":""}}`)
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Scaling webhook deployment back to one replica to trigger cert-rotator re-initialization")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "scale", "deployment",
+			cmd = utils.CommandContext(context.Background(), "kubectl", "scale", "deployment",
 				whDeployName, "-n", whResilienceNS, "--replicas=1")
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -159,7 +158,7 @@ var _ = Describe("Resilience - Webhook Failure Injection", Ordered, Label("compl
 			// Validate tls.crt and tls.key (the primary cert fields) rather than ca.crt alone,
 			// since the cert-rotator's CAName may differ from the literal "ca.crt" key.
 			Eventually(func() bool {
-				certCmd := exec.CommandContext(context.Background(), "kubectl", "get", "secret", tlsSecretName,
+				certCmd := utils.CommandContext(context.Background(), "kubectl", "get", "secret", tlsSecretName,
 					"-n", whResilienceNS,
 					"-o", "jsonpath={.data.tls\\.crt}")
 				tlsCrt, err := utils.Run(certCmd)
@@ -167,7 +166,7 @@ var _ = Describe("Resilience - Webhook Failure Injection", Ordered, Label("compl
 					return false
 				}
 
-				keyCmd := exec.CommandContext(context.Background(), "kubectl", "get", "secret", tlsSecretName,
+				keyCmd := utils.CommandContext(context.Background(), "kubectl", "get", "secret", tlsSecretName,
 					"-n", whResilienceNS,
 					"-o", "jsonpath={.data.tls\\.key}")
 				tlsKey, err := utils.Run(keyCmd)
@@ -206,7 +205,7 @@ spec:
   restrictedVerbs:
     - delete
 `, tlsTestRDName)
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(roleDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "RoleDefinition admission should succeed after TLS recovery")
@@ -217,10 +216,10 @@ spec:
 			}, whReconcileTimeout, whPollInterval).Should(Succeed())
 
 			By("Cleaning up test RoleDefinition")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", tlsTestRDName,
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", tlsTestRDName,
 				"--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrole",
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrole",
 				"resilience-wh-tls-generated-role", "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		})
@@ -231,7 +230,7 @@ spec:
 
 		It("should handle admission requests while webhook is scaled to zero", func() {
 			By("Scaling the webhook server deployment to zero replicas")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "scale", "deployment",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "scale", "deployment",
 				"-l", "control-plane=webhook-server",
 				"-n", whResilienceNS,
 				"--replicas=0")
@@ -240,7 +239,7 @@ spec:
 
 			By("Waiting for webhook pods to terminate")
 			Eventually(func() int {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 					"-l", "control-plane=webhook-server",
 					"-n", whResilienceNS,
 					"-o", "name")
@@ -266,7 +265,7 @@ spec:
   restrictedVerbs:
     - delete
 `, scaledDownTestRDName)
-			cmd = exec.CommandContext(context.Background(), "kubectl", "apply", "--dry-run=server", "-f", "-")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "apply", "--dry-run=server", "-f", "-")
 			cmd.Stdin = strings.NewReader(roleDefYAML)
 			_, err = utils.Run(cmd)
 			// With failurePolicy: Fail, admission must be rejected when the webhook endpoint is unreachable.
@@ -275,7 +274,7 @@ spec:
 
 		It("should recover reconciliation once webhook is restored", func() {
 			By("Scaling the webhook server deployment back to one replica")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "scale", "deployment",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "scale", "deployment",
 				"-l", "control-plane=webhook-server",
 				"-n", whResilienceNS,
 				"--replicas=1")
@@ -300,7 +299,7 @@ spec:
   restrictedVerbs:
     - delete
 `, scaledDownTestRDName)
-			cmd = exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd = utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(roleDefYAML)
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Admission should succeed after webhook recovery")
@@ -311,10 +310,10 @@ spec:
 			}, whReconcileTimeout, whPollInterval).Should(Succeed())
 
 			By("Cleaning up test RoleDefinition")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", scaledDownTestRDName,
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", scaledDownTestRDName,
 				"--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrole",
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrole",
 				"resilience-wh-scaled-generated-role", "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		})
@@ -363,7 +362,7 @@ var _ = Describe("Resilience - SSA Ownership Conflicts", Ordered, Label("complex
 			"--wait",
 			"--timeout", "5m",
 		)
-		cmd := exec.CommandContext(context.Background(), "helm", helmArgs...)
+		cmd := utils.CommandContext(context.Background(), "helm", helmArgs...)
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install Helm chart for SSA conflict tests")
 
@@ -384,7 +383,7 @@ var _ = Describe("Resilience - SSA Ownership Conflicts", Ordered, Label("complex
 
 		By("Cleaning up SSA conflict test resources")
 		By("Uninstalling SSA conflict Helm release")
-		cmd := exec.CommandContext(context.Background(), "helm", "uninstall", ssaResilienceRelease,
+		cmd := utils.CommandContext(context.Background(), "helm", "uninstall", ssaResilienceRelease,
 			"-n", ssaResilienceNS, "--wait", "--timeout", "2m")
 		_, _ = utils.Run(cmd)
 
@@ -412,7 +411,7 @@ spec:
     - delete
     - deletecollection
 `, ssaExternalRDName, ssaExternalCRName)
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(roleDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -428,7 +427,7 @@ spec:
 			// Overwrite rules to an empty list using a JSON merge patch (--type=merge).
 			// The operator should detect the drift and re-apply the correct rules via SSA.
 			patchJSON := `{"rules": []}`
-			cmd := exec.CommandContext(context.Background(), "kubectl", "patch", "clusterrole", ssaExternalCRName,
+			cmd := utils.CommandContext(context.Background(), "kubectl", "patch", "clusterrole", ssaExternalCRName,
 				"--type=merge",
 				"-p", patchJSON)
 			_, err := utils.Run(cmd)
@@ -436,7 +435,7 @@ spec:
 
 			By("Verifying the operator re-applies the correct rules via SSA reconciliation")
 			Eventually(func() (bool, error) {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", ssaExternalCRName,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", ssaExternalCRName,
 					"-o", "jsonpath={.rules}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -450,7 +449,7 @@ spec:
 
 		It("should clean up after SSA external-modification test", func() {
 			By("Deleting the test RoleDefinition")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", ssaExternalRDName,
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", ssaExternalRDName,
 				"--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 
@@ -482,7 +481,7 @@ spec:
   restrictedVerbs:
     - delete
 `, ssaConflictRDName, ssaConflictCRName)
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(roleDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -506,7 +505,7 @@ rules:
     verbs: ["get"]
 `, ssaConflictCRName)
 
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply",
 				"--server-side",
 				"--field-manager=resilience-test-conflict-manager",
 				"--force-conflicts",
@@ -527,7 +526,7 @@ rules:
 
 			By("Verifying the ClusterRole rules are non-empty after operator reconciliation")
 			Eventually(func() (bool, error) {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", ssaConflictCRName,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", ssaConflictCRName,
 					"-o", "jsonpath={.rules}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -542,7 +541,7 @@ rules:
 		It("should verify managedFields lists the operator as a field manager", func() {
 			By("Checking that the operator's field manager entry exists on the ClusterRole")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "clusterrole", ssaConflictCRName,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "clusterrole", ssaConflictCRName,
 					"-o", "jsonpath={.metadata.managedFields[*].manager}")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -558,12 +557,12 @@ rules:
 
 		It("should clean up after SSA conflict test", func() {
 			By("Deleting the test RoleDefinition")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", ssaConflictRDName,
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", ssaConflictRDName,
 				"--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 
 			By("Cleaning up residual ClusterRole if still present")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrole", ssaConflictCRName,
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrole", ssaConflictCRName,
 				"--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		})
@@ -593,10 +592,10 @@ var _ = Describe("Resilience - HA Failover", Ordered, Label("ha", "resilience"),
 		By("Setting up HA failover resilience test environment")
 
 		By("Creating HA operator namespace")
-		cmd := exec.CommandContext(context.Background(), "kubectl", "create", "ns", haResilienceNS,
+		cmd := utils.CommandContext(context.Background(), "kubectl", "create", "ns", haResilienceNS,
 			"--dry-run=client", "-o", "yaml")
 		yamlOutput, _ := utils.Run(cmd)
-		cmd = exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+		cmd = utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 		cmd.Stdin = strings.NewReader(string(yamlOutput))
 		_, _ = utils.Run(cmd)
 
@@ -622,7 +621,7 @@ var _ = Describe("Resilience - HA Failover", Ordered, Label("ha", "resilience"),
 			"--wait",
 			"--timeout", "8m",
 		)
-		cmd = exec.CommandContext(context.Background(), "helm", helmArgs...)
+		cmd = utils.CommandContext(context.Background(), "helm", helmArgs...)
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install Helm chart for HA resilience tests")
 
@@ -647,7 +646,7 @@ var _ = Describe("Resilience - HA Failover", Ordered, Label("ha", "resilience"),
 
 		By("Cleaning up HA resilience test resources")
 		By("Uninstalling HA resilience Helm release")
-		cmd := exec.CommandContext(context.Background(), "helm", "uninstall", haResilienceRelease,
+		cmd := utils.CommandContext(context.Background(), "helm", "uninstall", haResilienceRelease,
 			"-n", haResilienceNS, "--wait", "--timeout", "2m")
 		_, _ = utils.Run(cmd)
 
@@ -658,7 +657,7 @@ var _ = Describe("Resilience - HA Failover", Ordered, Label("ha", "resilience"),
 		It("should have 3 controller pods running", func() {
 			By("Verifying all 3 controller pods are in Running phase")
 			Eventually(func() int {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 					"-l", "control-plane=controller-manager",
 					"-n", haResilienceNS,
 					"-o", "jsonpath={.items[*].status.phase}")
@@ -681,7 +680,7 @@ var _ = Describe("Resilience - HA Failover", Ordered, Label("ha", "resilience"),
 		It("should have a leader elected via the lease", func() {
 			By("Waiting for a leader identity to appear on the lease")
 			Eventually(func() string {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "lease",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "lease",
 					haLeaseName,
 					"-n", haResilienceNS,
 					"-o", "jsonpath={.spec.holderIdentity}")
@@ -704,14 +703,14 @@ var _ = Describe("Resilience - HA Failover", Ordered, Label("ha", "resilience"),
 			if len(leaderParts) > 0 {
 				leaderPod := leaderParts[0]
 				_, _ = fmt.Fprintf(GinkgoWriter, "Deleting leader pod: %s\n", leaderPod)
-				cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "pod", leaderPod,
+				cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "pod", leaderPod,
 					"-n", haResilienceNS, "--grace-period=0", "--force")
 				_, _ = utils.Run(cmd)
 			}
 
 			By("Waiting for a new leader to be elected (different from the original)")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "lease",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "lease",
 					haLeaseName,
 					"-n", haResilienceNS,
 					"-o", "jsonpath={.spec.holderIdentity}")
@@ -726,7 +725,7 @@ var _ = Describe("Resilience - HA Failover", Ordered, Label("ha", "resilience"),
 
 			By("Verifying the system recovers to 3 running controller pods")
 			Eventually(func() int {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get", "pods",
 					"-l", "control-plane=controller-manager",
 					"-n", haResilienceNS,
 					"--field-selector=status.phase=Running",
@@ -755,7 +754,7 @@ spec:
   restrictedVerbs:
     - delete
 `, failoverRDName)
-			cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(roleDefYAML)
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "RoleDefinition should be admitted while HA leader election is enabled")
@@ -767,10 +766,10 @@ spec:
 				"Reconciler should generate the ClusterRole in HA mode")
 
 			By("Cleaning up failover test resources")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", failoverRDName,
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "roledefinition", failoverRDName,
 				"--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "clusterrole",
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete", "clusterrole",
 				"resilience-ha-failover-generated-role", "--ignore-not-found=true")
 			_, _ = utils.Run(cmd)
 		})

--- a/test/e2e/webhookauthorizer_e2e_test.go
+++ b/test/e2e/webhookauthorizer_e2e_test.go
@@ -9,7 +9,6 @@ package e2e
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -44,11 +43,11 @@ var _ = Describe("WebhookAuthorizer E2E", Ordered, Label("integration"), func() 
 		})
 
 		By("Installing auth-operator via Helm for WebhookAuthorizer E2E")
-		cmd := exec.CommandContext(context.Background(), "kind", "load", "docker-image",
+		cmd := utils.CommandContext(context.Background(), "kind", "load", "docker-image",
 			projectImage, "--name", kindClusterName)
 		_, _ = utils.Run(cmd)
 
-		cmd = exec.CommandContext(context.Background(), "helm", "upgrade", "--install",
+		cmd = utils.CommandContext(context.Background(), "helm", "upgrade", "--install",
 			waRelease, helmChartPath,
 			"-n", waNamespace,
 			"--set", "image.repository=auth-operator",
@@ -63,12 +62,12 @@ var _ = Describe("WebhookAuthorizer E2E", Ordered, Label("integration"), func() 
 
 	AfterAll(func() {
 		By("Uninstalling auth-operator Helm release")
-		cmd := exec.CommandContext(context.Background(), "helm", "uninstall", waRelease, "-n", waNamespace)
+		cmd := utils.CommandContext(context.Background(), "helm", "uninstall", waRelease, "-n", waNamespace)
 		_, _ = utils.Run(cmd)
 
 		By("Cleaning up e2e namespaces")
 		for _, ns := range []string{waNamespace, testNSLabeled, testNSPlain} {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "ns", ns, "--ignore-not-found")
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete", "ns", ns, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 		}
 	})
@@ -94,13 +93,13 @@ spec:
 		})
 
 		AfterAll(func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete",
 				"webhookauthorizer", "wa-e2e-basic", "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 		})
 
 		It("should show WebhookAuthorizer as created", func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get",
 				"webhookauthorizer", "wa-e2e-basic", "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to get WebhookAuthorizer")
@@ -132,13 +131,13 @@ spec:
 		})
 
 		AfterAll(func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete",
 				"webhookauthorizer", "wa-e2e-ns-selector", "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 		})
 
 		It("should show namespace-scoped WebhookAuthorizer", func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get",
 				"webhookauthorizer", "wa-e2e-ns-selector", "-o", "jsonpath={.spec.namespaceSelector}")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -167,14 +166,14 @@ spec:
 		})
 
 		AfterAll(func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete",
 				"webhookauthorizer", "wa-e2e-live-update", "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 		})
 
 		It("should reflect resource changes", func() {
 			By("Verifying initial state")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get",
 				"webhookauthorizer", "wa-e2e-live-update", "-o", "jsonpath={.spec.allowedPrincipals[0].user}")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -182,7 +181,7 @@ spec:
 
 			By("Updating the WebhookAuthorizer to change allowed user")
 			patchJSON := `{"spec":{"allowedPrincipals":[{"user":"e2e-updated-user"}]}}`
-			cmd = exec.CommandContext(context.Background(), "kubectl", "patch",
+			cmd = utils.CommandContext(context.Background(), "kubectl", "patch",
 				"webhookauthorizer", "wa-e2e-live-update",
 				"--type=merge", "-p", patchJSON)
 			output, err = utils.Run(cmd)
@@ -190,7 +189,7 @@ spec:
 
 			By("Verifying updated state")
 			Eventually(func() string {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get",
 					"webhookauthorizer", "wa-e2e-live-update",
 					"-o", "jsonpath={.spec.allowedPrincipals[0].user}")
 				output, _ := utils.Run(cmd)
@@ -236,14 +235,14 @@ spec:
 
 		AfterAll(func() {
 			for _, name := range []string{"wa-e2e-multi-1", "wa-e2e-multi-2"} {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "delete",
 					"webhookauthorizer", name, "--ignore-not-found")
 				_, _ = utils.Run(cmd)
 			}
 		})
 
 		It("should list both WebhookAuthorizers", func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get",
 				"webhookauthorizer", "-o", "json")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
@@ -273,7 +272,7 @@ spec:
 		})
 
 		AfterAll(func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete",
 				"webhookauthorizer", "wa-e2e-status", "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 		})
@@ -282,7 +281,7 @@ spec:
 			// The controller (if running) should update conditions.
 			// This test verifies the CRD supports the status subresource.
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get",
 					"webhookauthorizer", "wa-e2e-status", "-o", "json")
 				output, err := utils.Run(cmd)
 				if err != nil {
@@ -317,20 +316,20 @@ spec:
 			applyYAML(waDeleteYAML)
 
 			By("Verifying it exists")
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get",
 				"webhookauthorizer", "wa-e2e-delete")
 			_, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Deleting the WebhookAuthorizer")
-			cmd = exec.CommandContext(context.Background(), "kubectl", "delete",
+			cmd = utils.CommandContext(context.Background(), "kubectl", "delete",
 				"webhookauthorizer", "wa-e2e-delete", "--timeout=30s")
 			output, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Delete failed: %s", string(output))
 
 			By("Verifying it's gone")
 			Eventually(func() bool {
-				cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+				cmd := utils.CommandContext(context.Background(), "kubectl", "get",
 					"webhookauthorizer", "wa-e2e-delete")
 				_, err := utils.Run(cmd)
 				return err != nil // Should error (NotFound)
@@ -358,13 +357,13 @@ spec:
 		})
 
 		AfterAll(func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "delete",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "delete",
 				"webhookauthorizer", "wa-e2e-nonresource", "--ignore-not-found")
 			_, _ = utils.Run(cmd)
 		})
 
 		It("should have non-resource rules in spec", func() {
-			cmd := exec.CommandContext(context.Background(), "kubectl", "get",
+			cmd := utils.CommandContext(context.Background(), "kubectl", "get",
 				"webhookauthorizer", "wa-e2e-nonresource",
 				"-o", "jsonpath={.spec.nonResourceRules[0].nonResourceURLs}")
 			output, err := utils.Run(cmd)

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1127,9 +1127,15 @@ func SaveDebugInfoToFile(outputDir, filename, content string) error {
 	if err := os.MkdirAll(outputDir, 0o750); err != nil {
 		return err
 	}
+	if err := os.Chmod(outputDir, 0o750); err != nil {
+		return err
+	}
 
 	filePath := filepath.Join(outputDir, filename)
-	return os.WriteFile(filePath, []byte(content), 0o600)
+	if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(filePath, 0o600)
 }
 
 // CollectAndSaveAllDebugInfo collects all debug info and saves to files

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1124,10 +1124,10 @@ func jsonMarshalIndent(v interface{}, indent string) ([]byte, error) {
 
 // SaveDebugInfoToFile saves debug info to a file in the output directory.
 func SaveDebugInfoToFile(outputDir, filename, content string) error {
-	if err := os.MkdirAll(outputDir, 0o750); err != nil {
+	if err := os.MkdirAll(outputDir, 0o700); err != nil {
 		return err
 	}
-	if err := os.Chmod(outputDir, 0o750); err != nil {
+	if err := os.Chmod(outputDir, 0o700); err != nil { // #nosec G302 -- debug artifact directories need owner execute permission.
 		return err
 	}
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -87,6 +87,12 @@ func warnError(err error) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "warning: %v\n", err)
 }
 
+// CommandContext builds external commands used by repository-owned e2e helpers.
+func CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	// #nosec G204 -- e2e helpers execute fixed test tooling with repo-controlled arguments.
+	return exec.CommandContext(ctx, name, args...)
+}
+
 // DebugLogf writes debug output at the specified level.
 func DebugLogf(level int, format string, args ...interface{}) {
 	if level <= DebugLevel {
@@ -161,7 +167,7 @@ func DebugTable(headers []string, rows [][]string) {
 // InstallPrometheusOperator installs the prometheus Operator to be used to export the enabled metrics.
 func InstallPrometheusOperator() error {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.CommandContext(context.Background(), "kubectl", "create", "-f", url)
+	cmd := CommandContext(context.Background(), "kubectl", "create", "-f", url)
 	_, err := Run(cmd)
 	return err
 }
@@ -191,7 +197,7 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 }
 
 // RunWithTimeout executes a command with a timeout.
-// It rebuilds the command using exec.CommandContext so the OS process is killed
+// It rebuilds the command using CommandContext so the OS process is killed
 // automatically when the timeout expires, avoiding goroutine leaks.
 func RunWithTimeout(cmd *exec.Cmd, timeout time.Duration) ([]byte, error) {
 	dir, _ := GetProjectDir()
@@ -210,7 +216,7 @@ func RunWithTimeout(cmd *exec.Cmd, timeout time.Duration) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	ctxCmd := exec.CommandContext(ctx, cmd.Args[0], cmd.Args[1:]...) // args come from test code
+	ctxCmd := CommandContext(ctx, cmd.Args[0], cmd.Args[1:]...) // args come from test code
 	ctxCmd.Dir = cmd.Dir
 	ctxCmd.Env = cmd.Env
 
@@ -228,7 +234,7 @@ func RunWithTimeout(cmd *exec.Cmd, timeout time.Duration) ([]byte, error) {
 // UninstallPrometheusOperator uninstalls the prometheus.
 func UninstallPrometheusOperator() {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "-f", url)
+	cmd := CommandContext(context.Background(), "kubectl", "delete", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
@@ -237,7 +243,7 @@ func UninstallPrometheusOperator() {
 // UninstallCertManager uninstalls the cert manager.
 func UninstallCertManager() {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
-	cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "-f", url)
+	cmd := CommandContext(context.Background(), "kubectl", "delete", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
@@ -245,7 +251,7 @@ func UninstallCertManager() {
 
 // IsCertManagerInstalled checks if cert-manager is already installed.
 func IsCertManagerInstalled() bool {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "deployment", "cert-manager-webhook",
+	cmd := CommandContext(context.Background(), "kubectl", "get", "deployment", "cert-manager-webhook",
 		"-n", "cert-manager", "-o", "name")
 	_, err := Run(cmd)
 	return err == nil
@@ -257,7 +263,7 @@ func InstallCertManager() error {
 	if IsCertManagerInstalled() {
 		_, _ = fmt.Fprintf(GinkgoWriter, "cert-manager already installed, skipping installation\n")
 		// Still wait for it to be ready
-		cmd := exec.CommandContext(context.Background(), "kubectl", "wait", "deployment.apps/cert-manager-webhook",
+		cmd := CommandContext(context.Background(), "kubectl", "wait", "deployment.apps/cert-manager-webhook",
 			"--for", "condition=Available",
 			"--namespace", "cert-manager",
 			"--timeout", "5m",
@@ -272,7 +278,7 @@ func InstallCertManager() error {
 	var lastErr error
 	for attempt := 1; attempt <= 3; attempt++ {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Installing cert-manager (attempt %d/3)\n", attempt)
-		cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "-f", url, "--server-side", "--force-conflicts")
+		cmd := CommandContext(context.Background(), "kubectl", "apply", "-f", url, "--server-side", "--force-conflicts")
 		if _, err := Run(cmd); err != nil {
 			lastErr = err
 			if attempt < 3 {
@@ -292,7 +298,7 @@ func InstallCertManager() error {
 
 	// Wait for cert-manager-webhook to be ready, which can take time if cert-manager
 	// was re-installed after uninstalling on a cluster.
-	cmd := exec.CommandContext(context.Background(), "kubectl", "wait", "deployment.apps/cert-manager-webhook",
+	cmd := CommandContext(context.Background(), "kubectl", "wait", "deployment.apps/cert-manager-webhook",
 		"--for", "condition=Available",
 		"--namespace", "cert-manager",
 		"--timeout", "5m",
@@ -309,7 +315,7 @@ func LoadImageToKindClusterWithName(name string) error {
 		cluster = v
 	}
 	kindOptions := []string{"load", "docker-image", name, "--name", cluster}
-	cmd := exec.CommandContext(context.Background(), "kind", kindOptions...)
+	cmd := CommandContext(context.Background(), "kind", kindOptions...)
 	_, err := Run(cmd)
 	return err
 }
@@ -340,7 +346,7 @@ func GetProjectDir() (string, error) {
 
 // DeploymentExists checks if a deployment exists for a label selector in a namespace.
 func DeploymentExists(labelSelector, namespace string) bool {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "deployment",
+	cmd := CommandContext(context.Background(), "kubectl", "get", "deployment",
 		"-l", labelSelector,
 		"-n", namespace,
 		"-o", "name")
@@ -365,7 +371,7 @@ func WaitForResource(resourceType, name, namespace string, timeout time.Duration
 
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		cmd := exec.CommandContext(context.Background(), "kubectl", args...)
+		cmd := CommandContext(context.Background(), "kubectl", args...)
 		if _, err := Run(cmd); err == nil {
 			return nil
 		}
@@ -378,7 +384,7 @@ func WaitForResource(resourceType, name, namespace string, timeout time.Duration
 func WaitForPodRunning(labelSelector, namespace string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "get", "pods",
+		cmd := CommandContext(context.Background(), "kubectl", "get", "pods",
 			"-l", labelSelector,
 			"-n", namespace,
 			"-o", "jsonpath={.items[0].status.phase}")
@@ -393,7 +399,7 @@ func WaitForPodRunning(labelSelector, namespace string, timeout time.Duration) e
 
 // WaitForPodsReady waits for all pods matching the label selector to be Ready.
 func WaitForPodsReady(labelSelector, namespace string, timeout time.Duration) error {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "wait", "pod",
+	cmd := CommandContext(context.Background(), "kubectl", "wait", "pod",
 		"-l", labelSelector,
 		"-n", namespace,
 		"--for=condition=Ready",
@@ -404,7 +410,7 @@ func WaitForPodsReady(labelSelector, namespace string, timeout time.Duration) er
 
 // WaitForDeploymentAvailable waits for deployments matching label selector to be Available.
 func WaitForDeploymentAvailable(labelSelector, namespace string, timeout time.Duration) error {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "wait", "deployment",
+	cmd := CommandContext(context.Background(), "kubectl", "wait", "deployment",
 		"-l", labelSelector,
 		"-n", namespace,
 		"--for=condition=Available",
@@ -417,7 +423,7 @@ func WaitForDeploymentAvailable(labelSelector, namespace string, timeout time.Du
 func WaitForServiceEndpoints(serviceName, namespace string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "get", "endpoints", serviceName,
+		cmd := CommandContext(context.Background(), "kubectl", "get", "endpoints", serviceName,
 			"-n", namespace,
 			"-o", "jsonpath={.subsets}")
 		output, err := Run(cmd)
@@ -433,9 +439,9 @@ func WaitForServiceEndpoints(serviceName, namespace string, timeout time.Duratio
 func WaitForWebhookConfigurations(labelSelector string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		validating := exec.CommandContext(context.Background(), "kubectl", "get", "validatingwebhookconfiguration",
+		validating := CommandContext(context.Background(), "kubectl", "get", "validatingwebhookconfiguration",
 			"-l", labelSelector, "-o", "name")
-		mutating := exec.CommandContext(context.Background(), "kubectl", "get", "mutatingwebhookconfiguration",
+		mutating := CommandContext(context.Background(), "kubectl", "get", "mutatingwebhookconfiguration",
 			"-l", labelSelector, "-o", "name")
 		vOut, vErr := Run(validating)
 		mOut, mErr := Run(mutating)
@@ -453,13 +459,13 @@ func WaitForWebhookCABundle(labelSelector string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		// Check if mutating webhook has caBundle populated
-		mutatingCmd := exec.CommandContext(context.Background(), "kubectl", "get", "mutatingwebhookconfiguration",
+		mutatingCmd := CommandContext(context.Background(), "kubectl", "get", "mutatingwebhookconfiguration",
 			"-l", labelSelector,
 			"-o", "jsonpath={.items[*].webhooks[*].clientConfig.caBundle}")
 		mutatingOut, mutatingErr := Run(mutatingCmd)
 
 		// Check if validating webhook has caBundle populated
-		validatingCmd := exec.CommandContext(context.Background(), "kubectl", "get", "validatingwebhookconfiguration",
+		validatingCmd := CommandContext(context.Background(), "kubectl", "get", "validatingwebhookconfiguration",
 			"-l", labelSelector,
 			"-o", "jsonpath={.items[*].webhooks[*].clientConfig.caBundle}")
 		validatingOut, validatingErr := Run(validatingCmd)
@@ -499,7 +505,7 @@ func WaitForWebhookReady(timeout time.Duration) error {
 	for time.Now().Before(deadline) {
 		// Perform a dry-run namespace create which will trigger the mutating webhook
 		// If the webhook is ready with valid TLS, this will succeed
-		cmd := exec.CommandContext(context.Background(), "kubectl", "create", "namespace", testNS,
+		cmd := CommandContext(context.Background(), "kubectl", "create", "namespace", testNS,
 			"--dry-run=server", "-o", "yaml")
 		_, err := Run(cmd)
 		if err == nil {
@@ -536,7 +542,7 @@ func WaitForWebhookReady(timeout time.Duration) error {
 
 // ApplyManifest applies a YAML manifest from a string using server-side apply.
 func ApplyManifest(manifest string) error {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "apply", "--server-side", "--force-conflicts", "-f", "-")
+	cmd := CommandContext(context.Background(), "kubectl", "apply", "--server-side", "--force-conflicts", "-f", "-")
 	cmd.Stdin = strings.NewReader(manifest)
 	_, err := Run(cmd)
 	return err
@@ -544,7 +550,7 @@ func ApplyManifest(manifest string) error {
 
 // DeleteManifest deletes resources defined in a YAML manifest.
 func DeleteManifest(manifest string) error {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "-f", "-", "--ignore-not-found=true")
+	cmd := CommandContext(context.Background(), "kubectl", "delete", "-f", "-", "--ignore-not-found=true")
 	cmd.Stdin = strings.NewReader(manifest)
 	_, err := Run(cmd)
 	return err
@@ -556,7 +562,7 @@ func GetResourceField(resourceType, name, namespace, jsonpath string) (string, e
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}
-	cmd := exec.CommandContext(context.Background(), "kubectl", args...)
+	cmd := CommandContext(context.Background(), "kubectl", args...)
 	output, err := Run(cmd)
 	if err != nil {
 		return "", err
@@ -566,7 +572,7 @@ func GetResourceField(resourceType, name, namespace, jsonpath string) (string, e
 
 // KindClusterExists checks if a kind cluster with the given name exists.
 func KindClusterExists(name string) bool {
-	cmd := exec.CommandContext(context.Background(), "kind", "get", "clusters")
+	cmd := CommandContext(context.Background(), "kind", "get", "clusters")
 	output, err := Run(cmd)
 	if err != nil {
 		return false
@@ -588,7 +594,7 @@ func CreateKindCluster(name, k8sVersion string) error {
 	}
 
 	image := fmt.Sprintf("kindest/node:%s", k8sVersion)
-	cmd := exec.CommandContext(context.Background(), "kind", "create", "cluster",
+	cmd := CommandContext(context.Background(), "kind", "create", "cluster",
 		"--name", name,
 		"--image", image,
 		"--wait", "5m")
@@ -598,7 +604,7 @@ func CreateKindCluster(name, k8sVersion string) error {
 
 // DeleteKindCluster deletes a kind cluster.
 func DeleteKindCluster(name string) error {
-	cmd := exec.CommandContext(context.Background(), "kind", "delete", "cluster", "--name", name)
+	cmd := CommandContext(context.Background(), "kind", "delete", "cluster", "--name", name)
 	_, err := Run(cmd)
 	return err
 }
@@ -609,14 +615,14 @@ func CleanupWebhooks(labelSelector string) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "Cleaning up webhooks with label: %s\n", labelSelector)
 
 	// Clean up ValidatingWebhookConfigurations
-	cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "validatingwebhookconfiguration",
+	cmd := CommandContext(context.Background(), "kubectl", "delete", "validatingwebhookconfiguration",
 		"-l", labelSelector, "--ignore-not-found=true")
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
 
 	// Clean up MutatingWebhookConfigurations
-	cmd = exec.CommandContext(context.Background(), "kubectl", "delete", "mutatingwebhookconfiguration",
+	cmd = CommandContext(context.Background(), "kubectl", "delete", "mutatingwebhookconfiguration",
 		"-l", labelSelector, "--ignore-not-found=true")
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
@@ -636,22 +642,22 @@ func CleanupAllAuthOperatorWebhooks() {
 	}
 
 	for _, pattern := range webhookPatterns {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "get", "validatingwebhookconfiguration", "-o", "name")
+		cmd := CommandContext(context.Background(), "kubectl", "get", "validatingwebhookconfiguration", "-o", "name")
 		output, _ := Run(cmd)
 		for _, line := range GetNonEmptyLines(string(output)) {
 			if strings.Contains(line, pattern) {
 				name := strings.TrimPrefix(line, "validatingwebhookconfiguration.admissionregistration.k8s.io/")
-				cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "validatingwebhookconfiguration", name, "--ignore-not-found=true")
+				cmd := CommandContext(context.Background(), "kubectl", "delete", "validatingwebhookconfiguration", name, "--ignore-not-found=true")
 				_, _ = Run(cmd)
 			}
 		}
 
-		cmd = exec.CommandContext(context.Background(), "kubectl", "get", "mutatingwebhookconfiguration", "-o", "name")
+		cmd = CommandContext(context.Background(), "kubectl", "get", "mutatingwebhookconfiguration", "-o", "name")
 		output, _ = Run(cmd)
 		for _, line := range GetNonEmptyLines(string(output)) {
 			if strings.Contains(line, pattern) {
 				name := strings.TrimPrefix(line, "mutatingwebhookconfiguration.admissionregistration.k8s.io/")
-				cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "mutatingwebhookconfiguration", name, "--ignore-not-found=true")
+				cmd := CommandContext(context.Background(), "kubectl", "delete", "mutatingwebhookconfiguration", name, "--ignore-not-found=true")
 				_, _ = Run(cmd)
 			}
 		}
@@ -660,7 +666,7 @@ func CleanupAllAuthOperatorWebhooks() {
 
 // RemoveFinalizersForAll removes finalizers from all resources of a given type.
 func RemoveFinalizersForAll(resourceType string) {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", resourceType, "-A",
+	cmd := CommandContext(context.Background(), "kubectl", "get", resourceType, "-A",
 		"-o", `jsonpath={range .items[*]}{.metadata.namespace}{"/"}{.metadata.name}{"\n"}{end}`)
 	output, err := Run(cmd)
 	if err != nil {
@@ -674,7 +680,7 @@ func RemoveFinalizersForAll(resourceType string) {
 		if ns != "" {
 			args = append(args, "-n", ns)
 		}
-		patch := exec.CommandContext(context.Background(), "kubectl", args...)
+		patch := CommandContext(context.Background(), "kubectl", args...)
 		if _, err := Run(patch); err != nil {
 			warnError(err)
 		}
@@ -702,7 +708,7 @@ func CleanupResourcesByLabel(resourceType, labelSelector, namespace string) {
 	if namespace != "" {
 		args = append(args, "-n", namespace)
 	}
-	cmd := exec.CommandContext(context.Background(), "kubectl", args...)
+	cmd := CommandContext(context.Background(), "kubectl", args...)
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
@@ -710,13 +716,13 @@ func CleanupResourcesByLabel(resourceType, labelSelector, namespace string) {
 
 // CleanupNamespace deletes a namespace and waits for it to be fully removed.
 func CleanupNamespace(namespace string) {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "delete", "ns", namespace, "--ignore-not-found=true", "--wait=false")
+	cmd := CommandContext(context.Background(), "kubectl", "delete", "ns", namespace, "--ignore-not-found=true", "--wait=false")
 	_, _ = Run(cmd)
 
 	// Wait for namespace to be deleted (with timeout)
 	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
-		cmd := exec.CommandContext(context.Background(), "kubectl", "get", "ns", namespace)
+		cmd := CommandContext(context.Background(), "kubectl", "get", "ns", namespace)
 		if _, err := Run(cmd); err != nil {
 			// Namespace is gone
 			return
@@ -735,7 +741,7 @@ func CleanupClusterResources(labelSelector string) {
 			"delete", resource, "-l", labelSelector,
 			"--ignore-not-found=true", "--wait=false", "--timeout=30s",
 		}
-		cmd := exec.CommandContext(context.Background(), "kubectl", args...)
+		cmd := CommandContext(context.Background(), "kubectl", args...)
 		if _, err := Run(cmd); err != nil {
 			warnError(err)
 		}
@@ -1007,7 +1013,7 @@ func SaveTestSummaryJSON(
 	}
 
 	outputDir := GetE2EOutputDirForContext(suite)
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+	if err := os.MkdirAll(outputDir, 0o750); err != nil {
 		return err
 	}
 
@@ -1024,13 +1030,13 @@ func getClusterInfo() map[string]string {
 	info := make(map[string]string)
 
 	// Kubernetes version
-	cmd := exec.CommandContext(context.Background(), "kubectl", "version", "--client", "--short")
+	cmd := CommandContext(context.Background(), "kubectl", "version", "--client", "--short")
 	if output, err := Run(cmd); err == nil {
 		info["kubectl_version"] = strings.TrimSpace(string(output))
 	}
 
 	// Server version
-	cmd = exec.CommandContext(context.Background(), "kubectl", "version", "-o", "json")
+	cmd = CommandContext(context.Background(), "kubectl", "version", "-o", "json")
 	if output, err := Run(cmd); err == nil {
 		// Extract server version from JSON (simplified)
 		if strings.Contains(string(output), "serverVersion") {
@@ -1039,7 +1045,7 @@ func getClusterInfo() map[string]string {
 	}
 
 	// Current context
-	cmd = exec.CommandContext(context.Background(), "kubectl", "config", "current-context")
+	cmd = CommandContext(context.Background(), "kubectl", "config", "current-context")
 	if output, err := Run(cmd); err == nil {
 		info["context"] = strings.TrimSpace(string(output))
 	}
@@ -1118,12 +1124,12 @@ func jsonMarshalIndent(v interface{}, indent string) ([]byte, error) {
 
 // SaveDebugInfoToFile saves debug info to a file in the output directory.
 func SaveDebugInfoToFile(outputDir, filename, content string) error {
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+	if err := os.MkdirAll(outputDir, 0o750); err != nil {
 		return err
 	}
 
 	filePath := filepath.Join(outputDir, filename)
-	return os.WriteFile(filePath, []byte(content), 0o644)
+	return os.WriteFile(filePath, []byte(content), 0o600)
 }
 
 // CollectAndSaveAllDebugInfo collects all debug info and saves to files
@@ -1139,33 +1145,33 @@ func CollectAndSaveAllDebugInfo(testContext string) {
 
 	// Save to files for CI artifacts
 	outputDir := GetE2EOutputDirForContext(testContext)
-	_ = os.MkdirAll(outputDir, 0o755)
+	_ = os.MkdirAll(outputDir, 0o750)
 
 	// Cluster dump
-	cmd := exec.CommandContext(context.Background(), "kubectl", "cluster-info", "dump", "--output-directory", filepath.Join(outputDir, "cluster-dump"))
+	cmd := CommandContext(context.Background(), "kubectl", "cluster-info", "dump", "--output-directory", filepath.Join(outputDir, "cluster-dump"))
 	_, _ = Run(cmd)
 
 	// All resources
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "all", "-A", "-o", "wide")
+	cmd = CommandContext(context.Background(), "kubectl", "get", "all", "-A", "-o", "wide")
 	if output, err := Run(cmd); err == nil {
 		_ = SaveDebugInfoToFile(outputDir, "all-resources.txt", string(output))
 	}
 
 	// Events
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "events", "-A", "--sort-by=.lastTimestamp")
+	cmd = CommandContext(context.Background(), "kubectl", "get", "events", "-A", "--sort-by=.lastTimestamp")
 	if output, err := Run(cmd); err == nil {
 		_ = SaveDebugInfoToFile(outputDir, "events.txt", string(output))
 	}
 
 	// Pods
-	cmd = exec.CommandContext(context.Background(), "kubectl", "get", "pods", "-A", "-o", "wide")
+	cmd = CommandContext(context.Background(), "kubectl", "get", "pods", "-A", "-o", "wide")
 	if output, err := Run(cmd); err == nil {
 		_ = SaveDebugInfoToFile(outputDir, "pods.txt", string(output))
 	}
 
 	// CRD instances
 	for _, crd := range []string{"roledefinitions", "binddefinitions", "webhookauthorizers"} {
-		cmd = exec.CommandContext(context.Background(), "kubectl", "get", crd, "-A", "-o", "yaml")
+		cmd = CommandContext(context.Background(), "kubectl", "get", crd, "-A", "-o", "yaml")
 		if output, err := Run(cmd); err == nil {
 			_ = SaveDebugInfoToFile(outputDir, crd+".yaml", string(output))
 		}
@@ -1179,15 +1185,15 @@ func CollectAndSaveAllDebugInfo(testContext string) {
 		"auth-operator-integration-test",
 	}
 	for _, ns := range operatorNamespaces {
-		cmd = exec.CommandContext(context.Background(), "kubectl", "get", "ns", ns, "-o", "name")
+		cmd = CommandContext(context.Background(), "kubectl", "get", "ns", ns, "-o", "name")
 		if _, err := Run(cmd); err != nil {
 			continue
 		}
-		cmd = exec.CommandContext(context.Background(), "kubectl", "logs", "-n", ns, "-l", "control-plane=controller-manager", "--tail=1000")
+		cmd = CommandContext(context.Background(), "kubectl", "logs", "-n", ns, "-l", "control-plane=controller-manager", "--tail=1000")
 		if output, err := Run(cmd); err == nil {
 			_ = SaveDebugInfoToFile(outputDir, fmt.Sprintf("%s-controller-logs.txt", ns), string(output))
 		}
-		cmd = exec.CommandContext(context.Background(), "kubectl", "logs", "-n", ns, "-l", "app.kubernetes.io/component=webhook", "--tail=1000")
+		cmd = CommandContext(context.Background(), "kubectl", "logs", "-n", ns, "-l", "app.kubernetes.io/component=webhook", "--tail=1000")
 		if output, err := Run(cmd); err == nil {
 			_ = SaveDebugInfoToFile(outputDir, fmt.Sprintf("%s-webhook-logs.txt", ns), string(output))
 		}
@@ -1217,7 +1223,7 @@ func collectSection(title string, fn func()) {
 
 // runDebugCommand runs a command and prints output to GinkgoWriter (ignores errors).
 func runDebugCommand(name string, args ...string) {
-	cmd := exec.CommandContext(context.Background(), name, args...)
+	cmd := CommandContext(context.Background(), name, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "$ %s %s\n[error: %v]\n", name, strings.Join(args, " "), err)

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1145,7 +1145,10 @@ func CollectAndSaveAllDebugInfo(testContext string) {
 
 	// Save to files for CI artifacts
 	outputDir := GetE2EOutputDirForContext(testContext)
-	_ = os.MkdirAll(outputDir, 0o750)
+	if err := os.MkdirAll(outputDir, 0o750); err != nil {
+		DebugLogf(1, "failed to create debug output directory %s: %v", outputDir, err)
+		return
+	}
 
 	// Cluster dump
 	cmd := CommandContext(context.Background(), "kubectl", "cluster-info", "dump", "--output-directory", filepath.Join(outputDir, "cluster-dump"))


### PR DESCRIPTION
## Summary
- centralize e2e external command construction behind a documented helper to clear gosec G204 findings
- restrict e2e debug artifact directories/files to owner/group-private permissions
- move broad workflow token writes down to the jobs that need package, SARIF, release, or attestation writes

## Validation
- `make fmt`
- `go run github.com/securego/gosec/v2/cmd/gosec@$(grep '^GOSEC_VERSION=' versions.env | cut -d= -f2) -fmt=json -exclude=G104,G304 ./test/...`
- `go test ./test/e2e ./test/utils`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -shellcheck= .github/workflows/cleanup-pr-packages.yml .github/workflows/release.yml .github/workflows/security-scan.yml`

Note: full actionlint without `-shellcheck=` still reports pre-existing shellcheck warnings in workflow shell snippets unrelated to this permission hardening.
