### PR TITLE
fix(rolebinding-terminator): keep finalizers on list errors

### DIFF
--- a/internal/controller/authorization/rolebinding_terminator_controller.go
+++ b/internal/controller/authorization/rolebinding_terminator_controller.go
@@ -86,6 +86,10 @@ func newNamespaceTerminationStatus() *namespaceTerminationStatus {
 	}
 }
 
+type apiResourceProvider interface {
+	GetAPIResources() (discovery.APIResourcesByGroupVersion, error)
+}
+
 // RoleBindingTerminator is responsible for handling finalizers on RoleBindings owned by BindDefinitions.
 // During deletion, if the namespace is terminating it checks for remaining resources before removing finalizers; otherwise it removes them directly.
 type RoleBindingTerminator struct {
@@ -93,7 +97,7 @@ type RoleBindingTerminator struct {
 	reader                             client.Reader
 	scheme                             *runtime.Scheme
 	dynamicClient                      dynamic.Interface
-	resourceTracker                    *discovery.ResourceTracker
+	resourceTracker                    apiResourceProvider
 	recorder                           events.EventRecorder
 	namespaceTerminationResourcesCache sync.Map // map[string]*namespaceTerminationStatus
 }
@@ -183,7 +187,7 @@ func (r *RoleBindingTerminator) getNamespacedBlockingResources(ctx context.Conte
 // sub-resources) that still exist in a terminating namespace. A non-empty slice means
 // the namespace cannot be fully cleaned up yet and RoleBinding finalizers must be kept.
 // Returns ([]namespaceDeletionResourceBlocking, error).
-func namespaceHasResources(ctx context.Context, resourceTracker *discovery.ResourceTracker, dynamicClient dynamic.Interface, namespace string) ([]namespaceDeletionResourceBlocking, error) {
+func namespaceHasResources(ctx context.Context, resourceTracker apiResourceProvider, dynamicClient dynamic.Interface, namespace string) ([]namespaceDeletionResourceBlocking, error) {
 	logger := log.FromContext(ctx)
 	logger.V(2).Info("starting namespace resource check", "namespace", namespace)
 
@@ -243,6 +247,12 @@ func namespaceHasResources(ctx context.Context, resourceTracker *discovery.Resou
 				continue
 			}
 
+			if !resource.Namespaced {
+				logger.V(4).Info("skipping cluster-scoped resource", "namespace", namespace, "resource", resource.Name, "groupVersion", groupVersion)
+				resourcesSkipped.Add(1)
+				continue
+			}
+
 			if !supportsList(resource.Verbs) {
 				// if resource does not support "list", skip it
 				logger.V(4).Info("skipping resource without list verb", "namespace", namespace, "resource", resource.Name, "groupVersion", groupVersion)
@@ -261,9 +271,9 @@ func namespaceHasResources(ctx context.Context, resourceTracker *discovery.Resou
 				// using dynamic client to not instantiate all typed clients
 				list, err := dynamicClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
 				if err != nil {
-					logger.V(2).Info("skipping resource due to list error", "namespace", namespace, "resource", gvr.String(), "error", err)
+					logger.Error(err, "failed to list resource while checking namespace termination", "namespace", namespace, "resource", gvr.String())
 					resourcesSkipped.Add(1)
-					return nil
+					return fmt.Errorf("list %s in namespace %s: %w", gvr.String(), namespace, err)
 				}
 
 				resourcesChecked.Add(1)
@@ -293,11 +303,12 @@ func namespaceHasResources(ctx context.Context, resourceTracker *discovery.Resou
 			})
 		}
 	}
-	if err := errGroup.Wait(); err != nil {
-		return nil, fmt.Errorf("error listing resources in namespace %s: %w", namespace, err)
-	}
+	waitErr := errGroup.Wait()
 	close(blockingResourcesChannel)
 	collectorWg.Wait() // Wait for collector goroutine to finish processing all items
+	if waitErr != nil {
+		return nil, fmt.Errorf("error listing resources in namespace %s: %w", namespace, waitErr)
+	}
 
 	// If we found blocking resources, return them all
 	if len(blockingResources) > 0 {

--- a/internal/controller/authorization/rolebinding_terminator_controller_test.go
+++ b/internal/controller/authorization/rolebinding_terminator_controller_test.go
@@ -17,7 +17,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -25,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	authorizationv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
+	"github.com/telekom/auth-operator/pkg/discovery"
 )
 
 func newTestScheme() *runtime.Scheme {
@@ -56,6 +60,15 @@ func testBindDefinition() *authorizationv1alpha1.BindDefinition {
 			},
 		},
 	}
+}
+
+type fakeAPIResourceProvider struct {
+	resources discovery.APIResourcesByGroupVersion
+	err       error
+}
+
+func (f fakeAPIResourceProvider) GetAPIResources() (discovery.APIResourcesByGroupVersion, error) {
+	return f.resources, f.err
 }
 
 func TestIsOwnedByBindDefinition(t *testing.T) {
@@ -711,6 +724,131 @@ func TestRBTerminatorReconcileBlockingResourcesError(t *testing.T) {
 	})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("injected blocking resources error"))
