### PR TITLE
fix(rbd): continue cleanup after delete errors

### DIFF
--- a/internal/controller/authorization/restrictedbinddefinition_controller.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller.go
@@ -1154,41 +1154,46 @@ func (r *RestrictedBindDefinitionReconciler) rbdPruneStaleResources(
 	if deleteClient == nil {
 		deleteClient = r.client
 	}
+	var errs []error
 
 	// Prune stale ClusterRoleBindings.
 	crbs, err := r.rbdListOwnedClusterRoleBindings(ctx, rbd)
 	if err != nil {
-		return fmt.Errorf("list owned ClusterRoleBindings for pruning: %w", err)
-	}
-	for i := range crbs {
-		crb := &crbs[i]
-		if _, ok := desiredCRBs[crb.Name]; !ok {
-			logger.Info("pruning stale ClusterRoleBinding", "name", crb.Name, "rbd", rbd.Name)
-			if err := deleteClient.Delete(ctx, crb); err != nil && !apierrors.IsNotFound(err) {
-				return fmt.Errorf("delete stale ClusterRoleBinding %s: %w", crb.Name, err)
+		errs = append(errs, fmt.Errorf("list owned ClusterRoleBindings for pruning: %w", err))
+	} else {
+		for i := range crbs {
+			crb := &crbs[i]
+			if _, ok := desiredCRBs[crb.Name]; !ok {
+				logger.Info("pruning stale ClusterRoleBinding", "name", crb.Name, "rbd", rbd.Name)
+				if err := deleteClient.Delete(ctx, crb); err != nil && !apierrors.IsNotFound(err) {
+					errs = append(errs, fmt.Errorf("delete stale ClusterRoleBinding %s: %w", crb.Name, err))
+					continue
+				}
+				metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceClusterRoleBinding).Inc()
 			}
-			metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceClusterRoleBinding).Inc()
 		}
 	}
 
 	// Prune stale RoleBindings.
 	rbs, err := r.rbdListOwnedRoleBindings(ctx, rbd)
 	if err != nil {
-		return fmt.Errorf("list owned RoleBindings for pruning: %w", err)
-	}
-	for i := range rbs {
-		rb := &rbs[i]
-		key := rb.Namespace + "/" + rb.Name
-		if _, ok := desiredRBs[key]; !ok {
-			logger.Info("pruning stale RoleBinding", "namespace", rb.Namespace, "name", rb.Name, "rbd", rbd.Name)
-			if err := deleteClient.Delete(ctx, rb); err != nil && !apierrors.IsNotFound(err) {
-				return fmt.Errorf("delete stale RoleBinding %s/%s: %w", rb.Namespace, rb.Name, err)
+		errs = append(errs, fmt.Errorf("list owned RoleBindings for pruning: %w", err))
+	} else {
+		for i := range rbs {
+			rb := &rbs[i]
+			key := rb.Namespace + "/" + rb.Name
+			if _, ok := desiredRBs[key]; !ok {
+				logger.Info("pruning stale RoleBinding", "namespace", rb.Namespace, "name", rb.Name, "rbd", rbd.Name)
+				if err := deleteClient.Delete(ctx, rb); err != nil && !apierrors.IsNotFound(err) {
+					errs = append(errs, fmt.Errorf("delete stale RoleBinding %s/%s: %w", rb.Namespace, rb.Name, err))
+					continue
+				}
+				metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceRoleBinding).Inc()
 			}
-			metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceRoleBinding).Inc()
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (r *RestrictedBindDefinitionReconciler) rbdPruneStaleServiceAccounts(
@@ -1207,6 +1212,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdPruneStaleServiceAccounts(
 	if err != nil {
 		return fmt.Errorf("list owned ServiceAccounts for pruning: %w", err)
 	}
+	var errs []error
 	for i := range serviceAccounts {
 		sa := &serviceAccounts[i]
 		key := sa.Namespace + "/" + sa.Name
@@ -1220,11 +1226,12 @@ func (r *RestrictedBindDefinitionReconciler) rbdPruneStaleServiceAccounts(
 		}
 		logger.Info("pruning stale ServiceAccount", "namespace", sa.Namespace, "name", sa.Name, "rbd", rbd.Name)
 		if err := deleteClient.Delete(ctx, sa); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("delete stale ServiceAccount %s: %w", key, err)
+			errs = append(errs, fmt.Errorf("delete stale ServiceAccount %s: %w", key, err))
+			continue
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // rbdEnsureServiceAccounts ensures all ServiceAccount subjects exist, tracking
@@ -1627,34 +1634,42 @@ func (r *RestrictedBindDefinitionReconciler) rbdDeprovision(
 	if deleteClient == nil {
 		deleteClient = r.client
 	}
+	var errs []error
 
 	// Delete owned ClusterRoleBindings.
 	crbs, err := r.rbdListOwnedClusterRoleBindings(ctx, rbd)
 	if err != nil {
-		return fmt.Errorf("list owned ClusterRoleBindings: %w", err)
-	}
-	for i := range crbs {
-		crb := &crbs[i]
-		if err := deleteClient.Delete(ctx, crb); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("delete ClusterRoleBinding %s: %w", crb.Name, err)
+		errs = append(errs, fmt.Errorf("list owned ClusterRoleBindings: %w", err))
+	} else {
+		for i := range crbs {
+			crb := &crbs[i]
+			if err := deleteClient.Delete(ctx, crb); err != nil && !apierrors.IsNotFound(err) {
+				errs = append(errs, fmt.Errorf("delete ClusterRoleBinding %s: %w", crb.Name, err))
+				continue
+			}
+			metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceClusterRoleBinding).Inc()
 		}
-		metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceClusterRoleBinding).Inc()
 	}
 
 	// Delete owned RoleBindings.
 	rbs, err := r.rbdListOwnedRoleBindings(ctx, rbd)
 	if err != nil {
-		return fmt.Errorf("list owned RoleBindings: %w", err)
-	}
-	for i := range rbs {
-		rb := &rbs[i]
-		if err := deleteClient.Delete(ctx, rb); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("delete RoleBinding %s/%s: %w", rb.Namespace, rb.Name, err)
+		errs = append(errs, fmt.Errorf("list owned RoleBindings: %w", err))
+	} else {
+		for i := range rbs {
+			rb := &rbs[i]
+			if err := deleteClient.Delete(ctx, rb); err != nil && !apierrors.IsNotFound(err) {
+				errs = append(errs, fmt.Errorf("delete RoleBinding %s/%s: %w", rb.Namespace, rb.Name, err))
+				continue
+			}
+			metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceRoleBinding).Inc()
 		}
-		metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceRoleBinding).Inc()
 	}
 
 	if err := r.rbdPruneStaleServiceAccounts(ctx, rbd, nil, rbdDesiredServiceAccounts(rbd.Status.GeneratedServiceAccounts), deleteClient); err != nil {
+		errs = append(errs, err)
+	}
+	if err := errors.Join(errs...); err != nil {
 		return err
 	}
 

--- a/internal/controller/authorization/restrictedbinddefinition_controller_test.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller_test.go
@@ -1906,6 +1906,54 @@ func TestRBD_DeprovisionCleansUpResources(t *testing.T) {
 	g.Expect(emitted[len(emitted)-1]).NotTo(gomega.ContainSubstring("policy violations"))
 }
 
+func TestRBD_DeprovisionContinuesAfterDeleteError(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	rbd := &authorizationv1alpha1.RestrictedBindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "partial-deprov-rbd", UID: "partial-deprov-rbd-uid"},
+		Status: authorizationv1alpha1.RestrictedBindDefinitionStatus{
+			GeneratedServiceAccounts: []rbacv1.Subject{
+				{Kind: rbacv1.ServiceAccountKind, Name: "partial-deprov-sa", Namespace: "default"},
+			},
+		},
+	}
+	ownerRef := restrictedTestOwnerRef(authorizationv1alpha1.RestrictedBindDefinitionKind, rbd.Name, rbd.UID)
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "partial-deprov-crb", OwnerReferences: []metav1.OwnerReference{ownerRef}},
+	}
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "partial-deprov-rb", Namespace: "default", OwnerReferences: []metav1.OwnerReference{ownerRef}},
+	}
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "partial-deprov-sa", Namespace: "default", OwnerReferences: []metav1.OwnerReference{ownerRef}},
+	}
+
+	scheme := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(rbd, crb, rb, sa).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if obj.GetName() == crb.Name {
+					return fmt.Errorf("injected ClusterRoleBinding delete error")
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := NewRestrictedBindDefinitionReconciler(c, scheme, events.NewFakeRecorder(10))
+
+	err := r.rbdDeprovision(rbdCtx(), rbd, nil)
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("delete ClusterRoleBinding partial-deprov-crb")))
+
+	var keptCRB rbacv1.ClusterRoleBinding
+	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Name: crb.Name}, &keptCRB)).To(gomega.Succeed())
+	var deletedRB rbacv1.RoleBinding
+	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Namespace: rb.Namespace, Name: rb.Name}, &deletedRB)).To(gomega.HaveOccurred())
+	var deletedSA corev1.ServiceAccount
+	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Namespace: sa.Namespace, Name: sa.Name}, &deletedSA)).To(gomega.HaveOccurred())
+}
+
 func TestRBD_DeprovisionUsesLiveReaderWhenCachedOwnerIndexMisses(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -2048,6 +2096,44 @@ func TestRBD_PruneStaleResources_UsesProvidedDeleteClient(t *testing.T) {
 	err := r.rbdPruneStaleResources(rbdCtx(), rbd, nil, nil, deleteClient)
 	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("impersonated delete denied")))
 	g.Expect(deleteCalled).To(gomega.BeTrue())
