### PR TITLE
ci: update buildx setup action

### DIFF
--- a/.github/actions/build-operator-image/action.yml
+++ b/.github/actions/build-operator-image/action.yml
@@ -52,7 +52,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Log in to Container Registry
       if: inputs.push-to-registry == 'true'


### PR DESCRIPTION
## Summary
- update the reusable image-build action to docker/setup-buildx-action v4.1.0
- keep the action pinned by full commit SHA
- removes the deprecated Node 20 action warning from main CI builds

## Validation
- `git ls-remote https://github.com/docker/setup-buildx-action.git refs/tags/v4.1.0`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/build-operator-image/action.yml"); puts "yaml ok"'`\n- `git diff --check`