### PR TITLE
fix(webhook): constrain operator finalizer identity

### DIFF
--- a/api/authorization/v1alpha1/default_policy_assignment_webhook.go
+++ b/api/authorization/v1alpha1/default_policy_assignment_webhook.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -316,7 +317,14 @@ func isAuthOperatorControllerServiceAccount(username string) bool {
 	if sa.Namespace == "auth-operator-system" && sa.Name == "manager" {
 		return true
 	}
-	return strings.HasSuffix(sa.Name, "-controller-manager") ||
+
+	operatorNamespace := os.Getenv("POD_NAMESPACE")
+	if operatorNamespace == "" || sa.Namespace != operatorNamespace {
+		return false
+	}
+
+	return sa.Name == "manager" ||
+		strings.HasSuffix(sa.Name, "-controller-manager") ||
 		(strings.Contains(sa.Name, "auth-operator") && strings.HasSuffix(sa.Name, "-manager"))
 }
 

--- a/api/authorization/v1alpha1/default_policy_assignment_webhook_test.go
+++ b/api/authorization/v1alpha1/default_policy_assignment_webhook_test.go
@@ -655,7 +655,7 @@ func TestRestrictedValidatorsSkipDefaultPolicyAssignmentForSpecUnchangedUpdates(
 	ctxOperator := admission.NewContextWithRequest(context.Background(), admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{
 			UserInfo: authenticationv1.UserInfo{
-				Username: "system:serviceaccount:auth-operator-system:auth-operator-manager",
+				Username: "system:serviceaccount:auth-operator-system:manager",
 			},
 		},
 	})
@@ -696,6 +696,43 @@ func TestRestrictedValidatorsSkipDefaultPolicyAssignmentForSpecUnchangedUpdates(
 
 		if _, err := validator.ValidateUpdate(ctxOperator, oldRRD, newRRD); err != nil {
 			t.Fatalf("expected spec-unchanged finalizer update to bypass requester default-policy checks, got: %v", err)
+		}
+	})
+}
+
+func TestAuthOperatorControllerServiceAccountRequiresOperatorNamespace(t *testing.T) {
+	t.Run("allows kustomize default manager without pod namespace", func(t *testing.T) {
+		t.Setenv("POD_NAMESPACE", "")
+		if !isAuthOperatorControllerServiceAccount("system:serviceaccount:auth-operator-system:manager") {
+			t.Fatal("expected default kustomize manager serviceaccount to be allowed")
+		}
+	})
+
+	t.Run("allows helm controller manager in pod namespace", func(t *testing.T) {
+		t.Setenv("POD_NAMESPACE", "auth-operator")
+		if !isAuthOperatorControllerServiceAccount("system:serviceaccount:auth-operator:team-auth-operator-controller-manager") {
+			t.Fatal("expected auth-operator controller manager in POD_NAMESPACE to be allowed")
+		}
+	})
+
+	t.Run("rejects matching serviceaccount name outside pod namespace", func(t *testing.T) {
+		t.Setenv("POD_NAMESPACE", "auth-operator")
+		if isAuthOperatorControllerServiceAccount("system:serviceaccount:tenant-a:team-auth-operator-controller-manager") {
+			t.Fatal("expected auth-operator-looking serviceaccount outside POD_NAMESPACE to be rejected")
+		}
+	})
+
+	t.Run("allows fullname override controller manager in pod namespace", func(t *testing.T) {
+		t.Setenv("POD_NAMESPACE", "auth-operator")
+		if !isAuthOperatorControllerServiceAccount("system:serviceaccount:auth-operator:tenant-controller-manager") {
+			t.Fatal("expected controller-manager serviceaccount in POD_NAMESPACE to be allowed")
+		}
+	})
+
+	t.Run("rejects regular user", func(t *testing.T) {
+		t.Setenv("POD_NAMESPACE", "auth-operator")
+		if isAuthOperatorControllerServiceAccount("alice") {
+			t.Fatal("expected regular user to be rejected")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- require auth-operator controller finalizer-only bypasses to come from the webhook POD_NAMESPACE, except for the kustomize default auth-operator-system/manager identity
- reject auth-operator-looking controller-manager ServiceAccounts from tenant namespaces for default-policy finalizer updates
- add direct unit coverage for allowed and rejected controller-manager identities

## Validation
- go test ./api/authorization/v1alpha1 -run 'TestAuthOperatorControllerServiceAccountRequiresOperatorNamespace|TestRestrictedValidatorsSkipDefaultPolicyAssignmentForSpecUnchangedUpdates|TestRestrictedValidatorsEnforceDefaultPolicyAssignmentForUserFinalizerUpdates' -count=1
- KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.34.1 --bin-dir ./bin -p path)" go test ./api/authorization/v1alpha1 -count=1
- git diff --check