### PR TITLE
fix(webhook): allow explicit namespace mutator matches

### DIFF
--- a/internal/webhook/authorization/namespace_mutating_webhook.go
+++ b/internal/webhook/authorization/namespace_mutating_webhook.go
@@ -75,7 +75,7 @@ func (m *NamespaceMutator) Handle(ctx context.Context, req admission.Request) ad
 	}
 
 	// Collect labels from matching BindDefinitions
-	labelsToAdd, listErr := m.collectBindDefinitionLabels(ctx, req.Name, req.UserInfo.Username, userGroups, saInfo)
+	labelsToAdd, explicitNamespaceAllowed, listErr := m.collectBindDefinitionLabels(ctx, req.Name, req.UserInfo.Username, userGroups, saInfo)
 	if listErr != nil {
 		logger.Error(listErr, "failed to collect BindDefinition labels", "namespace", req.Name)
 		metrics.WebhookRequestsTotal.WithLabelValues(metrics.WebhookNamespaceMutator, string(req.Operation), metrics.WebhookResultErrored).Inc()
@@ -105,6 +105,18 @@ func (m *NamespaceMutator) Handle(ctx context.Context, req admission.Request) ad
 			return admission.Denied(fmt.Sprintf(DenialInvalidTrackedLabelsFmt, ns.Name))
 		}
 		return m.applyLabelPatch(ctx, req, ns, labelsToAdd)
+	}
+	if explicitNamespaceAllowed {
+		if !ValidTrackedOwnershipLabels(ns.Labels) {
+			logger.V(1).Info("namespace mutation denied - invalid tracked ownership labels on explicit namespace",
+				"namespace", req.Name, "operation", req.Operation, "username", req.UserInfo.Username)
+			metrics.WebhookRequestsTotal.WithLabelValues(metrics.WebhookNamespaceMutator, string(req.Operation), metrics.WebhookResultDenied).Inc()
+			return admission.Denied(fmt.Sprintf(DenialInvalidTrackedLabelsFmt, ns.Name))
+		}
+		logger.V(1).Info("namespace mutation allowed - explicit namespace binding matched",
+			"namespace", req.Name, "operation", req.Operation, "username", req.UserInfo.Username)
+		metrics.WebhookRequestsTotal.WithLabelValues(metrics.WebhookNamespaceMutator, string(req.Operation), metrics.WebhookResultAllowed).Inc()
+		return admission.Allowed("Explicit namespace binding matched")
 	}
 
 	// If no labels to add, deny the request with a warning
@@ -176,8 +188,9 @@ func denyConflictingInheritedLabels(
 }
 
 // collectBindDefinitionLabels iterates over all BindDefinitions and collects labels to add
