### PR TITLE
test: add Go fuzz smoke targets

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Fuzz Smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly on Saturdays, after the regular Scorecard run.
+    - cron: '15 2 * * 6'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  go-fuzz-smoke:
+    name: Go fuzz smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Go Environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Run API fuzz targets
+        run: |
+          set -euo pipefail
+
+          targets=$(go test ./api/authorization/v1alpha1 -run=^$ -list '^Fuzz' | awk '/^Fuzz/ { print $1 }')
+          if [ -z "${targets}" ]; then
+            echo "No fuzz targets found"
+            exit 1
+          fi
+
+          for target in ${targets}; do
+            echo "Running ${target}"
+            go test ./api/authorization/v1alpha1 -run=^$ -fuzz="^${target}$" -fuzztime=10s -parallel=2
+          done

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -44,5 +44,5 @@ jobs:
 
           for target in ${targets}; do
             echo "Running ${target}"
-            go test ./api/authorization/v1alpha1 -run=^$ -fuzz="^${target}$" -fuzztime=10s -parallel=2
+            go test ./api/authorization/v1alpha1 -run=^$ -fuzz="^${target}$" -fuzztime=10s -timeout=2m -parallel=2
           done

--- a/api/authorization/v1alpha1/fuzz_test.go
+++ b/api/authorization/v1alpha1/fuzz_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+const maxFuzzInputBytes = 64 * 1024
+
+func skipLargeFuzzInput(t *testing.T, data []byte) {
+	t.Helper()
+	if len(data) > maxFuzzInputBytes {
+		t.Skip("fuzz input is too large for smoke runs")
+	}
+}
+
+func FuzzBindDefinitionSpecUnmarshal(f *testing.F) {
+	for _, seed := range []string{
+		`null`,
+		`{}`,
+		`{"targetName":"team-access","subjects":[{"kind":"Group","apiGroup":"rbac.authorization.k8s.io","name":"team-a"}],"roleBindings":{"clusterRoleRefs":["view"],"namespace":"default"}}`,
+		`{"targetName":"team-access","subjects":[{"kind":"ServiceAccount","name":"robot","namespace":"default"}],"roleBindings":[{"roleRefs":["editor"],"namespace":"default"}]}`,
+	} {
+		f.Add([]byte(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		skipLargeFuzzInput(t, data)
+
+		var spec BindDefinitionSpec
+		if err := json.Unmarshal(data, &spec); err != nil {
+			return
+		}
+		if _, err := json.Marshal(&spec); err != nil {
+			t.Fatalf("marshal unmarshaled BindDefinitionSpec: %v", err)
+		}
+	})
+}
+
+func FuzzRoleDefinitionSpecValidation(f *testing.F) {
+	for _, seed := range []string{
+		`{"metadata":{"name":"team-reader"},"spec":{"targetRole":"ClusterRole","targetName":"team-reader","scopeNamespaced":false}}`,
+		`{"metadata":{"name":"tenant-reader"},"spec":{"targetRole":"Role","targetName":"tenant-reader","targetNamespace":"default","scopeNamespaced":true}}`,
+		`{"metadata":{"name":"bad-version"},"spec":{"targetRole":"ClusterRole","targetName":"bad-version","restrictedApis":[{"name":"apps","versions":[{"groupVersion":"apps/notv1","version":"notv1"}]}]}}`,
+		`{"metadata":{"name":"aggregate"},"spec":{"targetRole":"ClusterRole","targetName":"aggregate","aggregateFrom":{"clusterRoleSelectors":[{"matchLabels":{"rbac.example.com/aggregate":"true"}}]}}}`,
+	} {
+		f.Add([]byte(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		skipLargeFuzzInput(t, data)
+
+		var roleDefinition RoleDefinition
+		if err := json.Unmarshal(data, &roleDefinition); err != nil {
+			return
+		}
+		_ = validateRoleDefinitionSpec(&roleDefinition)
+	})
+}
+
+func FuzzWebhookAuthorizerValidation(f *testing.F) {
+	for _, seed := range []string{
+		`{"metadata":{"name":"allow-pods"},"spec":{"resourceRules":[{"verbs":["get"],"apiGroups":[""],"resources":["pods"]}],"allowedPrincipals":[{"user":"alice"}]}}`,
+		`{"metadata":{"name":"deny-healthz"},"spec":{"nonResourceRules":[{"verbs":["get"],"nonResourceURLs":["/healthz"]}],"deniedPrincipals":[{"groups":["blocked"]}]}}`,
+		`{"metadata":{"name":"selector"},"spec":{"namespaceSelector":{"matchLabels":{"environment":"prod"}},"resourceRules":[{"verbs":["list"],"apiGroups":["apps"],"resources":["deployments"]}],"allowedPrincipals":[{"namespace":"default"}]}}`,
+		`{"metadata":{"name":"invalid-rule"},"spec":{"resourceRules":[{"apiGroups":[""],"resources":["pods"]}],"allowedPrincipals":[{"user":"alice"}],"deniedPrincipals":[{"user":"alice"}]}}`,
+	} {
+		f.Add([]byte(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		skipLargeFuzzInput(t, data)
+
+		var webhookAuthorizer WebhookAuthorizer
+		if err := json.Unmarshal(data, &webhookAuthorizer); err != nil {
+			return
+		}
+		_, _ = validateWebhookAuthorizer(&webhookAuthorizer)
+	})
+}


### PR DESCRIPTION
## Summary
- Add native Go fuzz targets for BindDefinitionSpec JSON compatibility and RoleDefinition/WebhookAuthorizer semantic validation helpers.
- Add a lightweight Fuzz Smoke GitHub Actions workflow that discovers API fuzz targets and runs short Go fuzz smoke executions on PRs, main pushes, and a weekly schedule.
- Keep the change isolated from the existing CodeQL branch (#313) and avoid generated files.

## Validation
- `go test ./api/authorization/v1alpha1 -run='^Fuzz'`
- `bash -lc <workflow fuzz loop>`, with each target run locally using `-fuzztime=5s -parallel=2`
- `make lint-strict`
- `reuse lint`
- `git diff --cached --check`

## Scorecard notes
- This PR targets the OpenSSF Scorecard Fuzzing alert by adding Go-native fuzz targets and CI smoke execution.
- Branch-Protection and Code-Review alerts require repository settings/workflow policy outside this code change.
- CII-Best-Practices requires external OpenSSF Best Practices badge/project metadata outside this code change.
- Token-Permissions is still open in code scanning, but workflow permission hardening is outside this fuzzing-focused PR.
