### PR TITLE
ci: disable stale handling for pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Stale Issues and PRs
+name: Stale Issues
 
 on:
   schedule:
@@ -15,10 +15,10 @@ permissions:
 
 jobs:
   stale:
-    name: Mark Stale Issues and PRs
+    name: Mark Stale Issues
     runs-on: ubuntu-latest
     steps:
-      - name: Mark stale issues and PRs
+      - name: Mark stale issues
         uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   stale:
@@ -32,14 +32,9 @@ jobs:
           days-before-issue-close: 14
           exempt-issue-labels: 'pinned,security,enhancement,bug'
           # PR configuration
-          stale-pr-message: >
-            This pull request has been automatically marked as stale because it has not had
-            recent activity. It will remain open; please update this PR or comment if it's
-            still in progress.
-          stale-pr-label: 'stale'
-          days-before-pr-stale: 30
+          # PR stale processing is disabled; pull requests must not be stale-closed.
+          days-before-pr-stale: -1
           days-before-pr-close: -1
-          exempt-pr-labels: 'pinned,work-in-progress,do-not-close'
           # General settings
           operations-per-run: 100
           remove-stale-when-updated: true


### PR DESCRIPTION
## Summary
- disable actions/stale processing for pull requests
- keep issue stale handling unchanged
- reduce stale workflow PR permission from write to read

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/stale.yml"); puts "yaml ok"'`\n- `git diff --check`