### PR TITLE
fix(restrictedbinddefinition): return stalled status apply errors

### DIFF
--- a/internal/controller/authorization/restrictedbinddefinition_controller.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller.go
@@ -713,7 +713,9 @@ func (r *RestrictedBindDefinitionReconciler) rbdHandleMissingPolicy(
 			rbd.Name, rbd.Spec.PolicyRef.Name, err)
 	}
 	rbdClearDeprovisionedStatus(rbd)
-	r.rbdApplyStatusAndMarkStalled(ctx, rbd, "policy not found")
+	if err := r.rbdApplyStatusAndMarkStalled(ctx, rbd, "policy not found"); err != nil {
+		return ctrl.Result{}, err
+	}
 	metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultDegraded).Inc()
 	return ctrl.Result{RequeueAfter: DefaultRequeueInterval}, nil
 }
@@ -739,7 +741,9 @@ func (r *RestrictedBindDefinitionReconciler) rbdHandleDeletingPolicy(
 			rbd.Name, rbacPolicy.Name, err)
 	}
 	rbdClearDeprovisionedStatus(rbd)
-	r.rbdApplyStatusAndMarkStalled(ctx, rbd, "policy deleting")
+	if err := r.rbdApplyStatusAndMarkStalled(ctx, rbd, "policy deleting"); err != nil {
+		return ctrl.Result{}, err
+	}
 	metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultDegraded).Inc()
 	return ctrl.Result{RequeueAfter: DefaultRequeueInterval}, nil
 }
@@ -1723,7 +1727,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdApplyStatusAndMarkStalled(
 	ctx context.Context,
 	rbd *authorizationv1alpha1.RestrictedBindDefinition,
 	msg string,
-) {
+) error {
 	logger := log.FromContext(ctx)
 	conditions.MarkStalled(rbd, rbd.Generation,
 		authorizationv1alpha1.StalledReasonError, authorizationv1alpha1.StalledMessageError, msg)
@@ -1731,7 +1735,9 @@ func (r *RestrictedBindDefinitionReconciler) rbdApplyStatusAndMarkStalled(
 	rbd.Status.ObservedGeneration = rbd.Generation
 	if err := ssa.ApplyRestrictedBindDefinitionStatus(ctx, r.client, rbd); err != nil {
 		logger.Error(err, "failed to apply status via SSA", "name", rbd.Name)
+		return fmt.Errorf("apply RestrictedBindDefinition %s stalled status: %w", rbd.Name, err)
 	}
+	return nil
 }
 
 func (r *RestrictedBindDefinitionReconciler) rbdLogApplyIdentity(

--- a/internal/controller/authorization/restrictedbinddefinition_controller_test.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller_test.go
@@ -334,6 +334,48 @@ func TestRBD_Reconcile_PolicyNotFound(t *testing.T) {
 	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Namespace: ownedSA.Namespace, Name: ownedSA.Name}, &deletedSA)).NotTo(gomega.Succeed())
 }
 
+func TestRBD_Reconcile_PolicyNotFoundReturnsStatusApplyError(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	s := newTestScheme()
+	rbd := &authorizationv1alpha1.RestrictedBindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "status-error-rbd", UID: "status-error-rbd-uid", Generation: 1},
+		Spec: authorizationv1alpha1.RestrictedBindDefinitionSpec{
+			PolicyRef:  authorizationv1alpha1.RBACPolicyReference{Name: "missing-policy"},
+			TargetName: "status-error-binding",
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.UserKind, Name: "alice", APIGroup: rbacv1.GroupName},
+			},
+			ClusterRoleBindings: &authorizationv1alpha1.ClusterBinding{
+				ClusterRoleRefs: []string{"view"},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rbd).
+		WithStatusSubresource(&authorizationv1alpha1.RestrictedBindDefinition{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceApply: func(_ context.Context, _ client.Client, _ string, _ runtime.ApplyConfiguration, _ ...client.SubResourceApplyOption) error {
+				return fmt.Errorf("status apply failed")
+			},
+		}).
+		Build()
+	r := &RestrictedBindDefinitionReconciler{
+		client:   c,
+		reader:   c,
+		scheme:   s,
+		recorder: events.NewFakeRecorder(10),
+	}
+
+	_, err := r.Reconcile(rbdCtx(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: rbd.Name},
+	})
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("stalled status"))
+	g.Expect(err.Error()).To(gomega.ContainSubstring("status apply failed"))
+}
+
 func TestRBD_Reconcile_PolicyViolation_Deprovision(t *testing.T) {
 	g := gomega.NewWithT(t)
 


### PR DESCRIPTION
## Summary
- return errors when RestrictedBindDefinition cannot apply stalled status for missing/deleting RBACPolicy references
- add a regression test that injects a status subresource apply failure for the missing-policy path

## Evidence
A runtime audit found RestrictedBindDefinition policy-missing/deleting paths logged failed stalled status applies and still returned a degraded requeue. RestrictedRoleDefinition already returns the analogous status apply failure, so this aligns RBD behavior with RRD and prevents silent loss of status update errors.

## Validation
- `go test ./internal/controller/authorization -run TestRBD_Reconcile_PolicyNotFoundReturnsStatusApplyError -count=1`
- `make fmt vet`
- `KUBEBUILDER_ASSETS=/Users/A92615428/git/GitHub/telekom/auth-operator/bin/k8s/1.34.1-darwin-arm64 go test ./internal/controller/authorization -count=1`