### PR TITLE
fix: keep breakglass labels spec-owned

### DIFF
--- a/internal/controller/authorization/roledefinition_helpers.go
+++ b/internal/controller/authorization/roledefinition_helpers.go
@@ -43,6 +43,12 @@ func ownerRefForRoleDefinition(roleDefinition *authorizationv1alpha1.RoleDefinit
 	)
 }
 
+func buildRoleDefinitionResourceLabels(roleDefinition *authorizationv1alpha1.RoleDefinition) map[string]string {
+	labels := helpers.BuildResourceLabels(roleDefinition.Labels)
+	delete(labels, authorizationv1alpha1.BreakglassCompatibleLabel)
+	return labels
+}
+
 // markStalled marks the RoleDefinition as stalled with the given error (kstatus pattern).
 // Uses SSA to apply the stalled condition atomically.
 // The error is logged at debug level; callers log at the appropriate severity.
@@ -67,7 +73,7 @@ func (r *RoleDefinitionReconciler) markStalled(
 func (r *RoleDefinitionReconciler) buildRoleObject(
 	roleDefinition *authorizationv1alpha1.RoleDefinition,
 ) (client.Object, error) {
-	labels := helpers.BuildResourceLabels(roleDefinition.Labels)
+	labels := buildRoleDefinitionResourceLabels(roleDefinition)
 	annotations := helpers.BuildResourceAnnotations("RoleDefinition", roleDefinition.Name)
 
 	switch roleDefinition.Spec.TargetRole {
@@ -277,7 +283,7 @@ func (r *RoleDefinitionReconciler) ensureRole(
 	// then apply aggregation labels (ClusterRole-only) on top, and finally
 	// re-set operator identification labels so aggregationLabels can never
 	// overwrite them.
-	mergedLabels := helpers.BuildResourceLabels(roleDefinition.Labels)
+	mergedLabels := buildRoleDefinitionResourceLabels(roleDefinition)
 	if roleDefinition.Spec.TargetRole == authorizationv1alpha1.DefinitionClusterRole {
 		for k, v := range roleDefinition.Spec.AggregationLabels {
 			mergedLabels[k] = v

--- a/internal/controller/authorization/roledefinition_helpers_test.go
+++ b/internal/controller/authorization/roledefinition_helpers_test.go
@@ -894,6 +894,26 @@ func TestBuildRoleObjectBreakglassLabel(t *testing.T) {
 		g.Expect(cr.Labels).To(HaveKeyWithValue(authorizationv1alpha1.BreakglassCompatibleLabel, "false"))
 	})
 
+	t.Run("ClusterRole spec overrides metadata breakglass label", func(t *testing.T) {
+		g := NewWithT(t)
+		rd := &authorizationv1alpha1.RoleDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					authorizationv1alpha1.BreakglassCompatibleLabel: "true",
+				},
+			},
+			Spec: authorizationv1alpha1.RoleDefinitionSpec{
+				TargetRole:        authorizationv1alpha1.DefinitionClusterRole,
+				TargetName:        "test-cr",
+				BreakglassAllowed: false,
+			},
+		}
+		obj, err := r.buildRoleObject(rd)
+		g.Expect(err).NotTo(HaveOccurred())
+		cr := obj.(*rbacv1.ClusterRole)
+		g.Expect(cr.Labels).To(HaveKeyWithValue(authorizationv1alpha1.BreakglassCompatibleLabel, "false"))
+	})
+
 	t.Run("Role ignores BreakglassAllowed", func(t *testing.T) {
 		g := NewWithT(t)
 		rd := &authorizationv1alpha1.RoleDefinition{
@@ -908,6 +928,28 @@ func TestBuildRoleObjectBreakglassLabel(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		role := obj.(*rbacv1.Role)
 		g.Expect(role.Labels).NotTo(HaveKey(authorizationv1alpha1.BreakglassCompatibleLabel))
+	})
+
+	t.Run("Role strips metadata breakglass label", func(t *testing.T) {
+		g := NewWithT(t)
+		rd := &authorizationv1alpha1.RoleDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					authorizationv1alpha1.BreakglassCompatibleLabel: "true",
+					"custom": "keep",
+				},
+			},
+			Spec: authorizationv1alpha1.RoleDefinitionSpec{
+				TargetRole:      authorizationv1alpha1.DefinitionNamespacedRole,
+				TargetName:      "test-role",
+				TargetNamespace: "default",
+			},
+		}
+		obj, err := r.buildRoleObject(rd)
+		g.Expect(err).NotTo(HaveOccurred())
+		role := obj.(*rbacv1.Role)
+		g.Expect(role.Labels).NotTo(HaveKey(authorizationv1alpha1.BreakglassCompatibleLabel))
+		g.Expect(role.Labels).To(HaveKeyWithValue("custom", "keep"))
 	})
 }
 
