### PR TITLE
fix(webhookauthorizer): require trusted callers for rate limiting

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -331,8 +331,9 @@ Do not pass raw logger instances across helper boundaries when `ctx` is availabl
 | `--cert-rotation-mutating-webhook` | Mutating webhook names to patch with CA bundle | `[]` |
 | `--cert-rotation-validating-webhook` | Validating webhook names to patch with CA bundle | `[]` |
 | `--tdg-migration` | Enable T-DDI to T-CaaS migration mode | `false` |
-| `--authorize-rate-limit` | Per-pod sustained requests/second for authorize endpoint | `100` |
+| `--authorize-rate-limit` | Per-pod sustained requests/second for authorize endpoint | `0` |
 | `--authorize-rate-burst` | Burst size for authorize endpoint rate limiter | `200` |
+| `--authorize-auth-token-file` | Bearer-token file required by `/authorize` callers | `""` |
 
 ## Common Issues & Workarounds
 

--- a/chart/auth-operator/README.md
+++ b/chart/auth-operator/README.md
@@ -92,8 +92,10 @@ Image reference precedence: `digest` > `tag` > `Chart.AppVersion`
 |-----------|-------------|---------|
 | `webhookServer.replicas` | Number of webhook server replicas | `2` |
 | `webhookServer.tdgMigration` | Enable TDG migration mode | `"false"` |
-| `webhookServer.authorizeRateLimit` | Max sustained requests/sec for /authorize endpoint (per pod, 0 to disable) | `100` |
+| `webhookServer.authorizeRateLimit` | Max sustained requests/sec for /authorize endpoint (per pod, 0 to disable; requires caller auth when >0) | `0` |
 | `webhookServer.authorizeRateBurst` | Max burst size for /authorize rate limiter | `200` |
+| `webhookServer.authorizeAuth.tokenSecretName` | Existing Secret with bearer token for /authorize caller authentication | `""` |
+| `webhookServer.authorizeAuth.tokenSecretKey` | Secret key containing the /authorize bearer token | `token` |
 | `webhookServer.resources.limits.cpu` | CPU limit | `150m` |
 | `webhookServer.resources.limits.memory` | Memory limit | `256Mi` |
 | `webhookServer.resources.requests.cpu` | CPU request | `50m` |

--- a/chart/auth-operator/templates/webhook-server-deployment.yaml
+++ b/chart/auth-operator/templates/webhook-server-deployment.yaml
@@ -41,6 +41,9 @@ spec:
         - --tdg-migration={{ .Values.webhookServer.tdgMigration }}
         - --authorize-rate-limit={{ .Values.webhookServer.authorizeRateLimit }}
         - --authorize-rate-burst={{ .Values.webhookServer.authorizeRateBurst }}
+        {{- if .Values.webhookServer.authorizeAuth.tokenSecretName }}
+        - --authorize-auth-token-file=/var/run/auth-operator/authorize-auth/token
+        {{- end }}
         {{- if gt (int .Values.webhookServer.replicas) 1 }}
         - --leader-elect=true
         {{- end }}
@@ -98,6 +101,11 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+        {{- if .Values.webhookServer.authorizeAuth.tokenSecretName }}
+        - mountPath: /var/run/auth-operator/authorize-auth
+          name: authorize-auth-token
+          readOnly: true
+        {{- end }}
         {{- if .Values.metrics.auth.enabled }}
         - mountPath: /tmp/k8s-metrics-server/serving-certs
           name: metrics-certs
@@ -139,6 +147,15 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ include "auth-operator.fullname" . }}-webhook-certs
+      {{- if .Values.webhookServer.authorizeAuth.tokenSecretName }}
+      - name: authorize-auth-token
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.webhookServer.authorizeAuth.tokenSecretName | quote }}
+          items:
+          - key: {{ .Values.webhookServer.authorizeAuth.tokenSecretKey | quote }}
+            path: token
+      {{- end }}
       {{- if .Values.metrics.auth.enabled }}
       - name: metrics-certs
         emptyDir: {}

