### PR TITLE
fix(authz): use controller identity for revocation

### DIFF
--- a/internal/controller/authorization/restrictedbinddefinition_controller.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller.go
@@ -166,12 +166,11 @@ func (r *RestrictedBindDefinitionReconciler) rbdEvaluatePolicy(
 	ctx context.Context,
 	rbd *authorizationv1alpha1.RestrictedBindDefinition,
 	rbacPolicy *authorizationv1alpha1.RBACPolicy,
-	applyClient client.Client,
 ) (result ctrl.Result, handled bool, retErr error) {
 	labelGetter := newLabelGetter(r.ownershipReader())
 	violations := policy.EvaluateBindDefinition(ctx, rbacPolicy, rbd, labelGetter)
 	if err := labelGetter.Err(); err != nil {
-		if deprovisionErr := r.rbdDeprovision(ctx, rbd, applyClient); deprovisionErr != nil {
+		if deprovisionErr := r.rbdDeprovision(ctx, rbd, r.client); deprovisionErr != nil {
 			err = errors.Join(err, fmt.Errorf("deprovision after policy selector evaluation failure: %w", deprovisionErr))
 		} else {
 			rbdClearDeprovisionedStatus(rbd)
@@ -191,7 +190,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdEvaluatePolicy(
 		ControllerLabel: metrics.ControllerRestrictedBindDefinition,
 		ResourceKind:    "RestrictedBindDefinition",
 		Deprovision: func(ctx context.Context) error {
-			if err := r.rbdDeprovision(ctx, rbd, applyClient); err != nil {
+			if err := r.rbdDeprovision(ctx, rbd, r.client); err != nil {
 				return err
 			}
 			rbdClearDeprovisionedStatus(rbd)
@@ -586,29 +585,11 @@ func (r *RestrictedBindDefinitionReconciler) Reconcile(ctx context.Context, req 
 		return ctrl.Result{}, err
 	}
 	if rbacPolicy.GetDeletionTimestamp() != nil {
-		applyClient, impersonatedUser, err := r.rbdResolveApplyClient(rbacPolicy)
-		if err != nil {
-			r.rbdMarkStalled(ctx, rbd, err)
-			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()
-			metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ErrorTypeAPI).Inc()
-			return ctrl.Result{}, fmt.Errorf("resolve apply client for deleting RBACPolicy %s referenced by RestrictedBindDefinition %s: %w",
-				rbacPolicy.Name, rbd.Name, err)
-		}
-		r.rbdLogApplyIdentity(ctx, rbd.Name, rbacPolicy.Name, impersonatedUser)
-		return r.rbdHandleDeletingPolicy(ctx, rbd, rbacPolicy, applyClient)
+		return r.rbdHandleDeletingPolicy(ctx, rbd, rbacPolicy)
 	}
-
-	applyClient, impersonatedUser, err := r.rbdResolveApplyClient(rbacPolicy)
-	if err != nil {
-		r.rbdMarkStalled(ctx, rbd, err)
-		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()
-		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ErrorTypeAPI).Inc()
-		return ctrl.Result{}, fmt.Errorf("resolve apply client for RestrictedBindDefinition %s: %w", rbd.Name, err)
-	}
-	r.rbdLogApplyIdentity(ctx, rbd.Name, rbacPolicy.Name, impersonatedUser)
 
 	// Step 6: Evaluate policy compliance.
-	if result, handled, err := r.rbdEvaluatePolicy(ctx, rbd, rbacPolicy, applyClient); handled {
+	if result, handled, err := r.rbdEvaluatePolicy(ctx, rbd, rbacPolicy); handled {
 		return result, err
 	}
 
@@ -629,7 +610,7 @@ func (r *RestrictedBindDefinitionReconciler) Reconcile(ctx context.Context, req 
 	rbd.Status.MissingRoleRefs = missingRoles
 	metrics.RoleRefsMissing.WithLabelValues(rbd.Name).Set(float64(len(missingRoles)))
 	if len(missingRoles) > 0 {
-		return r.rbdHandleMissingRoleRefs(ctx, rbd, missingRoles, applyClient)
+		return r.rbdHandleMissingRoleRefs(ctx, rbd, missingRoles)
 	}
 
 	missingTargetNamespaces, err := r.rbdFindMissingTargetNamespaces(ctx, rbd)
@@ -642,6 +623,14 @@ func (r *RestrictedBindDefinitionReconciler) Reconcile(ctx context.Context, req 
 
 	// Step 8: Reconcile RBAC resources.
 	saCreationConfig := rbdSACreationConfig(rbacPolicy)
+	applyClient, impersonatedUser, err := r.rbdResolveApplyClient(rbacPolicy)
+	if err != nil {
+		r.rbdMarkStalled(ctx, rbd, err)
+		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()
+		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ErrorTypeAPI).Inc()
+		return ctrl.Result{}, fmt.Errorf("resolve apply client for RestrictedBindDefinition %s: %w", rbd.Name, err)
+	}
+	r.rbdLogApplyIdentity(ctx, rbd.Name, rbacPolicy.Name, impersonatedUser)
 	if err := r.rbdReconcileResources(ctx, rbd, applyClient, saCreationConfig); err != nil {
 		r.rbdMarkStalled(ctx, rbd, err)
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()
@@ -733,7 +722,6 @@ func (r *RestrictedBindDefinitionReconciler) rbdHandleDeletingPolicy(
 	ctx context.Context,
 	rbd *authorizationv1alpha1.RestrictedBindDefinition,
 	rbacPolicy *authorizationv1alpha1.RBACPolicy,
-	deleteClient client.Client,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("referenced RBACPolicy is deleting", "name", rbd.Name, "policyRef", rbacPolicy.Name)
@@ -743,7 +731,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdHandleDeletingPolicy(
 		authorizationv1alpha1.EventReasonPolicyViolation, authorizationv1alpha1.EventActionReconcile,
 		"Referenced RBACPolicy %q is being deleted", rbacPolicy.Name)
 	rbd.Status.PolicyViolations = []string{fmt.Sprintf("policy %q is being deleted", rbacPolicy.Name)}
-	if err := r.rbdDeprovision(ctx, rbd, deleteClient); err != nil {
+	if err := r.rbdDeprovision(ctx, rbd, r.client); err != nil {
 		r.rbdMarkStalled(ctx, rbd, err)
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()
 		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ErrorTypeAPI).Inc()
@@ -782,10 +770,9 @@ func (r *RestrictedBindDefinitionReconciler) rbdHandleMissingRoleRefs(
 	ctx context.Context,
 	rbd *authorizationv1alpha1.RestrictedBindDefinition,
 	missingRoles []string,
-	applyClient client.Client,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	if err := r.rbdDeprovision(ctx, rbd, applyClient); err != nil {
+	if err := r.rbdDeprovision(ctx, rbd, r.client); err != nil {
 		r.rbdMarkStalled(ctx, rbd, err)
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()
 		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ErrorTypeAPI).Inc()
@@ -873,7 +860,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdReconcileServiceAccounts(
 		return nil, err
 	}
 	desiredSAs := rbdDesiredServiceAccounts(rbd.Status.GeneratedServiceAccounts)
-	if err := r.rbdPruneStaleServiceAccounts(ctx, rbd, desiredSAs, previousGeneratedSAs, applyClient); err != nil {
+	if err := r.rbdPruneStaleServiceAccounts(ctx, rbd, desiredSAs, previousGeneratedSAs, r.client); err != nil {
 		return nil, err
 	}
 	return effectiveSubjects, nil
@@ -894,7 +881,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdReconcileBindings(
 		if retErr == nil || pruneAttempted {
 			return
 		}
-		if pruneErr := r.rbdPruneStaleResources(ctx, rbd, desiredCRBs, desiredRBs, applyClient); pruneErr != nil {
+		if pruneErr := r.rbdPruneStaleResources(ctx, rbd, desiredCRBs, desiredRBs, r.client); pruneErr != nil {
 			retErr = errors.Join(retErr, fmt.Errorf("prune stale RBAC resources after reconcile error: %w", pruneErr))
 		}
 	}()
@@ -954,7 +941,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdReconcileBindings(
 
 	// Prune stale owned resources that are no longer in the desired set.
 	pruneAttempted = true
-	return r.rbdPruneStaleResources(ctx, rbd, desiredCRBs, desiredRBs, applyClient)
+	return r.rbdPruneStaleResources(ctx, rbd, desiredCRBs, desiredRBs, r.client)
 }
 
 func (r *RestrictedBindDefinitionReconciler) rbdDesiredBindingKeys(

--- a/internal/controller/authorization/restrictedbinddefinition_controller_test.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller_test.go
@@ -350,6 +350,13 @@ func TestRBD_Reconcile_PolicyViolation_Deprovision(t *testing.T) {
 			BindingLimits: &authorizationv1alpha1.BindingLimits{
 				AllowClusterRoleBindings: false,
 			},
+			Impersonation: &authorizationv1alpha1.ImpersonationConfig{
+				Enabled: true,
+				ServiceAccountRef: &authorizationv1alpha1.SARef{
+					Name:      "rbac-applier",
+					Namespace: "team-a",
+				},
+			},
 		},
 	}
 
@@ -395,11 +402,18 @@ func TestRBD_Reconcile_PolicyViolation_Deprovision(t *testing.T) {
 	}
 
 	r, c := newRBDTestReconciler(rbdPolicyWithDefaultAllowances(pol), rbd, ownedCRB, ownedSA)
+	var impersonationFactoryCalled bool
+	r.impersonatedClientFactory = func(_ *rest.Config, _ *runtime.Scheme, _ string) (client.Client, error) {
+		impersonationFactoryCalled = true
+		return nil, fmt.Errorf("impersonated client must not be resolved for policy-violation revocation")
+	}
+
 	result, err := r.Reconcile(rbdCtx(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "violating-rbd"},
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
+	g.Expect(impersonationFactoryCalled).To(gomega.BeFalse())
 
 	var updated authorizationv1alpha1.RestrictedBindDefinition
 	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Name: "violating-rbd"}, &updated)).To(gomega.Succeed())
@@ -498,7 +512,7 @@ func TestRBD_Reconcile_DeletingPolicyDeprovisions(t *testing.T) {
 	g.Expect(conditions.IsStalled(&updated)).To(gomega.BeTrue())
 }
 
-func TestRBD_Reconcile_DeletingPolicyUsesImpersonatedDeleteClient(t *testing.T) {
+func TestRBD_Reconcile_DeletingPolicyUsesControllerClientForRevocation(t *testing.T) {
 	g := gomega.NewWithT(t)
 	now := metav1.Now()
 
@@ -542,22 +556,20 @@ func TestRBD_Reconcile_DeletingPolicyUsesImpersonatedDeleteClient(t *testing.T) 
 	}
 
 	r, c := newRBDTestReconciler(pol, rbd, crb)
-	r.restConfig = &rest.Config{Host: "https://cluster.local"}
-	deleteClient := &deleteForbiddenClient{Client: c}
-	var capturedUsername string
-	r.impersonatedClientFactory = func(_ *rest.Config, _ *runtime.Scheme, username string) (client.Client, error) {
-		capturedUsername = username
-		return deleteClient, nil
+	var impersonationFactoryCalled bool
+	r.impersonatedClientFactory = func(_ *rest.Config, _ *runtime.Scheme, _ string) (client.Client, error) {
+		impersonationFactoryCalled = true
+		return nil, fmt.Errorf("impersonated client must not be resolved for deleting policy revocation")
 	}
 
-	_, err := r.Reconcile(rbdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rbd.Name}})
-	g.Expect(err).To(gomega.HaveOccurred())
-	g.Expect(err.Error()).To(gomega.ContainSubstring("delete denied"))
-	g.Expect(capturedUsername).To(gomega.Equal("system:serviceaccount:team-a:rbac-applier"))
-	g.Expect(deleteClient.deleteCalls).To(gomega.Equal(1))
+	result, err := r.Reconcile(rbdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rbd.Name}})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
+	g.Expect(impersonationFactoryCalled).To(gomega.BeFalse())
 
-	var kept rbacv1.ClusterRoleBinding
-	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Name: crb.Name}, &kept)).To(gomega.Succeed())
+	var deleted rbacv1.ClusterRoleBinding
+	err = c.Get(rbdCtx(), types.NamespacedName{Name: crb.Name}, &deleted)
+	g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
 }
 
 func TestRBD_Reconcile_GetError(t *testing.T) {
@@ -1314,6 +1326,13 @@ func TestRBD_Reconcile_PrunesStaleGeneratedServiceAccount(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "prune-sa-policy", Generation: 1},
 		Spec: authorizationv1alpha1.RBACPolicySpec{
 			AppliesTo: authorizationv1alpha1.PolicyScope{Namespaces: []string{"default"}},
+			Impersonation: &authorizationv1alpha1.ImpersonationConfig{
+				Enabled: true,
+				ServiceAccountRef: &authorizationv1alpha1.SARef{
+					Name:      "rbac-applier",
+					Namespace: "team-a",
+				},
+			},
 		},
 	}
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
@@ -1346,9 +1365,19 @@ func TestRBD_Reconcile_PrunesStaleGeneratedServiceAccount(t *testing.T) {
 	clusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "view"}}
 
 	r, c := newRBDTestReconciler(rbdPolicyWithDefaultAllowances(pol), rbd, ns, staleSA, clusterRole)
+	r.restConfig = &rest.Config{Host: "https://cluster.local"}
+	applyClient := &deleteForbiddenClient{Client: c}
+	var impersonationFactoryCalled bool
+	r.impersonatedClientFactory = func(_ *rest.Config, _ *runtime.Scheme, _ string) (client.Client, error) {
+		impersonationFactoryCalled = true
+		return applyClient, nil
+	}
+
 	result, err := r.Reconcile(rbdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rbd.Name}})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
+	g.Expect(impersonationFactoryCalled).To(gomega.BeTrue())
+	g.Expect(applyClient.deleteCalls).To(gomega.Equal(0))
 
 	var deletedSA corev1.ServiceAccount
 	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Namespace: "default", Name: "stale-sa"}, &deletedSA)).NotTo(gomega.Succeed())
