### PR TITLE
fix: restore CRD e2e typecheck on main

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,9 +46,23 @@ jobs:
       - name: Run envtest-based tests
         run: make test
 
+  e2e-compile:
+    name: E2E Compile Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Go Environment
+        uses: ./.github/actions/setup-go-env
+
+      - name: Compile E2E tests
+        run: make test-e2e-compile
+
   e2e-basic:
     name: E2E Basic Tests
     runs-on: ubuntu-latest
+    needs: e2e-compile
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.test_suite == 'basic' || github.event.inputs.test_suite == 'all'
     steps:
       - name: Checkout
@@ -93,6 +107,7 @@ jobs:
   e2e-helm:
     name: E2E Helm Tests
     runs-on: ubuntu-latest
+    needs: e2e-compile
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.test_suite == 'helm' || github.event.inputs.test_suite == 'all'
     steps:
       - name: Checkout
@@ -138,6 +153,7 @@ jobs:
   e2e-complex:
     name: E2E Complex Tests
     runs-on: ubuntu-latest
+    needs: e2e-compile
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.test_suite == 'complex' || github.event.inputs.test_suite == 'all'
     steps:
       - name: Checkout
@@ -183,6 +199,7 @@ jobs:
   e2e-ha:
     name: E2E HA Tests
     runs-on: ubuntu-latest
+    needs: e2e-compile
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.test_suite == 'ha' || github.event.inputs.test_suite == 'all'
     steps:
       - name: Checkout
@@ -228,6 +245,7 @@ jobs:
   e2e-full-chain:
     name: E2E Full Chain (Popular CRDs)
     runs-on: ubuntu-latest
+    needs: e2e-compile
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.test_suite == 'all'
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,10 @@ test-e2e-setup-multi: kind-create-multi kind-load-image-multi install ## Set up 
 test-e2e: ## Run base e2e tests against existing kind cluster.
 	KIND_CLUSTER=$(KIND_CLUSTER_NAME) IMG=$(E2E_IMG) go test -tags e2e ./test/e2e/ -v -ginkgo.v -ginkgo.label-filter="!helm && !complex && !integration && !golden && !ha && !leader-election && !dev" -timeout 30m
 
+.PHONY: test-e2e-compile
+test-e2e-compile: ## Compile e2e tests without creating a kind cluster.
+	go test -tags e2e ./test/e2e/ -run '^$$'
+
 .PHONY: test-e2e-full
 test-e2e-full: ## Run full e2e test suite (fresh cluster each run, configurable cleanup).
 	@set -e; \


### PR DESCRIPTION
## Summary
- use the e2e `utils.CommandContext` wrapper in the WebhookAuthorizer status check
- fixes the undefined `exec` reference that currently breaks main CI lint/typecheck and e2e compilation

## Evidence
- main CI run `27876701914` failed in `Lint` with `test/e2e/crd_e2e_test.go:581:9: undefined: exec`
- main E2E run `27876701931` failed with the same compile error
- `make lint` -> `0 issues`
- `make test-e2e-full-chain` -> 38/38 selected specs passed