--- a/chart/auth-operator/values.schema.json
+++ b/chart/auth-operator/values.schema.json
@@ -317,6 +317,34 @@
       "type": "object",
       "description": "Webhook server configuration.",
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "authorizeRateLimit": {
+                "exclusiveMinimum": 0
+              }
+            },
+            "required": ["authorizeRateLimit"]
+          },
+          "then": {
+            "properties": {
+              "authorizeRateBurst": {
+                "minimum": 1
+              },
+              "authorizeAuth": {
+                "properties": {
+                  "tokenSecretName": {
+                    "minLength": 1
+                  }
+                },
+                "required": ["tokenSecretName"]
+              }
+            },
+            "required": ["authorizeAuth"]
+          }
+        }
+      ],
       "properties": {
         "replicas": {
           "type": "integer",
@@ -332,15 +360,33 @@
         },
         "authorizeRateLimit": {
           "type": "number",
-          "description": "Maximum sustained requests per second for the /authorize endpoint. Set to 0 to disable rate limiting. Per-pod limit.",
+          "description": "Maximum sustained requests per second for the /authorize endpoint. Set to 0 to disable rate limiting. Per-pod limit. Requires webhookServer.authorizeAuth.tokenSecretName when > 0.",
           "minimum": 0,
-          "default": 100
+          "default": 0
         },
         "authorizeRateBurst": {
           "type": "integer",
           "description": "Maximum burst size for the /authorize rate limiter. Must be >= 1 when rate limiting is enabled.",
           "minimum": 0,
           "default": 200
+        },
+        "authorizeAuth": {
+          "type": "object",
+          "description": "Optional bearer-token authentication for /authorize callers.",
+          "additionalProperties": false,
+          "properties": {
+            "tokenSecretName": {
+              "type": "string",
+              "description": "Existing Secret name containing the bearer token required for /authorize requests. Leave empty to disable caller authentication.",
+              "default": ""
+            },
+            "tokenSecretKey": {
+              "type": "string",
+              "description": "Key in tokenSecretName that contains the bearer token.",
+              "minLength": 1,
+              "default": "token"
+            }
+          }
         },
         "podDisruptionBudget": {
           "type": "object",

--- a/chart/auth-operator/values.yaml
+++ b/chart/auth-operator/values.yaml
@@ -107,12 +107,21 @@ webhookServer:
   replicas: 2
   tdgMigration: "false"
   # Maximum sustained requests per second for the /authorize endpoint.
+  # Disabled by default because rate limiting must only be enabled when
+  # authorizeAuth.tokenSecretName is configured for trusted callers.
   # Note: this limit is per pod. In HA deployments with multiple replicas,
   # the effective cluster-wide rate limit is (replicas × authorizeRateLimit).
-  authorizeRateLimit: 100
+  authorizeRateLimit: 0
   # Maximum burst size for the /authorize rate limiter.
   # Must be >= 1 when rate limiting is enabled.
   authorizeRateBurst: 200
+  authorizeAuth:
+    # Optional existing Secret containing the bearer token required for
+    # /authorize requests. Keep empty to leave caller authentication disabled.
+    # When authorizeRateLimit is > 0, this Secret must be configured and the
+    # API server authorization webhook kubeconfig must use the same token.
+    tokenSecretName: ""
+    tokenSecretKey: token
   podDisruptionBudget:
     # Enable PodDisruptionBudget for high availability
     enabled: true

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -9,6 +9,8 @@ package cmd
 
 import (
 	"flag"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -200,6 +202,68 @@ func TestValidateRateLimitFlags(t *testing.T) {
 	}
 }
 
+func TestValidateAuthorizeConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		limit       float64
+		burst       int
+		tokenFile   string
+		expectError bool
+	}{
+		{"disabled without token", 0, 0, "", false},
+		{"token without rate limit", 0, 0, "/var/run/token", false},
+		{"rate limit with token", 100, 200, "/var/run/token", false},
+		{"rate limit without token", 100, 200, "", true},
+		{"invalid burst with token", 100, 0, "/var/run/token", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAuthorizeConfig(tt.limit, tt.burst, tt.tokenFile)
+			if (err != nil) != tt.expectError {
+				t.Errorf("validateAuthorizeConfig(%v, %d, %q): expected error=%v, got %v",
+					tt.limit, tt.burst, tt.tokenFile, tt.expectError, err)
+			}
+		})
+	}
+}
+
+func TestLoadAuthorizeAuthToken(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenFile, []byte("shared-token\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	emptyFile := filepath.Join(dir, "empty")
+	if err := os.WriteFile(emptyFile, []byte("  \n"), 0o600); err != nil {
+		t.Fatalf("write empty token file: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		path        string
+		want        string
+		expectError bool
+	}{
+		{"disabled", "", "", false},
+		{"trims token file", tokenFile, "shared-token", false},
+		{"empty token file", emptyFile, "", true},
+		{"missing token file", filepath.Join(dir, "missing"), "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := loadAuthorizeAuthToken(tt.path)
+			if (err != nil) != tt.expectError {
+				t.Fatalf("loadAuthorizeAuthToken(%q): expected error=%v, got %v", tt.path, tt.expectError, err)
+			}
+			if got != tt.want {
+				t.Errorf("loadAuthorizeAuthToken(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRootCommandStructure(t *testing.T) {
 	// Verify rootCmd has expected subcommands
 	subcommands := rootCmd.Commands()
@@ -276,6 +340,9 @@ func TestWebhookCmdFlags(t *testing.T) {
 		"cert-rotation-mutating-webhook",
 		"cert-rotation-validating-webhook",
 		"tdg-migration",
+		"authorize-rate-limit",
+		"authorize-rate-burst",
+		"authorize-auth-token-file",
 	}
 
 	for _, name := range expectedFlags {
@@ -334,6 +401,9 @@ func TestFlagDefaults(t *testing.T) {
 		{"webhook", "enable-http2", "false"},
 		{"webhook", "disable-cert-rotation", "false"},
 		{"webhook", "tdg-migration", "false"},
+		{"webhook", "authorize-rate-limit", "0"},
+		{"webhook", "authorize-rate-burst", "200"},
+		{"webhook", "authorize-auth-token-file", ""},
 	}
 
 	for _, tt := range tests {

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -44,6 +45,7 @@ var (
 	enableTDGMigration             bool
 	authorizeRateLimit             float64
 	authorizeRateBurst             int
+	authorizeAuthTokenFile         string
 	webhookLeaderElect             bool
 )
 
@@ -255,9 +257,14 @@ func configureWebhooks(mgr manager.Manager, tp *tracing.Provider) error {
 		Log:    ctrl.Log.WithName("Authorizer"),
 		Tracer: tp.TracerIfEnabled(),
 	}
-	if err := validateRateLimitFlags(authorizeRateLimit, authorizeRateBurst); err != nil {
+	if err := validateAuthorizeConfig(authorizeRateLimit, authorizeRateBurst, authorizeAuthTokenFile); err != nil {
 		return err
 	}
+	token, err := loadAuthorizeAuthToken(authorizeAuthTokenFile)
+	if err != nil {
+		return err
+	}
+	authorizer.BearerToken = token
 	if authorizeRateLimit > 0 {
 		authorizer.Limiter = rate.NewLimiter(rate.Limit(authorizeRateLimit), authorizeRateBurst)
 		log.Info("rate limiting enabled for /authorize",
@@ -352,10 +359,13 @@ func init() {
 
 	webhookCmd.Flags().BoolVar(&enableTDGMigration, "tdg-migration", false,
 		"If set, the legacy labels and behavior for TDG migration will be enabled.")
-	webhookCmd.Flags().Float64Var(&authorizeRateLimit, "authorize-rate-limit", 100,
+	webhookCmd.Flags().Float64Var(&authorizeRateLimit, "authorize-rate-limit", 0,
 		"Maximum sustained requests per second for the /authorize endpoint. Set to 0 to disable rate limiting.")
 	webhookCmd.Flags().IntVar(&authorizeRateBurst, "authorize-rate-burst", 200,
 		"Maximum burst size for the /authorize endpoint rate limiter.")
+	webhookCmd.Flags().StringVar(&authorizeAuthTokenFile, "authorize-auth-token-file", "",
+		"Path to a file containing the bearer token required for /authorize requests. "+
+			"Required when /authorize rate limiting is enabled.")
 
 	webhookCmd.Flags().BoolVar(&webhookLeaderElect, "leader-elect", false,
 		"Enable leader election for the webhook manager. Required when running "+
@@ -371,4 +381,30 @@ func validateRateLimitFlags(limit float64, burst int) error {
 		return fmt.Errorf("--authorize-rate-burst must be positive when rate limiting is enabled, got %d", burst)
 	}
 	return nil
+}
+
+// validateAuthorizeConfig validates /authorize rate-limit and caller-auth settings.
+func validateAuthorizeConfig(limit float64, burst int, tokenFile string) error {
+	if err := validateRateLimitFlags(limit, burst); err != nil {
+		return err
+	}
+	if limit > 0 && tokenFile == "" {
+		return fmt.Errorf("--authorize-rate-limit requires --authorize-auth-token-file to prevent untrusted callers from consuming another subject's limit")
+	}
+	return nil
+}
+
+func loadAuthorizeAuthToken(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	tokenBytes, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read --authorize-auth-token-file: %w", err)
+	}
+	token := strings.TrimSpace(string(tokenBytes))
+	if token == "" {
+		return "", fmt.Errorf("--authorize-auth-token-file must not be empty")
+	}
+	return token, nil
 }

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -240,8 +240,9 @@ the assignment.
 | `--cert-rotation-mutating-webhook` | Mutating webhook names to patch with CA bundle | `[]` |
 | `--cert-rotation-validating-webhook` | Validating webhook names to patch with CA bundle | `[]` |
 | `--tdg-migration` | Enable T-DDI to T-CaaS migration mode | `false` |
-| `--authorize-rate-limit` | Per-pod sustained requests/second for authorize endpoint | `100` |
+| `--authorize-rate-limit` | Per-pod sustained requests/second for authorize endpoint | `0` |
 | `--authorize-rate-burst` | Burst size for authorize endpoint rate limiter | `200` |
+| `--authorize-auth-token-file` | Bearer-token file required by `/authorize` callers | `""` |
 
 ### Helm Values
 
@@ -270,8 +271,11 @@ controller:
 webhookServer:
   replicas: 2
   tdgMigration: "false"  # Enable for T-DDI to T-CaaS migration
-  authorizeRateLimit: 100   # Per-pod sustained requests/second
+  authorizeRateLimit: 0     # Per-pod sustained requests/second; 0 disables
   authorizeRateBurst: 200   # Burst size for rate limiter
+  authorizeAuth:
+    tokenSecretName: ""     # Existing Secret with the /authorize bearer token
+    tokenSecretKey: token
   resources:
     limits:
       cpu: 150m
@@ -502,15 +506,30 @@ Helm values to create them.
 
 ### Rate Limiting
 
-The `/authorize` webhook endpoint supports token-bucket rate limiting to
-protect the API server from excessive authorization requests. Configure it
-via Helm values:
+The `/authorize` webhook endpoint supports optional bearer-token caller
+authentication and token-bucket rate limiting. Caller authentication is
+disabled by default. Rate limiting is also disabled by default because it must
+only be enabled for trusted callers; otherwise, any pod that can reach the
+Service could spoof a SubjectAccessReview for another user and consume that
+user's limiter bucket.
+
+Create a shared token Secret in the release namespace and configure the API
+server authorization webhook kubeconfig to send the same bearer token. Then set
+the Helm values:
 
 ```yaml
 webhookServer:
+  authorizeAuth:
+    tokenSecretName: auth-operator-authorize-token
+    tokenSecretKey: token
   authorizeRateLimit: 100   # sustained requests per second per pod
   authorizeRateBurst: 200   # burst capacity
 ```
+
+When `authorizeAuth.tokenSecretName` is set, requests to `/authorize` must
+include `Authorization: Bearer <token>` before the request body is decoded.
+Setting `authorizeRateLimit` above zero without `authorizeAuth.tokenSecretName`
+causes the webhook server to fail startup.
 
 When rate limiting is active and the token bucket is exhausted, the webhook
 returns a valid `SubjectAccessReview` response with `Allowed: false` and
@@ -521,11 +540,6 @@ metric tracks how often this occurs.
 > replicas, the effective cluster-wide limit is `replicas × authorizeRateLimit`.
 
 Set `authorizeRateLimit: 0` to disable rate limiting entirely.
-
-> **Upgrade Note:** Rate limiting is **enabled by default** at 100 req/s
-> (burst 200). Existing clusters upgrading to this version will start
-> enforcing the limit automatically. Set `authorizeRateLimit: 0` to
-> restore the previous unlimited behaviour.
 
 **Webhook server** — Only allows ingress on port 9443 (webhook) from all
 namespaces (required for kube-apiserver on host network) and port 8081

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -2,6 +2,8 @@ package webhooks
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -55,6 +57,7 @@ const (
 	reasonEmptyIdentity           = "empty user identity and no groups"
 	reasonMissingAttrs            = "missing resource and non-resource attributes"
 	reasonInternalEvaluationError = "internal evaluation error"
+	reasonUnauthorized            = "unauthorized"
 )
 
 // Decision values used in structured audit log entries are defined in
@@ -82,6 +85,9 @@ type Authorizer struct {
 	Client client.Reader
 	Log    logr.Logger
 	Tracer trace.Tracer
+	// BearerToken is optional. When set, /authorize requests must include
+	// Authorization: Bearer <token> before the request body is trusted.
+	BearerToken string
 	// Limiter is used as a per-subject limiter template. Each SAR subject gets
 	// an independent token bucket with this limit and burst, preventing one
 	// identity from consuming another identity's authorization budget.
@@ -112,6 +118,11 @@ func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			wa.Log.Error(err, "failed to close request body")
 		}
 	}()
+
+	if !wa.authenticateRequest(w, r) {
+		wa.recordRejectedMetrics(start)
+		return
+	}
 
 	// Extract trace context and start a tracing span only when tracing is
 	// enabled (non-nil Tracer). When disabled, this avoids header parsing and
@@ -823,6 +834,25 @@ func (wa *Authorizer) writeDeniedResponse(w http.ResponseWriter, reason string) 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		wa.Log.Error(err, "failed to encode denied response")
 	}
+}
+
+func (wa *Authorizer) authenticateRequest(w http.ResponseWriter, r *http.Request) bool {
+	if wa.BearerToken == "" {
+		return true
+	}
+	token, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if !ok || token == "" || !constantTimeTokenEqual(token, wa.BearerToken) {
+		wa.Log.V(1).Info("rejecting unauthorized SubjectAccessReview request")
+		wa.writeDeniedResponse(w, reasonUnauthorized)
+		return false
+	}
+	return true
+}
+
+func constantTimeTokenEqual(a, b string) bool {
+	aHash := sha256.Sum256([]byte(a))
+	bHash := sha256.Sum256([]byte(b))
+	return subtle.ConstantTimeCompare(aHash[:], bHash[:]) == 1
 }
 
 // recordErrorMetrics records Prometheus request counter and duration histogram

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -1216,6 +1216,87 @@ func TestServeHTTP_RateLimiting(t *testing.T) {
 	}
 }
 
+func TestServeHTTP_BearerTokenRequiredBeforeRateLimit(t *testing.T) {
+	scheme := newScheme(t)
+	cl := newIndexedClient(scheme)
+	handler := &Authorizer{
+		Client:      cl,
+		Log:         logr.Discard(),
+		BearerToken: "shared-token",
+		Limiter:     rate.NewLimiter(rate.Limit(0), 1),
+	}
+
+	sar := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User:   "test-user",
+			Groups: []string{"test-group"},
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Namespace: "default",
+				Verb:      "get",
+				Resource:  "pods",
+			},
+		},
+	}
+	body := marshalSAR(t, sar)
+	assertUnauthorizedDeny := func(name string, rec *httptest.ResponseRecorder) {
+		t.Helper()
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected %s to return %d with a denied SubjectAccessReview, got %d", name, http.StatusOK, rec.Code)
+		}
+		var response authzv1.SubjectAccessReview
+		if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+			t.Fatalf("decode %s response: %v", name, err)
+		}
+		if response.Status.Allowed {
+			t.Fatalf("%s response should have Allowed=false", name)
+		}
+		if !response.Status.Denied {
+			t.Fatalf("%s response should have Denied=true", name)
+		}
+		if response.Status.Reason != reasonUnauthorized {
+			t.Fatalf("expected %s reason %q, got %q", name, reasonUnauthorized, response.Status.Reason)
+		}
+	}
+
+	unauthorizedReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(body))
+	unauthorizedRec := httptest.NewRecorder()
+	handler.ServeHTTP(unauthorizedRec, unauthorizedReq)
+	assertUnauthorizedDeny("missing bearer token", unauthorizedRec)
+
+	wrongTokenReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(body))
+	wrongTokenReq.Header.Set("Authorization", "Bearer wrong-token")
+	wrongTokenRec := httptest.NewRecorder()
+	handler.ServeHTTP(wrongTokenRec, wrongTokenReq)
+	assertUnauthorizedDeny("wrong bearer token", wrongTokenRec)
+
+	authorizedReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(body))
+	authorizedReq.Header.Set("Authorization", "Bearer shared-token")
+	authorizedRec := httptest.NewRecorder()
+	handler.ServeHTTP(authorizedRec, authorizedReq)
+	if authorizedRec.Code != http.StatusOK {
+		t.Fatalf("expected valid bearer token to return %d, got %d", http.StatusOK, authorizedRec.Code)
+	}
+	var firstResponse authzv1.SubjectAccessReview
+	if err := json.NewDecoder(authorizedRec.Body).Decode(&firstResponse); err != nil {
+		t.Fatalf("decode authorized response: %v", err)
+	}
+	if firstResponse.Status.Reason == "rate limit exceeded" {
+		t.Fatal("unauthorized requests consumed the subject rate-limit bucket")
+	}
+
+	rateLimitedReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(body))
+	rateLimitedReq.Header.Set("Authorization", "Bearer shared-token")
+	rateLimitedRec := httptest.NewRecorder()
+	handler.ServeHTTP(rateLimitedRec, rateLimitedReq)
+	var secondResponse authzv1.SubjectAccessReview
+	if err := json.NewDecoder(rateLimitedRec.Body).Decode(&secondResponse); err != nil {
+		t.Fatalf("decode rate-limited response: %v", err)
+	}
+	if secondResponse.Status.Reason != "rate limit exceeded" {
+		t.Fatalf("expected second authenticated request to be rate-limited, got reason %q", secondResponse.Status.Reason)
+	}
+}
+
 func TestServeHTTP_RateLimitingIsPerSubject(t *testing.T) {
 	scheme := newScheme(t)
 	cl := newIndexedClient(scheme)


### PR DESCRIPTION
## Summary
- keep `/authorize` caller authentication disabled by default and change the rate-limit default to `0`
- add optional bearer-token authentication via `--authorize-auth-token-file` / `webhookServer.authorizeAuth.*`
- reject positive `/authorize` rate limits unless a trusted caller token file is configured
- authenticate callers before decoding SubjectAccessReview bodies or consuming per-subject limiter buckets
- update Helm schema, chart docs, and operator docs for the opt-in flow

## Validation
- `go test ./cmd -run 'TestValidateRateLimitFlags|TestValidateAuthorizeConfig|TestLoadAuthorizeAuthToken|TestWebhookCmdFlags|TestFlagDefaults' -count=1`\n- `go test ./internal/webhook/authorization -run 'TestServeHTTP_(BearerTokenRequiredBeforeRateLimit|RateLimiting|RateLimitingIsPerSubject|NoRateLimiter)' -count=1`\n- `helm lint chart/auth-operator`\n- `helm template auth-operator chart/auth-operator --set webhookServer.authorizeAuth.tokenSecretName=authorize-token --set webhookServer.authorizeRateLimit=100`\n- `helm template auth-operator chart/auth-operator --set webhookServer.authorizeRateLimit=100` (expected schema failure without token Secret)\n- `make helm-lint`\n- `make fmt vet lint`\n- `make test`\n- `git diff --check`