### PR TITLE
ci: always post output delta report comments

### DIFF
--- a/.github/workflows/output-delta-comment.yml
+++ b/.github/workflows/output-delta-comment.yml
@@ -282,11 +282,52 @@ jobs:
             rm -rf "$diff_dir"
             mkdir -p "$diff_dir"
 
+            write_placeholder_report_comment() {
+              local message="$1"
+              local detail="${2:-}"
+
+              {
+                echo "<!-- output-delta:part1 -->"
+                echo "## :bar_chart: Output Delta Report"
+                echo ""
+                echo "$message"
+                if [ -n "$detail" ]; then
+                  echo "$detail"
+                fi
+                echo ""
+                echo "No full diff content was generated for this run."
+              } > "$diff_dir/part-0001.md"
+            }
+
             if [ "$has_diff" != "true" ]; then
+              if [ "$IS_CURRENT" = "false" ]; then
+                write_placeholder_report_comment \
+                  "Output differences were not computed for this stale workflow event." \
+                  "The PR head moved from \`${HEAD_SHA}\` to \`${CURRENT_HEAD}\`; wait for the current-head Output Delta run."
+              elif [ "$IS_CURRENT" = "unknown" ]; then
+                write_placeholder_report_comment \
+                  "Output differences could not be computed because the workflow could not confirm the current PR head." \
+                  "Inspect the workflow logs before merging."
+              elif [ "$IS_APPLICABLE" != "true" ]; then
+                write_placeholder_report_comment \
+                  "No output differences were detected for this PR." \
+                  "No output-delta input files changed, so the Output Delta comparison workflow was not run."
+              elif [ "$has_diff" = "false" ]; then
+                write_placeholder_report_comment \
+                  "No output differences were detected between trusted main baseline and this PR." \
+                  "There is no diff to inspect for this run."
+              else
+                write_placeholder_report_comment \
+                  "Output differences could not be computed for this run." \
+                  "Inspect the workflow run and uploaded artifacts before merging."
+              fi
               return 0
             fi
             if [ ! -s "$diff_file" ]; then
               echo "::warning::Output-delta diff artifact did not contain full-diff.txt; no inline diff comments generated."
+              write_placeholder_report_comment \
+                "Output differences were detected, but the inline full diff could not be generated." \
+                "The downloaded output-delta-diff-output artifact did not contain full-diff.txt."
               return 0
             fi
 


### PR DESCRIPTION
## Summary
- always create an Output Delta Report comment body, even when no full diff exists
- use a single no-diff report comment for skipped/not-applicable, no-diff, stale-head, unknown, and missing-artifact cases
- keep real full diffs chunked into report comments as before

## Diagnosis
PR #338 only changes `.github/workflows/ci.yml` and `.github/workflows/security-scan.yml`. Those paths are not Output Delta inputs, so the expensive Output Delta workflow is intentionally skipped. The comment workflow still posted the summary comment, but `write_diff_comment_bodies` returned early whenever `has_diff != true`, leaving zero `<!-- output-delta:partN -->` report comments. That is why #338 had no diff/report comment after the manual comments were deleted.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/output-delta-comment.yml"); puts "workflow yaml ok"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/output-delta-comment.yml`
- `git diff --check`