-// from those whose subjects match the requesting user.
-func (m *NamespaceMutator) collectBindDefinitionLabels(ctx context.Context, nsName, username string, userGroups []string, saInfo ServiceAccountInfo) (map[string]string, error) {
+// from those whose subjects match the requesting user. The boolean return value reports
+// whether an exact explicit namespace binding matched the request namespace.
+func (m *NamespaceMutator) collectBindDefinitionLabels(ctx context.Context, nsName, username string, userGroups []string, saInfo ServiceAccountInfo) (labelsToAdd map[string]string, explicitNamespaceAllowed bool, err error) {
 	logger := logf.FromContext(ctx).WithName("namespace-mutator")
 
 	listCtx, cancel := context.WithTimeout(ctx, authorizationv1alpha1.WebhookCacheTimeout)
@@ -185,13 +198,13 @@ func (m *NamespaceMutator) collectBindDefinitionLabels(ctx context.Context, nsNa
 	bindDefinitions, err := freshBindDefinitionsWithRoleBindings(listCtx, m.Client, m.admissionReader())
 	if err != nil {
 		logger.Error(err, "failed to list BindDefinitions", "namespace", nsName)
-		return nil, err
+		return nil, false, err
 	}
 
 	logger.V(2).Info("checking BindDefinitions for label mutations",
 		"namespace", nsName, "bindDefinitionCount", len(bindDefinitions))
 
-	labelsToAdd := map[string]string{}
+	labelsToAdd = map[string]string{}
 
 	for bdIdx, bindDef := range bindDefinitions {
 		if IsRestrictedBindDefinition(bindDef.Name) {
@@ -208,9 +221,15 @@ func (m *NamespaceMutator) collectBindDefinitionLabels(ctx context.Context, nsNa
 
 			for rbIdx, roleBinding := range bindDef.Spec.RoleBindings {
 				if roleBinding.Namespace != "" {
-					logger.V(4).Info("skipping namespace selectors because explicit namespace is set",
-						"namespace", nsName, "roleBindingIndex", rbIdx,
-						"explicitNamespace", roleBinding.Namespace)
+					if roleBinding.Namespace == nsName {
+						explicitNamespaceAllowed = true
+						logger.V(3).Info("explicit namespace binding matched",
+							"namespace", nsName, "bindDefinition", bindDef.Name, "roleBindingIndex", rbIdx)
+					} else {
+						logger.V(4).Info("explicit namespace did not match request namespace, skipping selectors",
+							"namespace", nsName, "roleBindingIndex", rbIdx,
+							"explicitNamespace", roleBinding.Namespace)
+					}
 					continue
 				}
 				if len(roleBinding.NamespaceSelector) > 0 {
@@ -236,7 +255,7 @@ func (m *NamespaceMutator) collectBindDefinitionLabels(ctx context.Context, nsNa
 		}
 	}
 
-	return labelsToAdd, nil
+	return labelsToAdd, explicitNamespaceAllowed, nil
 }
 
 func (m *NamespaceMutator) admissionReader() client.Reader {

--- a/internal/webhook/authorization/namespace_mutating_webhook_test.go
+++ b/internal/webhook/authorization/namespace_mutating_webhook_test.go
@@ -928,6 +928,101 @@ func TestNamespaceMutatorIgnoresSelectorsWhenExplicitNamespaceIsSet(t *testing.T
 	}
 }
 
+func TestNamespaceMutatorAllowsMatchingExplicitNamespaceWithoutPatch(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(authorizationv1alpha1.AddToScheme(scheme))
+
+	bd := &authorizationv1alpha1.BindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "explicit-namespace-mutator-bd"},
+		Spec: authorizationv1alpha1.BindDefinitionSpec{
+			TargetName: "explicit-namespace-mutator-target",
+			Subjects: []rbacv1.Subject{
+				{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: "allowed-group"},
+			},
+			RoleBindings: []authorizationv1alpha1.NamespaceBinding{{
+				Namespace:       "explicit-ns",
+				ClusterRoleRefs: []string{"admin"},
+			}},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bd).Build()
+	mutator := &webhooks.NamespaceMutator{
+		Client:  fakeClient,
+		Decoder: crAdmission.NewDecoder(scheme),
+	}
+
+	tests := []struct {
+		name          string
+		labels        map[string]string
+		expectAllowed bool
+	}{
+		{
+			name:          "exact explicit namespace with no tracked labels is allowed",
+			labels:        nil,
+			expectAllowed: true,
+		},
+		{
+			name: "exact explicit namespace with coherent tracked labels is allowed",
+			labels: map[string]string{
+				authorizationv1alpha1.LabelKeyOwner: authorizationv1alpha1.OwnerPlatform,
+			},
+			expectAllowed: true,
+		},
+		{
+			name: "exact explicit namespace with incoherent tracked labels is denied",
+			labels: map[string]string{
+				authorizationv1alpha1.LabelKeyOwner: authorizationv1alpha1.OwnerTenant,
+			},
+			expectAllowed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := &corev1.Namespace{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "explicit-ns",
+					Labels: tt.labels,
+				},
+			}
+			nsRaw, err := json.Marshal(ns)
+			if err != nil {
+				t.Fatalf("failed to marshal namespace: %v", err)
+			}
+			req := crAdmission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				UserInfo: authenticationv1.UserInfo{
+					Username: "user1",
+					Groups:   []string{"allowed-group"},
+				},
+				Kind: metav1.GroupVersionKind{
+					Group:   "",
+					Version: "v1",
+					Kind:    "Namespace",
+				},
+				Name:   ns.Name,
+				Object: runtime.RawExtension{Raw: nsRaw},
+			}}
+
+			resp := mutator.Handle(context.Background(), req)
+			if tt.expectAllowed {
+				if !resp.Allowed {
+					t.Fatalf("expected explicit namespace request to be allowed, got denied: %v", resp.Result)
+				}
+				if len(resp.Patches) != 0 {
+					t.Fatalf("expected explicit namespace request to be allowed without patches, got: %v", resp.Patches)
+				}
+				return
+			}
+			if resp.Allowed {
+				t.Fatal("expected incoherent explicit namespace labels to be denied")
+			}
+		})
+	}
+}
+
 func TestNamespaceMutatorSanitizesInternalErrors(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))


### PR DESCRIPTION
## Summary

- allow the namespace mutating webhook when a BindDefinition explicitly targets the namespace being created
- keep explicit namespace precedence over selectors and preserve denial for incoherent existing ownership labels
- add webhook coverage for matching explicit namespaces with and without valid existing labels

## Finding fixed

The namespace validating webhook already authorizes namespace CREATE when a BindDefinition roleBinding explicitly names the requested namespace. The mutating webhook skipped every roleBinding with an explicit namespace before checking whether it matched the namespace being created, so a valid explicit namespace binding with no selector-derived labels could be denied before validation ran.

## Target verification

- `gh repo view telekom/auth-operator --json nameWithOwner,url,defaultBranchRef,isFork,parent` returned `telekom/auth-operator`, `https://github.com/telekom/auth-operator`, default branch `main`, `isFork=false`, `parent=null`.
- Local `origin` fetch/push URL is `https://github.com/telekom/auth-operator.git`.

## Duplicate-check evidence

- Open PR search: `gh search prs "BindDefinition explicit namespace namespace_mutating_webhook" --repo telekom/auth-operator --state open ...` returned `[]`.
- Recently merged search: `gh search prs "BindDefinition explicit namespace namespace_mutating_webhook" --repo telekom/auth-operator --state closed --merged --merged-at ">=2026-06-01" ...` returned `[]`.
- Adjacent open PR #326 covers CAPI TDG bypass update scoping, not explicit namespace mutator authorization.
- Adjacent open PR #327 covers RoleDefinition aggregation surfaces, not namespace mutating webhook explicit namespace matching.

## Tests

- `make envtest`
- `./bin/setup-envtest use 1.34.1 --bin-dir ./bin`
- `GOCACHE=/private/tmp/auth-operator-go-build-cache go test -timeout=5m ./internal/webhook/authorization`
- `git diff --check`
