### PR TITLE
docs: clarify plain RBAC API trust boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Auth Operator provides six CRDs for managing RBAC:
 | **RestrictedRoleDefinition** | Policy-governed variant of RoleDefinition |
 | **RestrictedBindDefinition** | Policy-governed variant of BindDefinition |
 
+> **Trust boundary:** Plain `RoleDefinition` and `BindDefinition` write access is
+> for platform-admin or trusted-admin workflows. Writers can cause the operator
+> to create or bind real Kubernetes RBAC. For delegated or self-service RBAC,
+> use `RBACPolicy` with `RestrictedRoleDefinition` and
+> `RestrictedBindDefinition`.
+
 ### 1. Create a RoleDefinition
 
 Generate a ClusterRole that includes all resources *except* those in the deny list:

--- a/api/authorization/v1alpha1/applyconfiguration/authorization/v1alpha1/binddefinition.go
+++ b/api/authorization/v1alpha1/applyconfiguration/authorization/v1alpha1/binddefinition.go
@@ -30,6 +30,9 @@ import (
 // with apply.
 //
 // BindDefinition is the Schema for the binddefinitions API.
+// Write access is intended for platform-admin or trusted-admin workflows
+// because generated bindings affect real Kubernetes RBAC.
+// Use RestrictedBindDefinition under an RBACPolicy for delegated workflows.
 type BindDefinitionApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/api/authorization/v1alpha1/applyconfiguration/authorization/v1alpha1/roledefinition.go
+++ b/api/authorization/v1alpha1/applyconfiguration/authorization/v1alpha1/roledefinition.go
@@ -30,6 +30,9 @@ import (
 // with apply.
 //
 // RoleDefinition is the Schema for the roledefinitions API.
+// Write access is intended for platform-admin or trusted-admin workflows
+// because generated Roles and ClusterRoles affect real Kubernetes RBAC.
+// Use RestrictedRoleDefinition under an RBACPolicy for delegated workflows.
 type RoleDefinitionApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/api/authorization/v1alpha1/binddefinition_types.go
+++ b/api/authorization/v1alpha1/binddefinition_types.go
@@ -217,6 +217,9 @@ type BindDefinitionStatus struct {
 }
 
 // BindDefinition is the Schema for the binddefinitions API.
+// Write access is intended for platform-admin or trusted-admin workflows
+// because generated bindings affect real Kubernetes RBAC.
+// Use RestrictedBindDefinition under an RBACPolicy for delegated workflows.
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=binddefinitions,scope=Cluster,shortName=binddef

--- a/api/authorization/v1alpha1/roledefinition_types.go
+++ b/api/authorization/v1alpha1/roledefinition_types.go
@@ -151,6 +151,9 @@ type RoleDefinitionStatus struct {
 }
 
 // RoleDefinition is the Schema for the roledefinitions API.
+// Write access is intended for platform-admin or trusted-admin workflows
+// because generated Roles and ClusterRoles affect real Kubernetes RBAC.
+// Use RestrictedRoleDefinition under an RBACPolicy for delegated workflows.
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=roledefinitions,scope=Cluster,shortName=roledef

--- a/chart/auth-operator/Chart.yaml
+++ b/chart/auth-operator/Chart.yaml
@@ -51,12 +51,12 @@ annotations:
       version: v1alpha1
       name: roledefinitions.authorization.t-caas.telekom.com
       displayName: RoleDefinition
-      description: Dynamically generates ClusterRoles/Roles based on API discovery
+      description: Trusted-admin API that dynamically generates ClusterRoles/Roles based on API discovery
     - kind: BindDefinition
       version: v1alpha1
       name: binddefinitions.authorization.t-caas.telekom.com
       displayName: BindDefinition
-      description: Creates ClusterRoleBindings/RoleBindings for subjects
+      description: Trusted-admin API that creates ClusterRoleBindings/RoleBindings for subjects
     - kind: WebhookAuthorizer
       version: v1alpha1
       name: webhookauthorizers.authorization.t-caas.telekom.com
@@ -78,6 +78,9 @@ annotations:
       displayName: RestrictedBindDefinition
       description: Creates bounded RoleBindings or ClusterRoleBindings under an RBACPolicy
   artifacthub.io/crdsExamples: |
+    # Plain RoleDefinition and BindDefinition examples are for platform-admin
+    # or trusted-admin authors. Use RBACPolicy with restricted CRDs for
+    # delegated tenant workflows.
     - apiVersion: authorization.t-caas.telekom.com/v1alpha1
       kind: RoleDefinition
       metadata:

--- a/chart/auth-operator/README.md
+++ b/chart/auth-operator/README.md
@@ -217,12 +217,16 @@ helm uninstall auth-operator --namespace auth-operator-system
 
 This chart installs six Custom Resource Definitions:
 
-- **RoleDefinition** - Dynamically generates ClusterRoles/Roles based on API discovery
-- **BindDefinition** - Creates ClusterRoleBindings/RoleBindings for subjects (Users, Groups, ServiceAccounts)
+- **RoleDefinition** - Trusted-admin API that dynamically generates ClusterRoles/Roles based on API discovery
+- **BindDefinition** - Trusted-admin API that creates ClusterRoleBindings/RoleBindings for subjects (Users, Groups, ServiceAccounts)
 - **WebhookAuthorizer** - Configures webhook-based authorization decisions
 - **RBACPolicy** - Defines policy constraints for restricted RBAC resources
 - **RestrictedRoleDefinition** - Policy-governed RoleDefinition with automatic deprovisioning on violations
 - **RestrictedBindDefinition** - Policy-governed BindDefinition with automatic deprovisioning on violations
+
+Plain `RoleDefinition` and `BindDefinition` write access is platform-admin
+equivalent. Use `RBACPolicy` with restricted CRDs for tenant delegation and
+self-service workflows.
 
 For detailed API documentation, see the [API Reference](https://github.com/telekom/auth-operator/blob/main/docs/api-reference/authorization.t-caas.telekom.com.md).
 
@@ -242,6 +246,11 @@ When disabled (default), tracing has zero overhead — no headers are parsed
 and no spans are created.
 
 ## Examples
+
+The plain `RoleDefinition` and `BindDefinition` examples below are intended for
+platform-owned RBAC. Do not delegate write access to these APIs to tenants; use
+`RestrictedRoleDefinition` and `RestrictedBindDefinition` under an `RBACPolicy`
+for delegated workflows.
 
 ### RoleDefinition
 

--- a/chart/auth-operator/crds/binddefinitions.authorization.t-caas.telekom.com.yaml
+++ b/chart/auth-operator/crds/binddefinitions.authorization.t-caas.telekom.com.yaml
@@ -33,7 +33,11 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BindDefinition is the Schema for the binddefinitions API.
+        description: |-
+          BindDefinition is the Schema for the binddefinitions API.
+          Write access is intended for platform-admin or trusted-admin workflows
+          because generated bindings affect real Kubernetes RBAC.
+          Use RestrictedBindDefinition under an RBACPolicy for delegated workflows.
         properties:
           apiVersion:
             description: |-

--- a/chart/auth-operator/crds/roledefinitions.authorization.t-caas.telekom.com.yaml
+++ b/chart/auth-operator/crds/roledefinitions.authorization.t-caas.telekom.com.yaml
@@ -42,7 +42,11 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: RoleDefinition is the Schema for the roledefinitions API.
+        description: |-
+          RoleDefinition is the Schema for the roledefinitions API.
+          Write access is intended for platform-admin or trusted-admin workflows
+          because generated Roles and ClusterRoles affect real Kubernetes RBAC.
+          Use RestrictedRoleDefinition under an RBACPolicy for delegated workflows.
         properties:
           apiVersion:
             description: |-

--- a/chart/auth-operator/templates/NOTES.txt
+++ b/chart/auth-operator/templates/NOTES.txt
@@ -19,6 +19,10 @@ Namespace: {{ .Release.Namespace }}
 
 ## Creating Your First RoleDefinition
 
+Plain RoleDefinition and BindDefinition resources are intended for
+platform-admin or trusted-admin authors. For delegated tenant workflows, use
+RBACPolicy with RestrictedRoleDefinition and RestrictedBindDefinition.
+
 Create a RoleDefinition to generate a ClusterRole:
 
 ```yaml

--- a/config/crd/bases/authorization.t-caas.telekom.com_binddefinitions.yaml
+++ b/config/crd/bases/authorization.t-caas.telekom.com_binddefinitions.yaml
@@ -32,7 +32,11 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BindDefinition is the Schema for the binddefinitions API.
+        description: |-
+          BindDefinition is the Schema for the binddefinitions API.
+          Write access is intended for platform-admin or trusted-admin workflows
+          because generated bindings affect real Kubernetes RBAC.
+          Use RestrictedBindDefinition under an RBACPolicy for delegated workflows.
         properties:
           apiVersion:
             description: |-

--- a/config/crd/bases/authorization.t-caas.telekom.com_roledefinitions.yaml
+++ b/config/crd/bases/authorization.t-caas.telekom.com_roledefinitions.yaml
@@ -41,7 +41,11 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: RoleDefinition is the Schema for the roledefinitions API.
+        description: |-
+          RoleDefinition is the Schema for the roledefinitions API.
+          Write access is intended for platform-admin or trusted-admin workflows
+          because generated Roles and ClusterRoles affect real Kubernetes RBAC.
+          Use RestrictedRoleDefinition under an RBACPolicy for delegated workflows.
         properties:
           apiVersion:
             description: |-

--- a/config/samples/authorization_v1alpha1_binddefinition.yaml
+++ b/config/samples/authorization_v1alpha1_binddefinition.yaml
@@ -5,6 +5,11 @@
 # =============================================================================
 # BindDefinition Samples - Comprehensive Feature Coverage
 # =============================================================================
+# Trust boundary:
+# - Plain BindDefinition writes are intended for platform-admin or trusted-admin
+#   authors because generated bindings affect real Kubernetes RBAC.
+# - Use RBACPolicy with RestrictedBindDefinition for delegated tenant workflows.
+#
 # These samples demonstrate all features of the BindDefinition CRD:
 # - Multiple subject types: User, Group, ServiceAccount
 # - ClusterRoleBindings (cluster-wide access)

--- a/config/samples/authorization_v1alpha1_roledefinition.yaml
+++ b/config/samples/authorization_v1alpha1_roledefinition.yaml
@@ -5,6 +5,11 @@
 # =============================================================================
 # RoleDefinition Samples - Comprehensive Feature Coverage
 # =============================================================================
+# Trust boundary:
+# - Plain RoleDefinition writes are intended for platform-admin or trusted-admin
+#   authors because generated roles affect real Kubernetes RBAC.
+# - Use RBACPolicy with RestrictedRoleDefinition for delegated tenant workflows.
+#
 # These samples demonstrate all features of the RoleDefinition CRD:
 # - ClusterRole and Role targets
 # - API group restrictions (velero, calico, cert-manager)

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -7,6 +7,8 @@ kind: Kustomization
 resources:
   # Prerequisites first — pre-existing RBAC resources the edge-case BDs reference
   - edge-case-prerequisites.yaml
+  # Plain RoleDefinition/BindDefinition samples are platform-admin/trusted-admin
+  # authored examples. Use the restricted samples below for delegated workflows.
   - authorization_v1alpha1_roledefinition.yaml
   - authorization_v1alpha1_binddefinition.yaml
   - authorization_v1alpha1_webhookauthorizer.yaml

--- a/docs/api-reference/authorization.t-caas.telekom.com.md
+++ b/docs/api-reference/authorization.t-caas.telekom.com.md
@@ -29,6 +29,9 @@ Package v1alpha1 contains API Schema definitions for the authorization v1alpha1 
 
 
 BindDefinition is the Schema for the binddefinitions API.
+Write access is intended for platform-admin or trusted-admin workflows
+because generated bindings affect real Kubernetes RBAC.
+Use RestrictedBindDefinition under an RBACPolicy for delegated workflows.
 
 
 
@@ -515,6 +518,9 @@ _Appears in:_
 
 
 RoleDefinition is the Schema for the roledefinitions API.
+Write access is intended for platform-admin or trusted-admin workflows
+because generated Roles and ClusterRoles affect real Kubernetes RBAC.
+Use RestrictedRoleDefinition under an RBACPolicy for delegated workflows.
 
 
 

--- a/docs/breakglass-integration.md
+++ b/docs/breakglass-integration.md
@@ -230,6 +230,10 @@ Both systems support HA deployment:
 
 auth-operator generates the base roles:
 
+The plain `RoleDefinition` and `BindDefinition` examples in this section are
+platform-managed base RBAC. Tenant-delegated changes should use `RBACPolicy`
+with restricted CRDs.
+
 ```yaml
 # RoleDefinition for tenant base access
 apiVersion: authorization.t-caas.telekom.com/v1alpha1

--- a/docs/generated/api-reference.md
+++ b/docs/generated/api-reference.md
@@ -29,6 +29,9 @@ Package v1alpha1 contains API Schema definitions for the authorization v1alpha1 
 
 
 BindDefinition is the Schema for the binddefinitions API.
+Write access is intended for platform-admin or trusted-admin workflows
+because generated bindings affect real Kubernetes RBAC.
+Use RestrictedBindDefinition under an RBACPolicy for delegated workflows.
 
 
 
@@ -515,6 +518,9 @@ _Appears in:_
 
 
 RoleDefinition is the Schema for the roledefinitions API.
+Write access is intended for platform-admin or trusted-admin workflows
+because generated Roles and ClusterRoles affect real Kubernetes RBAC.
+Use RestrictedRoleDefinition under an RBACPolicy for delegated workflows.
 
 
 


### PR DESCRIPTION
## Summary
- state that plain `RoleDefinition` and `BindDefinition` writes are platform-admin/trusted-admin scope
- point delegated tenant/self-service workflows to `RBACPolicy` with restricted CRDs
- add the warning to top-level docs, chart docs/metadata/notes, samples, breakglass examples, CRD descriptions, and generated API reference

## Validation
- `make manifests generate docs helm`
- `make helm-lint`
- `make fmt vet lint`
- `git diff --check`