### PR TITLE
ci: fail closed on security scanner findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,8 @@ jobs:
           scan-ref: '.'
           format: 'sarif'
           output: 'trivy-fs-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
 
       - name: Upload Trivy scan results
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -88,7 +88,7 @@ jobs:
         run: go install github.com/securego/gosec/v2/cmd/gosec@${{ env.GOSEC_VERSION }}
 
       - name: Run gosec
-        run: gosec -fmt sarif -out gosec-results.sarif -exclude=G104,G304 ./... || true
+        run: gosec -fmt sarif -out gosec-results.sarif -exclude=G104,G304 ./...
 
       - name: Upload gosec results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
@@ -115,6 +115,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-fs-results.sarif'
           severity: 'CRITICAL,HIGH'
+          exit-code: '1'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
@@ -155,6 +156,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-image-results.sarif'
           severity: 'CRITICAL,HIGH'
+          exit-code: '1'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2


### PR DESCRIPTION
## Summary
- stop masking gosec findings with `|| true` while keeping SARIF upload best-effort
- make dedicated Trivy filesystem and image scans fail on HIGH/CRITICAL findings
- make the CI Trivy filesystem scan fail on HIGH/CRITICAL findings as well

## Validation
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "yaml ok"' .github/workflows/security-scan.yml .github/workflows/ci.yml\n- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/security-scan.yml .github/workflows/ci.yml\n- go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -fmt sarif -out /tmp/auth-operator-gosec-results.sarif -exclude=G104,G304 ./...\n- git diff --check\n\nTrivy is not installed locally in this environment, so the HIGH/CRITICAL exit-code behavior is validated by GitHub Actions.