### PR TITLE
fix(binddefinition): prune stale bindings

### DIFF
--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -532,6 +532,16 @@ func (r *BindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		"bindDefinition", bindDefinition.Name,
 		"missingRoleRefCount", missingRoleRefCount)
 
+	desiredCRBs, desiredRBs := bindDefinitionDesiredBindingKeys(bindDefinition, perRoleBindingNamespaces)
+	if err := r.pruneStaleBindingResources(ctx, bindDefinition, desiredCRBs, desiredRBs, r.client); err != nil {
+		logger.Error(err, "Failed to prune stale BindDefinition resources",
+			"bindDefinition", bindDefinition.Name)
+		r.markStalled(ctx, bindDefinition, err)
+		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultError).Inc()
+		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerBindDefinition, metrics.ErrorTypeAPI).Inc()
+		return ctrl.Result{}, err
+	}
+
 	// Mark Ready and apply final status via SSA (kstatus)
 	logger.V(2).Info("Marking BindDefinition as Ready and applying status",
 		"bindDefinition", bindDefinition.Name,
@@ -930,7 +940,7 @@ func (r *BindDefinitionReconciler) checkBindingOwnership(
 		return fmt.Errorf("unknown target binding kind %q", targetKind)
 	}
 
-	if err := r.client.Get(ctx, key, existing); err != nil {
+	if err := r.ownershipReader().Get(ctx, key, existing); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
@@ -962,7 +972,7 @@ func (r *BindDefinitionReconciler) deleteOwnedRoleBindingOnRoleRefChange(
 	desiredRoleRef rbacv1.RoleRef,
 ) error {
 	existing := &rbacv1.RoleBinding{}
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, existing); err != nil {
+	if err := r.ownershipReader().Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, existing); err != nil {
 		return client.IgnoreNotFound(err)
 	}
 	if !hasControllerOwnerRef(existing, bindDef) || existing.RoleRef == desiredRoleRef {
@@ -973,6 +983,130 @@ func (r *BindDefinitionReconciler) deleteOwnedRoleBindingOnRoleRefChange(
 	}
 	metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceRoleBinding).Inc()
 	return nil
+}
+
+func (r *BindDefinitionReconciler) ownershipReader() client.Reader {
+	if r.reader != nil {
+		return r.reader
+	}
+	return r.client
+}
+
+func bindDefinitionDesiredBindingKeys(
+	bindDef *authorizationv1alpha1.BindDefinition,
+	perRoleBindingNamespaces [][]corev1.Namespace,
+) (desiredCRBs, desiredRBs map[string]struct{}) {
+	desiredCRBs = make(map[string]struct{})
+	for _, clusterRoleRef := range bindDef.Spec.ClusterRoleBindings.ClusterRoleRefs {
+		desiredCRBs[helpers.BuildBindingName(bindDef.Spec.TargetName, clusterRoleRef)] = struct{}{}
+	}
+
+	desiredRBs = make(map[string]struct{})
+	for i, roleBinding := range bindDef.Spec.RoleBindings {
+		if i >= len(perRoleBindingNamespaces) {
+			break
+		}
+		for _, ns := range perRoleBindingNamespaces[i] {
+			if conditions.IsNamespaceTerminating(&ns) {
+				continue
+			}
+			for _, clusterRoleRef := range roleBinding.ClusterRoleRefs {
+				key := ns.Name + "/" + helpers.BuildBindingName(bindDef.Spec.TargetName, clusterRoleRef)
+				desiredRBs[key] = struct{}{}
+			}
+			for _, roleRef := range roleBinding.RoleRefs {
+				key := ns.Name + "/" + helpers.BuildBindingName(bindDef.Spec.TargetName, roleRef)
+				desiredRBs[key] = struct{}{}
+			}
+		}
+	}
+
+	return desiredCRBs, desiredRBs
+}
+
+func (r *BindDefinitionReconciler) listOwnedClusterRoleBindings(
+	ctx context.Context,
+	bindDef *authorizationv1alpha1.BindDefinition,
+) ([]rbacv1.ClusterRoleBinding, error) {
+	crbList := &rbacv1.ClusterRoleBindingList{}
+	if err := r.ownershipReader().List(ctx, crbList); err != nil {
+		return nil, fmt.Errorf("list ClusterRoleBindings for ownerRef cleanup: %w", err)
+	}
+	owned := make([]rbacv1.ClusterRoleBinding, 0, len(crbList.Items))
+	for i := range crbList.Items {
+		if hasControllerOwnerRef(&crbList.Items[i], bindDef) {
+			owned = append(owned, crbList.Items[i])
+		}
+	}
+	return owned, nil
+}
+
+func (r *BindDefinitionReconciler) listOwnedRoleBindings(
+	ctx context.Context,
+	bindDef *authorizationv1alpha1.BindDefinition,
+) ([]rbacv1.RoleBinding, error) {
+	rbList := &rbacv1.RoleBindingList{}
+	if err := r.ownershipReader().List(ctx, rbList); err != nil {
+		return nil, fmt.Errorf("list RoleBindings for ownerRef cleanup: %w", err)
+	}
+	owned := make([]rbacv1.RoleBinding, 0, len(rbList.Items))
+	for i := range rbList.Items {
+		if hasControllerOwnerRef(&rbList.Items[i], bindDef) {
+			owned = append(owned, rbList.Items[i])
+		}
+	}
+	return owned, nil
+}
+
+func (r *BindDefinitionReconciler) pruneStaleBindingResources(
+	ctx context.Context,
+	bindDef *authorizationv1alpha1.BindDefinition,
+	desiredCRBs map[string]struct{},
+	desiredRBs map[string]struct{},
+	deleteClient client.Client,
+) error {
+	logger := log.FromContext(ctx)
+	if deleteClient == nil {
+		deleteClient = r.client
+	}
+
+	var pruneErrors []error
+	crbs, err := r.listOwnedClusterRoleBindings(ctx, bindDef)
+	if err != nil {
+		return fmt.Errorf("list owned ClusterRoleBindings for pruning: %w", err)
+	}
+	for i := range crbs {
+		crb := &crbs[i]
+		if _, ok := desiredCRBs[crb.Name]; ok {
+			continue
+		}
+		logger.Info("pruning stale ClusterRoleBinding", "name", crb.Name, "bindDefinition", bindDef.Name)
+		if err := deleteClient.Delete(ctx, crb); err != nil && !apierrors.IsNotFound(err) {
+			pruneErrors = append(pruneErrors, fmt.Errorf("delete stale ClusterRoleBinding %s: %w", crb.Name, err))
+			continue
+		}
+		metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceClusterRoleBinding).Inc()
+	}
+
+	rbs, err := r.listOwnedRoleBindings(ctx, bindDef)
+	if err != nil {
+		return fmt.Errorf("list owned RoleBindings for pruning: %w", err)
+	}
+	for i := range rbs {
+		rb := &rbs[i]
+		key := rb.Namespace + "/" + rb.Name
+		if _, ok := desiredRBs[key]; ok {
+			continue
+		}
+		logger.Info("pruning stale RoleBinding", "namespace", rb.Namespace, "name", rb.Name, "bindDefinition", bindDef.Name)
+		if err := deleteClient.Delete(ctx, rb); err != nil && !apierrors.IsNotFound(err) {
+			pruneErrors = append(pruneErrors, fmt.Errorf("delete stale RoleBinding %s/%s: %w", rb.Namespace, rb.Name, err))
+			continue
+		}
+		metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceRoleBinding).Inc()
+	}
+
+	return errors.Join(pruneErrors...)
 }
 
 // validateServiceAccountNamespace checks if the namespace exists and is not terminating.

