### PR TITLE
ci: avoid blocking output delta on tag cleanup

### DIFF
--- a/.github/workflows/output-delta.yml
+++ b/.github/workflows/output-delta.yml
@@ -420,13 +420,8 @@ jobs:
             kubectl logs -n "$ns" -l control-plane=webhook-server > "/tmp/controller-logs/tag-${ns}-webhook.log" 2>/dev/null || true
           done
 
-          kubectl delete -k config/samples/broken/ --ignore-not-found --timeout=60s 2>/dev/null || true
-          kubectl delete -k config/samples/ --ignore-not-found --timeout=60s 2>/dev/null || true
-          make undeploy 2>/dev/null || true
-          kubectl wait --for=delete deployment/auth-operator-controller-manager -n auth-operator-system --timeout=180s 2>/dev/null || true
-          kubectl wait --for=delete deployment/auth-operator-webhook-server -n auth-operator-system --timeout=180s 2>/dev/null || true
-
           echo "tag_success=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Skipping latest-tag in-step cleanup; the baseline kind cluster is deleted after artifacts are uploaded."
 
       - name: Upload main output
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary
- stop doing latest-tag sample/operator cleanup inside the tag-output generation step
- rely on the existing final baseline kind-cluster cleanup after artifacts upload
- preserves tag diff generation while avoiding cancellation before main/tag artifacts and comment data are available

## Diagnosis
After `v0.5.0-alpha.0` became the latest semver-like tag, Output Delta started running the latest-tag baseline path. The tag output was captured successfully, but the step then spent the remaining job budget in tag cleanup/undeploy and the trusted baseline job was cancelled before artifacts could be uploaded. That prevented the comment workflow from creating report comments on the rebased PRs.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/output-delta.yml"); puts "workflow yaml ok"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/output-delta.yml`
- `git diff --check`