+}
+
+func TestRBD_PruneStaleResourcesContinuesAfterDeleteError(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	rbd := &authorizationv1alpha1.RestrictedBindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "partial-prune-rbd", UID: "partial-prune-rbd-uid"},
+	}
+	ownerRef := restrictedTestOwnerRef(authorizationv1alpha1.RestrictedBindDefinitionKind, rbd.Name, rbd.UID)
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "partial-prune-crb", OwnerReferences: []metav1.OwnerReference{ownerRef}},
+	}
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "partial-prune-rb", Namespace: "default", OwnerReferences: []metav1.OwnerReference{ownerRef}},
+	}
+
+	scheme := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(crb, rb).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if obj.GetName() == crb.Name {
+					return fmt.Errorf("injected stale ClusterRoleBinding delete error")
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := NewRestrictedBindDefinitionReconciler(c, scheme, events.NewFakeRecorder(10))
+
+	err := r.rbdPruneStaleResources(rbdCtx(), rbd, nil, nil, nil)
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("delete stale ClusterRoleBinding partial-prune-crb")))
+
+	var keptCRB rbacv1.ClusterRoleBinding
+	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Name: crb.Name}, &keptCRB)).To(gomega.Succeed())
+	var deletedRB rbacv1.RoleBinding
+	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Namespace: rb.Namespace, Name: rb.Name}, &deletedRB)).To(gomega.HaveOccurred())
 }
 
 func TestRBD_PruneStaleResources_UsesLiveOwnerRefWithoutOwnerIndex(t *testing.T) {
@@ -2274,6 +2360,50 @@ func TestRBD_PruneStaleServiceAccounts_UsesLiveOwnerRefWithoutOwnerIndex(t *test
 
 	var deletedSA corev1.ServiceAccount
 	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Namespace: "default", Name: "fallback-stale-sa"}, &deletedSA)).To(gomega.HaveOccurred())
