### PR TITLE
config: harden kustomize pod security contexts

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,10 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
         runAsNonRoot: true
+        runAsUser: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -54,6 +57,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
+            readOnlyRootFilesystem: true
           livenessProbe:
             httpGet:
               path: /healthz

--- a/config/webhook/deployment.yaml
+++ b/config/webhook/deployment.yaml
@@ -21,7 +21,10 @@ spec:
         control-plane: webhook-server
     spec:
       securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
         runAsNonRoot: true
+        runAsUser: 65532
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -57,6 +60,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
+            readOnlyRootFilesystem: true
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Summary
- align Kustomize controller and webhook deployments with Helm pod security defaults
- set explicit non-root UID/GID/fsGroup 65532
- make controller and webhook containers use read-only root filesystems

## Validation
- kubectl kustomize config/default >/tmp/auth-operator-config-default.yaml
- git diff --check