### PR TITLE
ci: update setup-helm action to node24

### DIFF
--- a/.github/actions/setup-go-env/action.yml
+++ b/.github/actions/setup-go-env/action.yml
@@ -69,7 +69,7 @@ runs:
 
     - name: Install Helm
       if: inputs.install-helm == 'true'
-      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+      uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
         version: ${{ inputs.helm-version }}
 


### PR DESCRIPTION
## Summary
- update the composite setup action to use Azure/setup-helm v5.0.0 pinned by SHA
- remove the remaining Node 20 action warning from Helm-installing CI jobs

## Validation
- ruby YAML parser loaded .github/actions/setup-go-env/action.yml
- git diff --check

## Notes
- v5.0.0 action metadata uses node24
