### PR TITLE
ci: include latest tag diffs in output-delta comments

### DIFF
--- a/.github/workflows/output-delta-comment.yml
+++ b/.github/workflows/output-delta-comment.yml
@@ -199,6 +199,7 @@ jobs:
           baseline_result=unknown
           candidate_result=unknown
           latest_tag=
+          diff_comment_status=none
 
           valid_bool() {
             case "$1" in
@@ -285,6 +286,7 @@ jobs:
             write_placeholder_report_comment() {
               local message="$1"
               local detail="${2:-}"
+              diff_comment_status=placeholder
 
               {
                 echo "<!-- output-delta:part1 -->"
@@ -556,6 +558,9 @@ jobs:
                   raise SystemExit(f"Generated output-delta comment part {index} is too large")
               (diff_dir / f"part-{index:0{digits}d}.md").write_text(body, encoding="utf-8")
           PY
+            if [ -n "$(find "$diff_dir" -type f -name 'part-*.md' -print -quit)" ]; then
+              diff_comment_status=full
+            fi
           }
 
           write_comment_body() {
@@ -619,7 +624,7 @@ jobs:
               else
                 case "$has_diff" in
                   true)
-                    if [ "$diff_comment_count" -gt 0 ]; then
+                    if [ "$diff_comment_count" -gt 0 ] && [ "$diff_comment_status" = "full" ]; then
                       echo "Output differences were detected. The full diff is posted below in ${diff_comment_count} bot comment(s)."
                     else
                       echo "Output differences were detected, but the inline diff could not be generated. Inspect the \`output-delta-diff-output\` artifact before merging."

--- a/.github/workflows/output-delta.yml
+++ b/.github/workflows/output-delta.yml
@@ -1248,6 +1248,30 @@ jobs:
             fi
           }
 
+          has_diff_files() {
+            local dir="$1"
+            local file
+            for file in "$dir"/*.diff; do
+              [ -e "$file" ] || continue
+              if [ -s "$file" ]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          append_diff_files() {
+            local dir="$1"
+            local out="$2"
+            local file
+            for file in "$dir"/*.diff; do
+              [ -e "$file" ] || continue
+              if [ -s "$file" ]; then
+                cat "$file" >> "$out"
+              fi
+            done
+          }
+
           for resource in clusterroles roles clusterrolebindings rolebindings serviceaccounts; do
             diff_file "/tmp/main-output/${resource}.yaml" "/tmp/pr-output/${resource}.yaml" "/tmp/diff-output/main/${resource}.diff"
           done
@@ -1255,7 +1279,12 @@ jobs:
             diff_file "/tmp/main-output/${resource}.yaml" "/tmp/pr-output/${resource}.yaml" "/tmp/diff-output/main/${resource}.diff"
           done
           diff_file /tmp/main-output/metrics.txt /tmp/pr-output/metrics.txt /tmp/diff-output/main/metrics.diff
+          has_main_diff=false
+          if has_diff_files /tmp/diff-output/main; then
+            has_main_diff=true
+          fi
 
+          has_tag_diff=false
           if [ "$TAG_SUCCESS" = "true" ] && [ -d /tmp/tag-output ]; then
             for resource in clusterroles roles clusterrolebindings rolebindings serviceaccounts; do
               diff_file "/tmp/tag-output/${resource}.yaml" "/tmp/pr-output/${resource}.yaml" "/tmp/diff-output/tag/${resource}.diff"
@@ -1264,13 +1293,16 @@ jobs:
               diff_file "/tmp/tag-output/${resource}.yaml" "/tmp/pr-output/${resource}.yaml" "/tmp/diff-output/tag/${resource}.diff"
             done
             diff_file /tmp/tag-output/metrics.txt /tmp/pr-output/metrics.txt /tmp/diff-output/tag/metrics.diff
-            github_output "has_tag_diff=true"
-          else
-            github_output "has_tag_diff=false"
+            if has_diff_files /tmp/diff-output/tag; then
+              has_tag_diff=true
+            fi
           fi
+          github_output "has_tag_diff=${has_tag_diff}"
 
-          cat /tmp/diff-output/main/*.diff /tmp/diff-output/tag/*.diff > /tmp/diff-output/full-diff.txt 2>/dev/null || true
-          if diff -qr /tmp/main-output /tmp/pr-output >/dev/null 2>&1; then
+          : > /tmp/diff-output/full-diff.txt
+          append_diff_files /tmp/diff-output/main /tmp/diff-output/full-diff.txt
+          append_diff_files /tmp/diff-output/tag /tmp/diff-output/full-diff.txt
+          if [ "$has_main_diff" = "false" ] && [ "$has_tag_diff" = "false" ] && diff -qr /tmp/main-output /tmp/pr-output >/dev/null 2>&1; then
             github_output "has_diff=false"
           else
             github_output "has_diff=true"


### PR DESCRIPTION
## Summary

Fixes an output-delta comment regression for latest-tag-only differences.

Previously the compare job generated tag-vs-PR diff files and concatenated them into `full-diff.txt`, but `has_diff` was based only on `diff -qr /tmp/main-output /tmp/pr-output`. When main and PR outputs matched but the latest release tag differed from the PR, the comment workflow treated the run as no-diff and did not download/post the full diff artifact.

This PR:
- computes `has_tag_diff` from non-empty latest-tag diff files instead of merely from tag job success
- marks overall `has_diff=true` when either main-vs-PR or latest-tag-vs-PR output diffs exist
- builds `full-diff.txt` from non-empty diff files only
- prevents placeholder diagnostic diff comments from being counted as successful full-diff comments in the summary

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/output-delta.yml .github/workflows/output-delta-comment.yml`
- extracted `Generate trusted diff` and `Download comment data` run blocks with Ruby and checked both using `bash -n`
- local regression simulation: main output equals PR output, latest tag differs -> `has_main_diff=false`, `has_tag_diff=true`, `has_diff=true`, non-empty `full-diff.txt`
- local no-diff simulation: main, PR, and latest tag all equal -> `has_diff=false`, empty `full-diff.txt`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/output-delta.yml .github/workflows/output-delta-comment.yml`
- `git diff --check`
