### PR TITLE
fix(binddefinition): return role lookup errors

### DIFF
--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -1665,7 +1665,7 @@ func (r *BindDefinitionReconciler) validateRoleReferences(
 							missingRoles = append(missingRoles, roleName)
 						}
 					} else {
-						logger.Error(err, "Failed to check Role existence", "role", roleRef, "namespace", ns.Name)
+						return missingRoles, fmt.Errorf("check Role %s/%s existence: %w", ns.Name, roleRef, err)
 					}
 				}
 			}

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -1845,6 +1845,44 @@ func TestValidateRoleReferences(t *testing.T) {
 		g.Expect(missing).To(ContainElement("Role/test-ns/missing-role"))
 	})
 
+	t.Run("should return non-NotFound Role lookup errors", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+			Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+		}
+		bindDef := &authorizationv1alpha1.BindDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-bd"},
+			Spec: authorizationv1alpha1.BindDefinitionSpec{
+				TargetName: "test",
+				Subjects:   []rbacv1.Subject{{Kind: "User", Name: "u"}},
+				RoleBindings: []authorizationv1alpha1.NamespaceBinding{
+					{
+						RoleRefs:  []string{"existing-role"},
+						Namespace: "test-ns",
+					},
+				},
+			},
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*rbacv1.Role); ok {
+						return fmt.Errorf("injected role lookup error")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			}).Build()
+		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+
+		missing, err := r.validateRoleReferences(ctx, bindDef)
+		g.Expect(err).To(MatchError(ContainSubstring("check Role test-ns/existing-role existence")))
+		g.Expect(err).To(MatchError(ContainSubstring("injected role lookup error")))
+		g.Expect(missing).To(BeEmpty())
+	})
+
 	t.Run("should not duplicate ClusterRole references", func(t *testing.T) {
 		g := NewWithT(t)
 


### PR DESCRIPTION
## Summary

- Return non-NotFound namespaced `Role` lookup errors during `BindDefinition` role-reference validation.
- Add a regression test that injects a Role lookup error and verifies it is surfaced instead of being treated as a successful validation.

## Evidence

`validateRoleReferences` already returns non-NotFound errors when checking `ClusterRole` references. The namespaced `Role` path only logged the error and continued, so transient/API/RBAC failures could be reconciled as if the referenced Role was valid.

The restricted BindDefinition path already returns the equivalent Role lookup error.

## Validation

- `go test ./internal/controller/authorization -run TestValidateRoleReferences -count=1`
- `make fmt vet`
- `KUBEBUILDER_ASSETS=/Users/A92615428/git/GitHub/telekom/auth-operator/bin/k8s/1.34.1-darwin-arm64 go test ./internal/controller/authorization -count=1`