@@ -3169,9 +3198,12 @@ func TestRBD_ReconcileResources_PrunesStaleBindingsOnNameCollision(t *testing.T)
 	}
 
 	r, c := newRBDTestReconciler(rbd, ns, staleCRB)
-	err := r.rbdReconcileResources(rbdCtx(), rbd, c, nil)
+	applyClient := &deleteForbiddenClient{Client: c}
+	err := r.rbdReconcileResources(rbdCtx(), rbd, applyClient, nil)
 	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(err.Error()).To(gomega.ContainSubstring("RoleBinding name collision"))
+	g.Expect(err.Error()).NotTo(gomega.ContainSubstring("delete denied"))
+	g.Expect(applyClient.deleteCalls).To(gomega.Equal(0))
 
 	var deletedCRB rbacv1.ClusterRoleBinding
 	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Name: staleCRB.Name}, &deletedCRB)).To(gomega.HaveOccurred())

--- a/internal/controller/authorization/restrictedroledefinition_controller.go
+++ b/internal/controller/authorization/restrictedroledefinition_controller.go
@@ -164,12 +164,11 @@ func (r *RestrictedRoleDefinitionReconciler) rrdEvaluatePolicy(
 	ctx context.Context,
 	rrd *authorizationv1alpha1.RestrictedRoleDefinition,
 	rbacPolicy *authorizationv1alpha1.RBACPolicy,
-	applyClient client.Client,
 ) (result ctrl.Result, handled bool, retErr error) {
 	labelGetter := newLabelGetter(r.ownershipReader())
 	violations := policy.EvaluateRoleDefinitionWithLabels(ctx, rbacPolicy, rrd, labelGetter)
 	if err := labelGetter.Err(); err != nil {
-		if deprovisionErr := r.rrdDeprovision(ctx, rrd, applyClient); deprovisionErr != nil {
+		if deprovisionErr := r.rrdDeprovision(ctx, rrd, r.client); deprovisionErr != nil {
 			err = errors.Join(err, fmt.Errorf("deprovision after policy selector evaluation failure: %w", deprovisionErr))
 		}
 		markPolicyEvaluationError(rrd, rrd.Generation, err)
@@ -186,7 +185,7 @@ func (r *RestrictedRoleDefinitionReconciler) rrdEvaluatePolicy(
 	result, err := handlePolicyViolations(ctx, rrd, rrd.Generation, violations, r.recorder, rrd, ViolationHandlerConfig{
 		ControllerLabel: metrics.ControllerRestrictedRoleDefinition,
 		ResourceKind:    "RestrictedRoleDefinition",
-		Deprovision:     func(ctx context.Context) error { return r.rrdDeprovision(ctx, rrd, applyClient) },
+		Deprovision:     func(ctx context.Context) error { return r.rrdDeprovision(ctx, rrd, r.client) },
 		MarkStalled:     func(ctx context.Context, err error) { r.rrdMarkStalled(ctx, rrd, err) },
 		SetReconciled:   func(v bool) { rrd.Status.RoleReconciled = v },
 		ApplyStatus:     func(ctx context.Context) error { return ssa.ApplyRestrictedRoleDefinitionStatus(ctx, r.client, rrd) },
@@ -373,29 +372,11 @@ func (r *RestrictedRoleDefinitionReconciler) Reconcile(ctx context.Context, req 
 		return ctrl.Result{}, fmt.Errorf("fetch RBACPolicy %s: %w", rrd.Spec.PolicyRef.Name, err)
 	}
 	if rbacPolicy.GetDeletionTimestamp() != nil {
-		applyClient, impersonatedUser, err := r.rrdResolveApplyClient(rbacPolicy)
-		if err != nil {
-			r.rrdMarkStalled(ctx, rrd, err)
-			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ResultError).Inc()
-			metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ErrorTypeAPI).Inc()
-			return ctrl.Result{}, fmt.Errorf("resolve apply client for deleting RBACPolicy %s referenced by RestrictedRoleDefinition %s: %w",
-				rbacPolicy.Name, rrd.Name, err)
-		}
-		r.rrdLogApplyIdentity(ctx, rrd.Name, rbacPolicy.Name, impersonatedUser)
-		return r.rrdHandleDeletingPolicy(ctx, rrd, rbacPolicy, applyClient)
+		return r.rrdHandleDeletingPolicy(ctx, rrd, rbacPolicy)
 	}
-
-	applyClient, impersonatedUser, err := r.rrdResolveApplyClient(rbacPolicy)
-	if err != nil {
-		r.rrdMarkStalled(ctx, rrd, err)
-		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ResultError).Inc()
-		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ErrorTypeAPI).Inc()
-		return ctrl.Result{}, fmt.Errorf("resolve apply client for RestrictedRoleDefinition %s: %w", rrd.Name, err)
-	}
-	r.rrdLogApplyIdentity(ctx, rrd.Name, rbacPolicy.Name, impersonatedUser)
 
 	// Step 6: Evaluate policy compliance.
-	if result, handled, err := r.rrdEvaluatePolicy(ctx, rrd, rbacPolicy, applyClient); handled {
+	if result, handled, err := r.rrdEvaluatePolicy(ctx, rrd, rbacPolicy); handled {
 		return result, err
 	}
 
@@ -406,7 +387,7 @@ func (r *RestrictedRoleDefinitionReconciler) Reconcile(ctx context.Context, req 
 	// Step 7: Discover and filter API resources.
 	finalRules, requeue, err := r.rrdDiscoverAndFilter(ctx, rrd)
 	if err != nil {
-		if deprovisionErr := r.rrdDeprovision(ctx, rrd, applyClient); deprovisionErr != nil {
+		if deprovisionErr := r.rrdDeprovision(ctx, rrd, r.client); deprovisionErr != nil {
 			err = errors.Join(err, fmt.Errorf("deprovision after role discovery failure: %w", deprovisionErr))
 		}
 		markPolicyEvaluationError(rrd, rrd.Generation, err)
@@ -429,7 +410,7 @@ func (r *RestrictedRoleDefinitionReconciler) Reconcile(ctx context.Context, req 
 		result, err := handlePolicyViolations(ctx, rrd, rrd.Generation, []policy.Violation{*v}, r.recorder, rrd, ViolationHandlerConfig{
 			ControllerLabel: metrics.ControllerRestrictedRoleDefinition,
 			ResourceKind:    "RestrictedRoleDefinition",
-			Deprovision:     func(ctx context.Context) error { return r.rrdDeprovision(ctx, rrd, applyClient) },
+			Deprovision:     func(ctx context.Context) error { return r.rrdDeprovision(ctx, rrd, r.client) },
 			MarkStalled:     func(ctx context.Context, err error) { r.rrdMarkStalled(ctx, rrd, err) },
 			SetReconciled:   func(v bool) { rrd.Status.RoleReconciled = v },
 			ApplyStatus:     func(ctx context.Context) error { return ssa.ApplyRestrictedRoleDefinitionStatus(ctx, r.client, rrd) },
@@ -438,6 +419,14 @@ func (r *RestrictedRoleDefinitionReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	// Step 8: Ensure the target role exists.
+	applyClient, impersonatedUser, err := r.rrdResolveApplyClient(rbacPolicy)
+	if err != nil {
+		r.rrdMarkStalled(ctx, rrd, err)
+		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ResultError).Inc()
+		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ErrorTypeAPI).Inc()
+		return ctrl.Result{}, fmt.Errorf("resolve apply client for RestrictedRoleDefinition %s: %w", rrd.Name, err)
+	}
+	r.rrdLogApplyIdentity(ctx, rrd.Name, rbacPolicy.Name, impersonatedUser)
 	if err := r.rrdEnsureRole(ctx, rrd, finalRules, applyClient); err != nil {
 		r.rrdMarkStalled(ctx, rrd, err)
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ResultError).Inc()
@@ -494,7 +483,6 @@ func (r *RestrictedRoleDefinitionReconciler) rrdHandleDeletingPolicy(
 	ctx context.Context,
 	rrd *authorizationv1alpha1.RestrictedRoleDefinition,
 	rbacPolicy *authorizationv1alpha1.RBACPolicy,
-	deleteClient client.Client,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("referenced RBACPolicy is deleting", "name", rrd.Name, "policyRef", rbacPolicy.Name)
@@ -505,7 +493,7 @@ func (r *RestrictedRoleDefinitionReconciler) rrdHandleDeletingPolicy(
 		authorizationv1alpha1.EventReasonPolicyViolation, authorizationv1alpha1.EventActionReconcile,
 		"Referenced RBACPolicy %q is being deleted", rbacPolicy.Name)
 
-	if err := r.rrdDeprovision(ctx, rrd, deleteClient); err != nil {
+	if err := r.rrdDeprovision(ctx, rrd, r.client); err != nil {
 		r.rrdMarkStalled(ctx, rrd, err)
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ResultError).Inc()
 		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ErrorTypeAPI).Inc()

--- a/internal/controller/authorization/restrictedroledefinition_controller_test.go
+++ b/internal/controller/authorization/restrictedroledefinition_controller_test.go
@@ -198,6 +198,13 @@ func TestRRD_Reconcile_UsesReaderForPolicyEvaluation(t *testing.T) {
 			RoleLimits: &authorizationv1alpha1.RoleLimits{
 				AllowClusterRoles: false,
 			},
+			Impersonation: &authorizationv1alpha1.ImpersonationConfig{
+				Enabled: true,
+				ServiceAccountRef: &authorizationv1alpha1.SARef{
+					Name:      "rbac-applier",
+					Namespace: "team-a",
+				},
+			},
 		},
 	}
 	rrd := &authorizationv1alpha1.RestrictedRoleDefinition{
@@ -281,7 +288,7 @@ func TestRRD_Reconcile_DeletingPolicyIsUnavailable(t *testing.T) {
 	g.Expect(conditions.IsStalled(&updated)).To(BeTrue())
 }
 
-func TestRRD_Reconcile_DeletingPolicyUsesImpersonatedDeleteClient(t *testing.T) {
+func TestRRD_Reconcile_DeletingPolicyUsesControllerClientForRevocation(t *testing.T) {
 	g := NewWithT(t)
 	now := metav1.Now()
 
@@ -323,22 +330,20 @@ func TestRRD_Reconcile_DeletingPolicyUsesImpersonatedDeleteClient(t *testing.T) 
 	}
 
 	r, c := newRRDTestReconcilerFake(pol, rrd, cr)
-	r.restConfig = &rest.Config{Host: "https://cluster.local"}
-	deleteClient := &deleteForbiddenClient{Client: c}
-	var capturedUsername string
-	r.impersonatedClientFactory = func(_ *rest.Config, _ *runtime.Scheme, username string) (client.Client, error) {
-		capturedUsername = username
-		return deleteClient, nil
+	var impersonationFactoryCalled bool
+	r.impersonatedClientFactory = func(_ *rest.Config, _ *runtime.Scheme, _ string) (client.Client, error) {
+		impersonationFactoryCalled = true
+		return nil, fmt.Errorf("impersonated client must not be resolved for deleting policy revocation")
 	}
 
-	_, err := r.Reconcile(rrdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rrd.Name}})
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("delete denied"))
-	g.Expect(capturedUsername).To(Equal("system:serviceaccount:team-a:rbac-applier"))
-	g.Expect(deleteClient.deleteCalls).To(Equal(1))
+	result, err := r.Reconcile(rrdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rrd.Name}})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(DefaultRequeueInterval))
+	g.Expect(impersonationFactoryCalled).To(BeFalse())
 
-	var kept rbacv1.ClusterRole
-	g.Expect(c.Get(rrdCtx(), types.NamespacedName{Name: cr.Name}, &kept)).To(Succeed())
+	var deleted rbacv1.ClusterRole
+	err = c.Get(rrdCtx(), types.NamespacedName{Name: cr.Name}, &deleted)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 }
 
 func TestRRD_Reconcile_PolicyViolation(t *testing.T) {
@@ -383,11 +388,18 @@ func TestRRD_Reconcile_PolicyViolation(t *testing.T) {
 	}
 
 	r, c := newRRDTestReconcilerFake(pol, rrd, ownedRole)
+	var impersonationFactoryCalled bool
+	r.impersonatedClientFactory = func(_ *rest.Config, _ *runtime.Scheme, _ string) (client.Client, error) {
+		impersonationFactoryCalled = true
+		return nil, fmt.Errorf("impersonated client must not be resolved for policy-violation revocation")
+	}
+
 	result, err := r.Reconcile(rrdCtx(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "violating-rrd"},
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.RequeueAfter).To(Equal(DefaultRequeueInterval))
+	g.Expect(impersonationFactoryCalled).To(BeFalse())
 
 	var updated authorizationv1alpha1.RestrictedRoleDefinition
 	g.Expect(c.Get(rrdCtx(), types.NamespacedName{Name: "violating-rrd"}, &updated)).To(Succeed())


### PR DESCRIPTION
## Summary
- use the controller client for RestrictedBindDefinition and RestrictedRoleDefinition cleanup/deprovision paths
- defer impersonated apply-client resolution until an actual apply is needed
- keep impersonation for desired resource creation/update while ensuring revocation is fail-closed under the operator identity

## Tests
- go test ./internal/controller/authorization -run 'TestRBD_Reconcile_PolicyViolation_Deprovision|TestRBD_Reconcile_DeletingPolicyUsesControllerClientForRevocation|TestRBD_Reconcile_PrunesStaleGeneratedServiceAccount|TestRBD_ReconcileResources_PrunesStaleBindingsOnNameCollision|TestRRD_Reconcile_PolicyViolation|TestRRD_Reconcile_DeletingPolicyUsesControllerClientForRevocation|TestRRD_Deprovision_UsesProvidedDeleteClient|TestRBD_PruneStaleResources_UsesProvidedDeleteClient' -count=1\n- KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.34.1 --bin-dir ./bin -p path)" go test ./internal/controller/authorization -count=1\n- git diff --check