+}
+
+func TestRBTerminatorReconcileDynamicListErrorKeepsFinalizer(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	scheme := newTestScheme()
+
+	now := metav1.Now()
+	bdOwnerRef := testBindDefinitionControllerOwnerRef("test-bd", "bd-uid")
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "list-error-rb",
+			Namespace:         "list-error-ns",
+			OwnerReferences:   []metav1.OwnerReference{bdOwnerRef},
+			DeletionTimestamp: &now,
+			Finalizers:        []string{authorizationv1alpha1.RoleBindingFinalizer},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "list-error-ns",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"kubernetes"},
+		},
+		Status: corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rb, ns, testBindDefinition()).Build()
+	podGVR := schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{podGVR: "PodList"},
+	)
+	dynamicClient.PrependReactor("list", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("injected pod list error")
+	})
+	resourceTracker := fakeAPIResourceProvider{
+		resources: discovery.APIResourcesByGroupVersion{
+			"v1": {
+				{Name: "pods", Namespaced: true, Verbs: metav1.Verbs{"list"}},
+			},
+		},
+	}
+	r := &RoleBindingTerminator{
+		client:          c,
+		scheme:          scheme,
+		dynamicClient:   dynamicClient,
+		resourceTracker: resourceTracker,
+		recorder:        events.NewFakeRecorder(10),
+	}
+
+	_, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "list-error-rb", Namespace: "list-error-ns"},
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("injected pod list error"))
+
+	var updated rbacv1.RoleBinding
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: "list-error-rb", Namespace: "list-error-ns"}, &updated)).To(Succeed())
+	g.Expect(updated.Finalizers).To(ContainElement(authorizationv1alpha1.RoleBindingFinalizer))
+}
+
+func TestRBTerminatorReconcileSkipsClusterScopedResources(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	scheme := newTestScheme()
+
+	now := metav1.Now()
+	bdOwnerRef := testBindDefinitionControllerOwnerRef("test-bd", "bd-uid")
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cluster-scoped-rb",
+			Namespace:         "cluster-scoped-ns",
+			OwnerReferences:   []metav1.OwnerReference{bdOwnerRef},
+			DeletionTimestamp: &now,
+			Finalizers:        []string{authorizationv1alpha1.RoleBindingFinalizer},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cluster-scoped-ns",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"kubernetes"},
+		},
+		Status: corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(rb, ns, testBindDefinition()).
+		WithStatusSubresource(ns).
+		Build()
+	nodeGVR := schema.GroupVersionResource{Version: "v1", Resource: "nodes"}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{nodeGVR: "NodeList"},
+	)
+	dynamicClient.PrependReactor("list", "nodes", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("cluster-scoped nodes should not be listed through a namespace")
+	})
+	resourceTracker := fakeAPIResourceProvider{
+		resources: discovery.APIResourcesByGroupVersion{
+			"v1": {
+				{Name: "nodes", Namespaced: false, Verbs: metav1.Verbs{"list"}},
+			},
+		},
+	}
+	r := &RoleBindingTerminator{
+		client:          c,
+		scheme:          scheme,
+		dynamicClient:   dynamicClient,
+		resourceTracker: resourceTracker,
+		recorder:        events.NewFakeRecorder(10),
+	}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "cluster-scoped-rb", Namespace: "cluster-scoped-ns"},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(reconcile.Result{}))
+
+	var updated rbacv1.RoleBinding
+	err = c.Get(ctx, types.NamespacedName{Name: "cluster-scoped-rb", Namespace: "cluster-scoped-ns"}, &updated)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "RoleBinding should be gone after finalizer removal")
 }
 
 func TestRBTerminatorReconcileErrorRemovingFinalizerNonTerminating(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes an audit finding in `RoleBindingTerminator`: while checking a terminating namespace, dynamic `List` errors for namespaced resources were logged and skipped. If the remaining checks found no resources, the controller could remove the RoleBinding finalizer even though it had not successfully proven the namespace was empty.

This PR:
- propagates dynamic list failures through the existing `errgroup`
- closes and drains the blocking-resource collector channel before returning errors
- keeps the RoleBinding finalizer when namespace-resource discovery/listing fails
- adds a regression test using a fake API-resource provider plus dynamic client list failure

## Validation

- `go test ./internal/controller/authorization -run 'TestRBTerminatorReconcileDynamicListErrorKeepsFinalizer|TestRBTerminatorReconcileBlockingResourcesError|TestRBTerminatorReconcileTerminatingNamespaceNoBlockingResources|TestRBTerminatorReconcileTerminatingNamespaceWithBlockingResources|TestSupportsList' -count=1`
- `KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.36.0 --bin-dir ./bin -p path)" go test ./internal/controller/authorization -count=1`
- `git diff --check`
