### PR TITLE
fix(authorizer): count rate-limited SAR denials

### DIFF
--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -162,6 +162,7 @@ func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	wa.annotateSARSpan(ctx, &sar)
 	if wa.Limiter != nil && !wa.allowSubjectRequest(&sar) {
 		pkgmetrics.AuthorizerRateLimitedTotal.Inc()
+		wa.recordRejectedMetrics(start)
 		wa.Log.V(1).Info("rate limit exceeded, rejecting request",
 			"user", sar.Spec.User,
 			"groups", cappedGroups(sar.Spec.Groups),
@@ -887,7 +888,7 @@ func (wa *Authorizer) recordErrorMetrics(start time.Time) {
 }
 
 // recordRejectedMetrics records Prometheus request counter and duration
-// histogram with decision=denied for malformed-SAR rejection paths.
+// histogram with decision=denied for early rejection paths.
 func (wa *Authorizer) recordRejectedMetrics(start time.Time) {
 	duration := time.Since(start).Seconds()
 	pkgmetrics.AuthorizerRequestsTotal.WithLabelValues(pkgmetrics.AuthorizerDecisionDenied, pkgmetrics.AuthorizerNameNone).Inc()

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -1231,6 +1231,8 @@ func TestServeHTTP_RateLimiting(t *testing.T) {
 	// Ensure the counter series exists so we can measure the delta.
 	pkgmetrics.AuthorizerRateLimitedTotal.Add(0)
 	initialCount := testutil.ToFloat64(pkgmetrics.AuthorizerRateLimitedTotal)
+	initialDeniedCount := testutil.ToFloat64(pkgmetrics.AuthorizerRequestsTotal.WithLabelValues(
+		pkgmetrics.AuthorizerDecisionDenied, pkgmetrics.AuthorizerNameNone))
 
 	// First request should succeed (uses the burst token).
 	req1 := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(body))
@@ -1268,6 +1270,11 @@ func TestServeHTTP_RateLimiting(t *testing.T) {
 	afterCount := testutil.ToFloat64(pkgmetrics.AuthorizerRateLimitedTotal)
 	if afterCount-initialCount < 1 {
 		t.Errorf("AuthorizerRateLimitedTotal did not increment: before=%v, after=%v", initialCount, afterCount)
+	}
+	afterDeniedCount := testutil.ToFloat64(pkgmetrics.AuthorizerRequestsTotal.WithLabelValues(
+		pkgmetrics.AuthorizerDecisionDenied, pkgmetrics.AuthorizerNameNone))
+	if afterDeniedCount-initialDeniedCount < 1 {
+		t.Errorf("AuthorizerRequestsTotal denied metric did not increment: before=%v, after=%v", initialDeniedCount, afterDeniedCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- record rate-limited SubjectAccessReview requests in the main authorizer request and duration metrics
- keep the dedicated rate-limit counter and add a regression assertion for the denied request metric

## Evidence
The rate-limit path returned before `recordMetrics`, so dashboards using `AuthorizerRequestsTotal` undercounted processed SARs even though `AuthorizerRateLimitedTotal` increased.

## Validation
- `go test ./internal/webhook/authorization -run TestServeHTTP_RateLimiting -count=1`
- `KUBEBUILDER_ASSETS=/Users/A92615428/git/GitHub/telekom/auth-operator/bin/k8s/1.34.1-darwin-arm64 go test ./internal/webhook/authorization -count=1`
- `make fmt vet`