### PR TITLE
fix: make Helm security scan enforce critical findings

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -188,8 +188,9 @@ jobs:
           scan-type: 'config'
           scan-ref: '/tmp/helm-rendered.yaml'
           format: 'table'
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          exit-code: '0'  # Don't fail on config issues, just report
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+          trivyignores: '.trivyignore'
 
   dependency-review:
     name: Dependency Review

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -182,7 +182,18 @@ jobs:
             --set image.tag=v1.0.0 \
             > /tmp/helm-rendered.yaml
 
-      - name: Run Trivy on Helm templates
+      - name: Report Trivy MEDIUM Helm findings
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        continue-on-error: true
+        with:
+          scan-type: 'config'
+          scan-ref: '/tmp/helm-rendered.yaml'
+          format: 'table'
+          severity: 'MEDIUM'
+          exit-code: '0'
+          trivyignores: '.trivyignore'
+
+      - name: Enforce Trivy HIGH and CRITICAL Helm findings
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'config'

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+#
+# These Kubernetes RBAC findings are expected for this operator and are documented
+# inline in the rendered ClusterRoles. The Helm security job still fails on any
+# unignored HIGH/CRITICAL finding.
+
+# RoleDefinition discovery must list API resources across groups so generated
+# Role/ClusterRole output stays accurate.
+KSV-0046
+
+# BindDefinition intentionally manages RoleBindings/ClusterRoleBindings and the
+# generated roles they reference.
+KSV-0050
+
+# The webhook server certificate controller must patch admission webhook
+# configurations with its CA bundle.
+KSV-0114

--- a/test/e2e/crd_e2e_test.go
+++ b/test/e2e/crd_e2e_test.go
@@ -578,7 +578,7 @@ func checkBindDefinitionReconciled(name string) bool {
 }
 
 func checkWebhookAuthorizerConfigured(name string) bool {
-	cmd := exec.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", name,
+	cmd := utils.CommandContext(context.Background(), "kubectl", "get", "webhookauthorizer", name,
 		"-o", "jsonpath={.status.authorizerConfigured}")
 	output, err := utils.Run(cmd)
 	if err != nil {


### PR DESCRIPTION
## Summary
- make the Helm Trivy config scan fail on unignored HIGH/CRITICAL findings
- document and ignore the operator-specific RBAC findings that are already intentional in the rendered ClusterRoles
- include the pending CRD E2E CommandContext wrapper fix so this branch gets useful CI feedback while main is still waiting on #315

## Verification
- helm template auth-operator ./chart/auth-operator --set image.tag=v1.0.0 > /tmp/helm-rendered.yaml
- docker run --rm -v "/private/tmp/auth-helm-security-ci":/repo -v /tmp/helm-rendered.yaml:/tmp/helm-rendered.yaml:ro -w /repo aquasec/trivy:latest config --ignorefile /repo/.trivyignore --severity CRITICAL,HIGH --exit-code 1 /tmp/helm-rendered.yaml
- make helm-lint
- make lint