+}
+
+func TestRBD_PruneStaleServiceAccountsContinuesAfterDeleteError(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	rbd := &authorizationv1alpha1.RestrictedBindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "partial-sa-prune-rbd", UID: "partial-sa-prune-rbd-uid"},
+		Status: authorizationv1alpha1.RestrictedBindDefinitionStatus{
+			GeneratedServiceAccounts: []rbacv1.Subject{
+				{Kind: rbacv1.ServiceAccountKind, Name: "aa-fail-sa", Namespace: "default"},
+				{Kind: rbacv1.ServiceAccountKind, Name: "zz-clean-sa", Namespace: "default"},
+			},
+		},
+	}
+	ownerRef := restrictedTestOwnerRef(authorizationv1alpha1.RestrictedBindDefinitionKind, rbd.Name, rbd.UID)
+	failSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "aa-fail-sa", Namespace: "default", OwnerReferences: []metav1.OwnerReference{ownerRef}},
+	}
+	cleanSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "zz-clean-sa", Namespace: "default", OwnerReferences: []metav1.OwnerReference{ownerRef}},
+	}
+
+	scheme := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(failSA, cleanSA).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if obj.GetName() == failSA.Name {
+					return fmt.Errorf("injected stale ServiceAccount delete error")
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := NewRestrictedBindDefinitionReconciler(c, scheme, events.NewFakeRecorder(10))
+
+	err := r.rbdPruneStaleServiceAccounts(rbdCtx(), rbd, nil, rbdDesiredServiceAccounts(rbd.Status.GeneratedServiceAccounts), nil)
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("delete stale ServiceAccount default/aa-fail-sa")))
+
+	var keptSA corev1.ServiceAccount
+	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Namespace: failSA.Namespace, Name: failSA.Name}, &keptSA)).To(gomega.Succeed())
+	var deletedSA corev1.ServiceAccount
+	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Namespace: cleanSA.Namespace, Name: cleanSA.Name}, &deletedSA)).To(gomega.HaveOccurred())
 }
 
 func TestRBD_PruneStaleServiceAccounts_IgnoresSpoofedOwnerRefWithoutStatus(t *testing.T) {


### PR DESCRIPTION
## Summary
- make RestrictedBindDefinition RBAC cleanup best-effort across owned ClusterRoleBindings and RoleBindings, returning joined errors after attempting all deletes
- make trusted generated ServiceAccount pruning continue after individual delete failures
- add regressions for deprovision, stale RBAC pruning, and generated ServiceAccount pruning when one delete fails

## Validation
- go test ./internal/controller/authorization -run 'TestRBD_(DeprovisionContinuesAfterDeleteError|PruneStaleResourcesContinuesAfterDeleteError|PruneStaleServiceAccountsContinuesAfterDeleteError|DeprovisionCleansUpResources|PruneStaleResources_UsesLiveOwnerRefWithoutManagedLabels|PruneStaleServiceAccounts_UsesLiveOwnerRefWithoutOwnerIndex)' -count=1\n- KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.34.1 --bin-dir ./bin -p path)" go test ./internal/controller/authorization -count=1\n- git diff --check