### PR TITLE
fix(webhookauthorizer): match rules with Kubernetes semantics

### DIFF
--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -721,17 +721,17 @@ func (wa *Authorizer) resourceRuleIndex(rules []authzv1.ResourceRule, attr *auth
 		resourceKey = attr.Resource + "/" + attr.Subresource
 	}
 	for i, rule := range rules {
-		if !matchesRule(rule.Verbs, attr.Verb) {
+		if !matchesExactOrAll(rule.Verbs, attr.Verb) {
 			continue
 		}
-		if !matchesRule(rule.APIGroups, attr.Group) {
+		if !matchesExactOrAll(rule.APIGroups, attr.Group) {
 			continue
 		}
-		if !matchesRule(rule.Resources, resourceKey) {
+		if !matchesResourceRule(rule.Resources, resourceKey, attr.Subresource) {
 			continue
 		}
 		// ResourceNames: non-empty list restricts which resource names are allowed.
-		if len(rule.ResourceNames) > 0 && !matchesRule(rule.ResourceNames, attr.Name) {
+		if len(rule.ResourceNames) > 0 && !matchesExactOrAll(rule.ResourceNames, attr.Name) {
 			continue
 		}
 		return i
@@ -742,8 +742,8 @@ func (wa *Authorizer) resourceRuleIndex(rules []authzv1.ResourceRule, attr *auth
 // nonResourceRuleIndex returns the index of the first matching non-resource rule, or -1.
 func (wa *Authorizer) nonResourceRuleIndex(rules []authzv1.NonResourceRule, attr *authzv1.NonResourceAttributes) int {
 	for i, rule := range rules {
-		if matchesRule(rule.Verbs, attr.Verb) &&
-			matchesRule(rule.NonResourceURLs, attr.Path) {
+		if matchesExactOrAll(rule.Verbs, attr.Verb) &&
+			matchesNonResourceURLRule(rule.NonResourceURLs, attr.Path) {
 			return i
 		}
 	}
@@ -842,13 +842,35 @@ func (wa *Authorizer) recordRejectedMetrics(start time.Time) {
 	pkgmetrics.AuthorizerRequestDuration.WithLabelValues(pkgmetrics.AuthorizerDecisionDenied).Observe(duration)
 }
 
-// matchesRule checks if a value matches any pattern in the list.
-func matchesRule(patterns []string, value string) bool {
+// matchesExactOrAll matches Kubernetes ResourceRule fields where only exact
+// values or the full "*" wildcard are supported.
+func matchesExactOrAll(patterns []string, value string) bool {
 	for _, pattern := range patterns {
 		if pattern == "*" || pattern == value {
 			return true
 		}
-		if strings.HasSuffix(pattern, "*") && strings.HasPrefix(value, strings.TrimSuffix(pattern, "*")) {
+	}
+	return false
+}
+
+func matchesResourceRule(patterns []string, resourceKey, subresource string) bool {
+	for _, pattern := range patterns {
+		if pattern == "*" || pattern == resourceKey {
+			return true
+		}
+		if subresource != "" && pattern == "*/"+subresource {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesNonResourceURLRule(patterns []string, path string) bool {
+	for _, pattern := range patterns {
+		if pattern == "*" || pattern == path {
+			return true
+		}
+		if strings.HasSuffix(pattern, "/*") && strings.HasPrefix(path, strings.TrimSuffix(pattern, "*")) {
 			return true
 		}
 	}

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -54,6 +54,7 @@ const maxRequestBodySize = 1 << 20 // 1MB
 const (
 	reasonEmptyIdentity           = "empty user identity and no groups"
 	reasonMissingAttrs            = "missing resource and non-resource attributes"
+	reasonMultipleAttrs           = "resource and non-resource attributes are mutually exclusive"
 	reasonInternalEvaluationError = "internal evaluation error"
 )
 
@@ -181,9 +182,11 @@ func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	items := append([]authorizationv1alpha1.WebhookAuthorizer(nil), globalItems...)
 
 	// Always keep scoped authorizers loaded so the active-rules gauge reflects the
-	// full set regardless of request type. Scoped authorizers are only used
-	// for evaluation when the SAR targets a specific namespace.
-	if sar.Spec.ResourceAttributes != nil && sar.Spec.ResourceAttributes.Namespace != "" {
+	// full set regardless of request type. Scoped authorizers are only used for
+	// namespaced evaluation when the SAR targets a specific namespace; for
+	// resource SARs without a namespace, they may only fail closed through a
+	// matching deniedPrincipal/resourceRule.
+	if sar.Spec.ResourceAttributes != nil {
 		items = append(items, scopedItems...)
 	}
 
@@ -520,6 +523,22 @@ func (wa *Authorizer) evaluateSAR(ctx context.Context, sar *authzv1.SubjectAcces
 				resourceNS = sar.Spec.ResourceAttributes.Namespace
 			}
 			if resourceNS == "" {
+				if sar.Spec.ResourceAttributes != nil &&
+					wa.principalMatches(sar.Spec.User, sar.Spec.Groups, webhookAuthorizer.Spec.DeniedPrincipals) {
+					if ruleIdx := wa.resourceRuleIndex(webhookAuthorizer.Spec.ResourceRules, sar.Spec.ResourceAttributes); ruleIdx >= 0 {
+						evaluated++
+						return evaluationResult{
+							allowed:        false,
+							reason:         fmt.Sprintf("Access denied by WebhookAuthorizer %s", webhookAuthorizer.Name),
+							decision:       pkgmetrics.AuthorizerDecisionDenied,
+							authorizerName: webhookAuthorizer.Name,
+							matchedRule:    ruleIdx,
+							matchedField:   "deniedPrincipal",
+							evaluatedCount: evaluated,
+							skippedCount:   skipped,
+						}, nil
+					}
+				}
 				wa.Log.V(2).Info("skipping namespace-scoped authorizer for non-namespaced SAR",
 					"authorizer", webhookAuthorizer.Name)
 				skipped++
@@ -799,6 +818,9 @@ func validateSAR(sar *authzv1.SubjectAccessReview) string {
 	}
 	if sar.Spec.ResourceAttributes == nil && sar.Spec.NonResourceAttributes == nil {
 		return reasonMissingAttrs
+	}
+	if sar.Spec.ResourceAttributes != nil && sar.Spec.NonResourceAttributes != nil {
+		return reasonMultipleAttrs
 	}
 	return ""
 }

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -1839,6 +1839,56 @@ func TestResourceRuleIndex_ResourceNamesMatching(t *testing.T) {
 	})
 }
 
+func TestResourceRuleIndex_KubernetesWildcardSemantics(t *testing.T) {
+	scheme := newScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+
+	tests := []struct {
+		name string
+		rule authzv1.ResourceRule
+		attr authzv1.ResourceAttributes
+		want bool
+	}{
+		{
+			name: "resource prefix wildcard is not supported",
+			rule: authzv1.ResourceRule{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pod*"}},
+			attr: authzv1.ResourceAttributes{Verb: "get", Group: "", Resource: "pods"},
+		},
+		{
+			name: "all resources subresource wildcard matches requested subresource",
+			rule: authzv1.ResourceRule{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"*/log"}},
+			attr: authzv1.ResourceAttributes{Verb: "get", Group: "", Resource: "pods", Subresource: "log"},
+			want: true,
+		},
+		{
+			name: "api group prefix wildcard is not supported",
+			rule: authzv1.ResourceRule{Verbs: []string{"get"}, APIGroups: []string{"apps*"}, Resources: []string{"deployments"}},
+			attr: authzv1.ResourceAttributes{Verb: "get", Group: "apps.example.com", Resource: "deployments"},
+		},
+		{
+			name: "resource name prefix wildcard is not supported",
+			rule: authzv1.ResourceRule{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"secrets"}, ResourceNames: []string{"prod-*"}},
+			attr: authzv1.ResourceAttributes{Verb: "get", Group: "", Resource: "secrets", Name: "prod-secret"},
+		},
+		{
+			name: "verb prefix wildcard is not supported",
+			rule: authzv1.ResourceRule{Verbs: []string{"get*"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			attr: authzv1.ResourceAttributes{Verb: "get", Group: "", Resource: "pods"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := handler.resourceRuleIndex([]authzv1.ResourceRule{tt.rule}, &tt.attr)
+			got := idx >= 0
+			if got != tt.want {
+				t.Fatalf("resourceRuleIndex() matched = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNonResourceRuleIndex_SuffixWildcardMatching(t *testing.T) {
 	scheme := newScheme(t)
 	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
@@ -1861,6 +1911,28 @@ func TestNonResourceRuleIndex_SuffixWildcardMatching(t *testing.T) {
 		idx := handler.nonResourceRuleIndex(rules, attr)
 		if idx >= 0 {
 			t.Errorf("expected no match for unrelated path, got rule index %d", idx)
+		}
+	})
+
+	t.Run("non-terminal wildcard does not match child path", func(t *testing.T) {
+		prefixRules := []authzv1.NonResourceRule{
+			{Verbs: []string{"get"}, NonResourceURLs: []string{"/api*"}},
+		}
+		attr := &authzv1.NonResourceAttributes{Verb: "get", Path: "/api/v1"}
+		idx := handler.nonResourceRuleIndex(prefixRules, attr)
+		if idx >= 0 {
+			t.Errorf("expected no match for unsupported /api* wildcard, got rule index %d", idx)
+		}
+	})
+
+	t.Run("non-terminal wildcard does not match sibling path", func(t *testing.T) {
+		prefixRules := []authzv1.NonResourceRule{
+			{Verbs: []string{"get"}, NonResourceURLs: []string{"/api*"}},
+		}
+		attr := &authzv1.NonResourceAttributes{Verb: "get", Path: "/apis"}
+		idx := handler.nonResourceRuleIndex(prefixRules, attr)
+		if idx >= 0 {
+			t.Errorf("expected no match for unsupported /api* wildcard, got rule index %d", idx)
 		}
 	})
 }

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -248,6 +248,61 @@ func TestServeHTTP_AuthorizerRulesUseLiveClient(t *testing.T) {
 	}
 }
 
+func TestServeHTTP_ScopedAuthorizerDeniesClusterScopedResourceSAR(t *testing.T) {
+	scheme := newScheme(t)
+	scopedDeny := &authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "scoped-cluster-deny"},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			NamespaceSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+			DeniedPrincipals: []authzv1alpha1.Principal{{Groups: []string{"tenant-admins"}}},
+			ResourceRules: []authzv1.ResourceRule{{
+				Verbs:     []string{"delete"},
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"clusterroles"},
+			}},
+		},
+	}
+	handler := &Authorizer{
+		Client: newIndexedClient(scheme, scopedDeny),
+		Log:    logr.Discard(),
+	}
+	sar := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User:   "alice",
+			Groups: []string{"tenant-admins"},
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Verb:     "delete",
+				Group:    "rbac.authorization.k8s.io",
+				Resource: "clusterroles",
+				Name:     "dangerous-role",
+			},
+		},
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(marshalSAR(t, sar)))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d; body: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var resp authzv1.SubjectAccessReview
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status.Allowed {
+		t.Fatal("expected cluster-scoped SAR to be denied")
+	}
+	if !resp.Status.Denied {
+		t.Fatal("expected Denied=true for scoped deniedPrincipal on cluster-scoped resource SAR")
+	}
+	if resp.Status.Reason != "Access denied by WebhookAuthorizer" {
+		t.Fatalf("expected sanitized deny reason, got %q", resp.Status.Reason)
+	}
+}
+
 func TestAuditLog_DenyDecisionAtV0(t *testing.T) {
 	var buf strings.Builder
 	logger := capturingLogger(&buf, 0)
@@ -1452,6 +1507,48 @@ func TestServeHTTP_RejectsNoAttributes(t *testing.T) {
 	}
 	if !strings.Contains(resp.Status.Reason, reasonMissingAttrs) {
 		t.Errorf("expected reason about missing attributes, got: %s", resp.Status.Reason)
+	}
+	if !strings.Contains(buf.String(), "rejecting malformed SubjectAccessReview") {
+		t.Errorf("expected rejection log entry, got:\n%s", buf.String())
+	}
+}
+
+func TestServeHTTP_RejectsBothResourceAndNonResourceAttributes(t *testing.T) {
+	var buf strings.Builder
+	logger := capturingLogger(&buf, 1)
+	scheme := newScheme(t)
+	cl := newIndexedClient(scheme)
+
+	handler := &Authorizer{Client: cl, Log: logger}
+
+	sar := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User:                  "some-user",
+			ResourceAttributes:    &authzv1.ResourceAttributes{Verb: "delete", Resource: "secrets"},
+			NonResourceAttributes: &authzv1.NonResourceAttributes{Verb: "get", Path: "/healthz"},
+		},
+	}
+	body := marshalSAR(t, sar)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	var resp authzv1.SubjectAccessReview
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status.Allowed {
+		t.Error("expected Allowed=false for SAR with both resource and non-resource attributes")
+	}
+	if !resp.Status.Denied {
+		t.Error("expected Denied=true for SAR with both resource and non-resource attributes")
+	}
+	if resp.Status.Reason != reasonMultipleAttrs {
+		t.Errorf("expected reason %q, got: %s", reasonMultipleAttrs, resp.Status.Reason)
 	}
 	if !strings.Contains(buf.String(), "rejecting malformed SubjectAccessReview") {
 		t.Errorf("expected rejection log entry, got:\n%s", buf.String())


### PR DESCRIPTION
## Summary
- match ResourceRule verbs, API groups, and resource names only by exact value or `*`
- support Kubernetes resource subresource wildcard rules like `*/log`
- restrict NonResourceURL wildcard matching to exact, `*`, or terminal `/*` prefixes
- add regression coverage for unsupported prefix-style wildcards

## Validation
- `go test ./internal/webhook/authorization -run 'TestResourceRuleIndex|TestNonResourceRuleIndex' -count=1`\n- `make fmt vet lint`\n- `make test`\n- `git diff --check`