### PR TITLE
ci: clean up e2e kind clusters by suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Cleanup cluster
         if: always()
         run: |
-          kind delete cluster --name auth-operator-e2e || true
+          kind delete cluster --name auth-operator-e2e-helm || true
 
   e2e-complex:
     name: E2E Complex Tests
@@ -196,7 +196,7 @@ jobs:
       - name: Cleanup cluster
         if: always()
         run: |
-          kind delete cluster --name auth-operator-e2e || true
+          kind delete cluster --name auth-operator-e2e-complex || true
 
   e2e-ha:
     name: E2E HA Tests


### PR DESCRIPTION
## Summary
- delete the helm e2e kind cluster with the suite-specific `auth-operator-e2e-helm` name
- delete the complex e2e kind cluster with the suite-specific `auth-operator-e2e-complex` name

## Evidence
- Upstream target verified before push: `telekom/auth-operator`, default branch `main`, `isFork=false`.
- Duplicate check before PR creation: open and closed searches for `e2e cleanup kind cluster auth-operator-e2e-helm auth-operator-e2e-complex .github/workflows/e2e.yml` returned no matching PRs.
- `make test-e2e-helm-full` creates `auth-operator-e2e-helm`; `make test-e2e-complex` creates `auth-operator-e2e-complex`; the workflow cleanup previously targeted `auth-operator-e2e` for both jobs.

## Validation
- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/e2e.yml\"); puts \"ok\"`
- `git diff --check`

`actionlint` was not installed in the local environment, so workflow validation is limited to YAML parsing plus diff hygiene.