@@ -1024,6 +1066,92 @@ func TestEnsureRoleBreakglassLabelApplied(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(appliedLabels).To(HaveKeyWithValue(authorizationv1alpha1.BreakglassCompatibleLabel, "true"),
 		"ensureRole must include the breakglass-compatible label in the SSA apply configuration")
+}
+
+func TestEnsureRoleClusterRoleBreakglassSpecOverridesMetadataLabel(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	s := runtime.NewScheme()
+	_ = authorizationv1alpha1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
+
+	rd := &authorizationv1alpha1.RoleDefinition{
+		TypeMeta: metav1.TypeMeta{APIVersion: authorizationv1alpha1.GroupVersion.String(), Kind: "RoleDefinition"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bg-metadata-rd",
+			UID:  "bg-metadata-uid",
+			Labels: map[string]string{
+				authorizationv1alpha1.BreakglassCompatibleLabel: "true",
+			},
+		},
+		Spec: authorizationv1alpha1.RoleDefinitionSpec{
+			TargetRole:        authorizationv1alpha1.DefinitionClusterRole,
+			TargetName:        "bg-metadata-cr",
+			BreakglassAllowed: false,
+		},
+	}
+
+	var appliedLabels map[string]string
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(rd).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				if cr, ok := obj.(*rbacv1ac.ClusterRoleApplyConfiguration); ok && cr.ObjectMetaApplyConfiguration != nil {
+					appliedLabels = cr.Labels
+				}
+				return nil
+			},
+		}).Build()
+	r := &RoleDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
+
+	err := r.ensureRole(ctx, rd, []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}}})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(appliedLabels).To(HaveKeyWithValue(authorizationv1alpha1.BreakglassCompatibleLabel, "false"))
+}
+
+func TestEnsureRoleNamespacedRoleStripsMetadataBreakglassLabel(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	s := runtime.NewScheme()
+	_ = authorizationv1alpha1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
+
+	rd := &authorizationv1alpha1.RoleDefinition{
+		TypeMeta: metav1.TypeMeta{APIVersion: authorizationv1alpha1.GroupVersion.String(), Kind: "RoleDefinition"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "strip-bg-label-rd",
+			UID:  "strip-bg-label-uid",
+			Labels: map[string]string{
+				authorizationv1alpha1.BreakglassCompatibleLabel: "true",
+				"custom": "keep",
+			},
+		},
+		Spec: authorizationv1alpha1.RoleDefinitionSpec{
+			TargetRole:      authorizationv1alpha1.DefinitionNamespacedRole,
+			TargetName:      "strip-bg-label-role",
+			TargetNamespace: "default",
+		},
+	}
+
+	var appliedLabels map[string]string
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(rd).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(_ context.Context, _ client.WithWatch, obj runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				if role, ok := obj.(*rbacv1ac.RoleApplyConfiguration); ok && role.ObjectMetaApplyConfiguration != nil {
+					appliedLabels = role.Labels
+				}
+				return nil
+			},
+		}).Build()
+	r := &RoleDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
+
+	err := r.ensureRole(ctx, rd, []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}}})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(appliedLabels).NotTo(HaveKey(authorizationv1alpha1.BreakglassCompatibleLabel))
+	g.Expect(appliedLabels).To(HaveKeyWithValue("custom", "keep"))
 }
 
 func TestEnsureRoleClusterRoleSSAError(t *testing.T) {


### PR DESCRIPTION
## Summary
- strip `t-caas.telekom.com/breakglass-compatible` from copied `RoleDefinition` metadata labels before generating RBAC objects
- keep the Breakglass compatibility label spec-owned for ClusterRoles, including the `false` value used to clear stale `true` labels
- add regression coverage for object construction and SSA apply configurations

## Upstream target verification
- Target repo verified immediately before PR creation: `telekom/auth-operator`
- GitHub metadata: `isFork=false`, `parent=null`, `defaultBranch=main`, `viewerPermission=ADMIN`
- Remote used for push: `https://github.com/telekom/auth-operator.git`

## Duplicate-check evidence
- Open upstream PR search: `BreakglassCompatibleLabel RoleDefinition metadata labels breakglassAllowed Role ClusterRole` -> no matches
- Recently closed upstream PR search with `updated:>=2026-04-01` -> no matches
- Existing open PR #350 is CI cleanup only; #327 is helper refactoring and does not cover this label propagation behavior

## Finding fixed
Namespaced `RoleDefinition` objects could smuggle the reserved Breakglass compatibility label through metadata labels into generated `Role` objects, even though `spec.breakglassAllowed` only applies to generated `ClusterRole` objects. ClusterRoles also now explicitly ignore conflicting metadata values and use the spec value as the single source of truth.

## Tests
- `GOCACHE=/private/tmp/auth-operator-go-build-cache go test ./internal/controller/authorization -run 'TestBuildRoleObjectBreakglassLabel|TestEnsureRole.*Breakglass.*Label|TestEnsureRoleNamespacedRoleStripsMetadataBreakglassLabel' -count=1 -timeout=90s`
- `go test ./internal/controller/authorization -count=1 -timeout=180s`
- `git diff --check -- internal/controller/authorization/roledefinition_helpers.go internal/controller/authorization/roledefinition_helpers_test.go`

## Local validation notes
- The full package test was run after installing local envtest assets with `setup-envtest use 1.34.1 --bin-dir ./bin -p path`.
- A first sandboxed full-package run failed because the sandbox blocked `127.0.0.1` binding; rerun outside the sandbox passed.