--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -532,7 +532,15 @@ func (r *BindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		"bindDefinition", bindDefinition.Name,
 		"missingRoleRefCount", missingRoleRefCount)
 
-	desiredCRBs, desiredRBs := bindDefinitionDesiredBindingKeys(bindDefinition, perRoleBindingNamespaces)
+	desiredCRBs, desiredRBs, err := bindDefinitionDesiredBindingKeys(bindDefinition, perRoleBindingNamespaces)
+	if err != nil {
+		logger.Error(err, "Failed to compute desired BindDefinition resource keys",
+			"bindDefinition", bindDefinition.Name)
+		r.markStalled(ctx, bindDefinition, err)
+		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultError).Inc()
+		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerBindDefinition, metrics.ErrorTypeAPI).Inc()
+		return ctrl.Result{}, err
+	}
 	if err := r.pruneStaleBindingResources(ctx, bindDefinition, desiredCRBs, desiredRBs, r.client); err != nil {
 		logger.Error(err, "Failed to prune stale BindDefinition resources",
 			"bindDefinition", bindDefinition.Name)
@@ -995,18 +1003,25 @@ func (r *BindDefinitionReconciler) ownershipReader() client.Reader {
 func bindDefinitionDesiredBindingKeys(
 	bindDef *authorizationv1alpha1.BindDefinition,
 	perRoleBindingNamespaces [][]corev1.Namespace,
-) (desiredCRBs, desiredRBs map[string]struct{}) {
+) (desiredCRBs, desiredRBs map[string]struct{}, err error) {
 	desiredCRBs = make(map[string]struct{})
 	for _, clusterRoleRef := range bindDef.Spec.ClusterRoleBindings.ClusterRoleRefs {
 		desiredCRBs[helpers.BuildBindingName(bindDef.Spec.TargetName, clusterRoleRef)] = struct{}{}
 	}
 
 	desiredRBs = make(map[string]struct{})
+	if len(perRoleBindingNamespaces) != len(bindDef.Spec.RoleBindings) {
+		return desiredCRBs, desiredRBs, fmt.Errorf("perRoleBindingNamespaces length (%d) does not match RoleBindings length (%d)",
+			len(perRoleBindingNamespaces), len(bindDef.Spec.RoleBindings))
+	}
+
 	for i, roleBinding := range bindDef.Spec.RoleBindings {
 		if i >= len(perRoleBindingNamespaces) {
-			break
+			return desiredCRBs, desiredRBs, fmt.Errorf("perRoleBindingNamespaces length (%d) does not match RoleBindings length (%d)",
+				len(perRoleBindingNamespaces), len(bindDef.Spec.RoleBindings))
 		}
-		for _, ns := range perRoleBindingNamespaces[i] {
+		targetNamespaces := perRoleBindingNamespaces[i] //nolint:gosec // Length equality is checked above and guarded before this parallel-slice access.
+		for _, ns := range targetNamespaces {
 			if conditions.IsNamespaceTerminating(&ns) {
 				continue
 			}
@@ -1021,7 +1036,7 @@ func bindDefinitionDesiredBindingKeys(
 		}
 	}
 
-	return desiredCRBs, desiredRBs
+	return desiredCRBs, desiredRBs, nil
 }
 
 func (r *BindDefinitionReconciler) listOwnedClusterRoleBindings(

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -3545,15 +3545,16 @@ func TestBindDefinitionPruneStaleBindingResources(t *testing.T) {
 		Build()
 	r := &BindDefinitionReconciler{client: c, reader: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-	desiredCRBs, desiredRBs := bindDefinitionDesiredBindingKeys(bindDef, [][]corev1.Namespace{{
+	desiredCRBs, desiredRBs, err := bindDefinitionDesiredBindingKeys(bindDef, [][]corev1.Namespace{{
 		{ObjectMeta: metav1.ObjectMeta{Name: "prune-ns"}},
 	}})
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(r.pruneStaleBindingResources(ctx, bindDef, desiredCRBs, desiredRBs, c)).To(Succeed())
 
 	var crb rbacv1.ClusterRoleBinding
 	g.Expect(c.Get(ctx, types.NamespacedName{Name: desiredCRB.Name}, &crb)).To(Succeed())
 	g.Expect(c.Get(ctx, types.NamespacedName{Name: unownedCRB.Name}, &crb)).To(Succeed())
-	err := c.Get(ctx, types.NamespacedName{Name: staleCRB.Name}, &crb)
+	err = c.Get(ctx, types.NamespacedName{Name: staleCRB.Name}, &crb)
 	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
 	var rb rbacv1.RoleBinding

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -3473,6 +3473,160 @@ func TestReconcileResourcesWithSSAError(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("injected SSA error"))
 }
 
+func TestBindDefinitionPruneStaleBindingResources(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	_ = authorizationv1alpha1.AddToScheme(scheme)
+	_ = rbacv1.SchemeBuilder.AddToScheme(scheme)
+	_ = corev1.SchemeBuilder.AddToScheme(scheme)
+
+	bindDef := &authorizationv1alpha1.BindDefinition{
+		TypeMeta:   metav1.TypeMeta{APIVersion: authorizationv1alpha1.GroupVersion.String(), Kind: "BindDefinition"},
+		ObjectMeta: metav1.ObjectMeta{Name: "prune-bd", UID: "prune-bd-uid"},
+		Spec: authorizationv1alpha1.BindDefinitionSpec{
+			TargetName: "prune-target",
+			Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "devs", APIGroup: rbacv1.GroupName}},
+			ClusterRoleBindings: authorizationv1alpha1.ClusterBinding{
+				ClusterRoleRefs: []string{"view"},
+			},
+			RoleBindings: []authorizationv1alpha1.NamespaceBinding{
+				{Namespace: "prune-ns", ClusterRoleRefs: []string{"edit"}},
+			},
+		},
+	}
+	ownerRef := metav1.OwnerReference{
+		APIVersion: authorizationv1alpha1.GroupVersion.String(),
+		Kind:       "BindDefinition",
+		Name:       bindDef.Name,
+		UID:        bindDef.UID,
+		Controller: boolPtr(true),
+	}
+	desiredCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            helpers.BuildBindingName(bindDef.Spec.TargetName, "view"),
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+	}
+	staleCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            helpers.BuildBindingName(bindDef.Spec.TargetName, "old"),
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+	}
+	unownedCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: helpers.BuildBindingName(bindDef.Spec.TargetName, "external")},
+	}
+	desiredRB := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            helpers.BuildBindingName(bindDef.Spec.TargetName, "edit"),
+			Namespace:       "prune-ns",
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+	}
+	staleRB := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            helpers.BuildBindingName(bindDef.Spec.TargetName, "old"),
+			Namespace:       "prune-ns",
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+	}
+	unownedRB := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helpers.BuildBindingName(bindDef.Spec.TargetName, "external"),
+			Namespace: "prune-ns",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(bindDef, desiredCRB, staleCRB, unownedCRB, desiredRB, staleRB, unownedRB).
+		Build()
+	r := &BindDefinitionReconciler{client: c, reader: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+
+	desiredCRBs, desiredRBs := bindDefinitionDesiredBindingKeys(bindDef, [][]corev1.Namespace{{
+		{ObjectMeta: metav1.ObjectMeta{Name: "prune-ns"}},
+	}})
+	g.Expect(r.pruneStaleBindingResources(ctx, bindDef, desiredCRBs, desiredRBs, c)).To(Succeed())
+
+	var crb rbacv1.ClusterRoleBinding
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: desiredCRB.Name}, &crb)).To(Succeed())
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: unownedCRB.Name}, &crb)).To(Succeed())
+	err := c.Get(ctx, types.NamespacedName{Name: staleCRB.Name}, &crb)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+	var rb rbacv1.RoleBinding
+	g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "prune-ns", Name: desiredRB.Name}, &rb)).To(Succeed())
+	g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "prune-ns", Name: unownedRB.Name}, &rb)).To(Succeed())
+	err = c.Get(ctx, types.NamespacedName{Namespace: "prune-ns", Name: staleRB.Name}, &rb)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+}
+
+func TestBindDefinitionReconcilePrunesSelectorStaleRoleBinding(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	_ = authorizationv1alpha1.AddToScheme(scheme)
+	_ = rbacv1.SchemeBuilder.AddToScheme(scheme)
+	_ = corev1.SchemeBuilder.AddToScheme(scheme)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "selector-prune-ns",
+			Labels: map[string]string{"env": "dev"},
+		},
+		Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	}
+	bindDef := &authorizationv1alpha1.BindDefinition{
+		TypeMeta: metav1.TypeMeta{APIVersion: authorizationv1alpha1.GroupVersion.String(), Kind: "BindDefinition"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "selector-prune-bd",
+			UID:        "selector-prune-bd-uid",
+			Generation: 2,
+		},
+		Spec: authorizationv1alpha1.BindDefinitionSpec{
+			TargetName: "selector-prune-target",
+			Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "devs", APIGroup: rbacv1.GroupName}},
+			RoleBindings: []authorizationv1alpha1.NamespaceBinding{
+				{
+					NamespaceSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"env": "prod"}}},
+					ClusterRoleRefs:   []string{"view"},
+				},
+			},
+		},
+	}
+	staleRB := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helpers.BuildBindingName(bindDef.Spec.TargetName, "view"),
+			Namespace: ns.Name,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: authorizationv1alpha1.GroupVersion.String(),
+				Kind:       "BindDefinition",
+				Name:       bindDef.Name,
+				UID:        bindDef.UID,
+				Controller: boolPtr(true),
+			}},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(bindDef, ns, staleRB).
+		WithStatusSubresource(bindDef).
+		Build()
+	r := &BindDefinitionReconciler{client: c, reader: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+
+	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: bindDef.Name}})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var rb rbacv1.RoleBinding
+	err = c.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: staleRB.Name}, &rb)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+}
+
 func TestReconcileDeleteError(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- prune owned ClusterRoleBindings and RoleBindings that are no longer desired after a BindDefinition spec or namespace-selector shrink
- use the live ownership reader for binding ownership preflight and roleRef-change cleanup when available
- add focused coverage for owned stale resource pruning and selector label-removal cleanup

## Testing
- go test ./internal/controller/authorization -run 'TestBindDefinitionPruneStaleBindingResources|TestBindDefinitionReconcilePrunesSelectorStaleRoleBinding|TestReconcileResourcesWithSSAError|TestEnsureSingleRoleBindingError|TestBindDefinitionDriftDetection' -count=1\n- go test ./internal/controller/authorization -count=1\n- git diff --check