### PR TITLE
ci: resolve fork PRs for output delta comments

### DIFF
--- a/.github/workflows/output-delta-comment.yml
+++ b/.github/workflows/output-delta-comment.yml
@@ -28,8 +28,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           set -euo pipefail
           if [ -n "${PR_NUMBER:-}" ]; then
@@ -41,7 +44,26 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "repos/${GH_REPO}/commits/${HEAD_SHA}/pulls" \
             --jq '.[0].number // ""')"
+
+          if [ -z "$pr_number" ] && [ -n "${HEAD_BRANCH:-}" ] && [ -n "${HEAD_REPOSITORY:-}" ]; then
+            head_owner="${HEAD_REPOSITORY%%/*}"
+            if [ -n "$head_owner" ] && [ "$head_owner" != "$HEAD_REPOSITORY" ]; then
+              pr_number="$(gh api \
+                --method GET \
+                -H "Accept: application/vnd.github+json" \
+                "repos/${GH_REPO}/pulls" \
+                -f state=open \
+                -f head="${head_owner}:${HEAD_BRANCH}" \
+                | jq -r --arg sha "$HEAD_SHA" 'map(select(.head.sha == $sha)) | .[0].number // .[0].number // ""')"
+            fi
+          fi
+
           if [ -z "$pr_number" ]; then
+            if [ "${RUN_EVENT:-}" = "pull_request" ]; then
+              echo "::error::No pull request found for pull_request workflow run ${HEAD_SHA}; cannot post output-delta comment."
+              exit 1
+            fi
+
             echo "::notice::No pull request found for workflow run ${HEAD_SHA}; skipping output-delta comment."
             echo "number=" >> "$GITHUB_OUTPUT"
             exit 0
@@ -178,7 +200,7 @@ jobs:
                   echo "Output differences were detected. Inspect the \`output-delta-diff-output\` artifact before merging."
                   ;;
                 false)
-                  echo "No output differences were detected between trusted main baseline and this PR."
+                  echo "No output differences were detected between trusted main baseline and this PR. There is no diff to inspect for this run."
                   ;;
                 *)
                   echo "Output differences could not be computed. Inspect the workflow run and uploaded artifacts before merging."

--- a/.github/workflows/output-delta-comment.yml
+++ b/.github/workflows/output-delta-comment.yml
@@ -52,9 +52,10 @@ jobs:
                 --method GET \
                 -H "Accept: application/vnd.github+json" \
                 "repos/${GH_REPO}/pulls" \
-                -f state=open \
+                -f state=all \
+                -f per_page=100 \
                 -f head="${head_owner}:${HEAD_BRANCH}" \
-                | jq -r --arg sha "$HEAD_SHA" 'map(select(.head.sha == $sha)) | .[0].number // .[0].number // ""')"
+                | jq -r --arg sha "$HEAD_SHA" 'map(select(.head.sha == $sha)) | .[0].number // ""')"
             fi
           fi
 


### PR DESCRIPTION
## Summary
- Resolve output-delta PR comments for fork-based PRs by falling back to the workflow run head repository owner and branch.
- Keep pull_request runs visible by failing the comment workflow if no PR can be resolved, instead of silently skipping the comment.

## Verification
- Reproduced the live failure mode on PR #324: the existing commits/{sha}/pulls lookup returned no PR for the fork commit.
- Validated the new fallback resolves PR #324 from MaxRink:codex-dependency-refresh and SHA adca50591418e557d0fac6506153f0e2c56ff572.
- Ran git diff --check.
- Ran go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/output-delta-comment.yml.
