### PR TITLE
fix(binddefinition): reject rolebinding name collisions

### DIFF
--- a/api/authorization/v1alpha1/binddefinition_webhook.go
+++ b/api/authorization/v1alpha1/binddefinition_webhook.go
@@ -141,8 +141,12 @@ func (v *BindDefinitionValidator) validateBindDefinitionSpec(ctx context.Context
 	// Determine the missing-role policy from annotation.
 	policy := r.GetMissingRolePolicy()
 
-	if err := validateNamespaceBindings(schema.GroupKind{Group: GroupVersion.Group, Kind: "BindDefinition"}, r.Name, r.Spec.RoleBindings); err != nil {
+	kind := schema.GroupKind{Group: GroupVersion.Group, Kind: BindDefinitionKind}
+	if err := validateNamespaceBindings(kind, r.Name, r.Spec.RoleBindings); err != nil {
 		logger.Info("validation failed: invalid roleBindings", "name", r.Name, "error", err.Error())
+		return warnings, err
+	}
+	if err := v.validateRoleBindingNameCollisions(ctx, kind, r); err != nil {
 		return warnings, err
 	}
 
@@ -306,6 +310,93 @@ func (v *BindDefinitionValidator) validateBindDefinitionSpec(ctx context.Context
 	}
 
 	return warnings, nil
+}
+
+func (v *BindDefinitionValidator) validateRoleBindingNameCollisions(
+	ctx context.Context,
+	kind schema.GroupKind,
+	obj *BindDefinition,
+) error {
+	claims := make(map[string]roleBindingNameClaim)
+	for i, binding := range obj.Spec.RoleBindings {
+		namespaces, err := v.resolveRoleBindingNamespacesForValidation(ctx, binding, i, obj.Name)
+		if err != nil {
+			return err
+		}
+		for _, namespace := range namespaces {
+			for j, roleRef := range binding.ClusterRoleRefs {
+				path := field.NewPath("spec", "roleBindings").Index(i).Child("clusterRoleRefs").Index(j)
+				if err := recordRoleBindingNameClaim(kind, obj.Name, obj.Spec.TargetName, claims, namespace, "ClusterRole", roleRef, path); err != nil {
+					return err
+				}
+			}
+			for j, roleRef := range binding.RoleRefs {
+				path := field.NewPath("spec", "roleBindings").Index(i).Child("roleRefs").Index(j)
+				if err := recordRoleBindingNameClaim(kind, obj.Name, obj.Spec.TargetName, claims, namespace, "Role", roleRef, path); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (v *BindDefinitionValidator) resolveRoleBindingNamespacesForValidation(
+	ctx context.Context,
+	binding NamespaceBinding,
+	bindingIndex int,
+	objectName string,
+) ([]string, error) {
+	if binding.Namespace != "" {
+		return []string{binding.Namespace}, nil
+	}
+
+	namespaceSet := make(map[string]struct{})
+	for selectorIndex, namespaceSelector := range binding.NamespaceSelector {
+		selector, err := metav1.LabelSelectorAsSelector(&namespaceSelector)
+		if err != nil {
+			return nil, apierrors.NewInvalid(
+				schema.GroupKind{Group: GroupVersion.Group, Kind: BindDefinitionKind},
+				objectName,
+				field.ErrorList{field.Invalid(
+					field.NewPath("spec", "roleBindings").Index(bindingIndex).Child("namespaceSelector").Index(selectorIndex),
+					namespaceSelector,
+					err.Error())})
+		}
+
+		continueToken := ""
+		for {
+			namespaceList := &corev1.NamespaceList{}
+			nextContinueToken, err := listAdmissionPage(
+				ctx,
+				v.reader(),
+				namespaceList,
+				continueToken,
+				client.MatchingLabelsSelector{Selector: selector},
+			)
+			if err != nil {
+				return nil, apierrors.NewInternalError(errors.New("unable to list namespaces for RoleBinding name collision validation"))
+			}
+			for i := range namespaceList.Items {
+				namespace := &namespaceList.Items[i]
+				if namespace.Status.Phase == corev1.NamespaceTerminating {
+					continue
+				}
+				namespaceSet[namespace.Name] = struct{}{}
+			}
+			if nextContinueToken == "" {
+				break
+			}
+			continueToken = nextContinueToken
+		}
+	}
+
+	namespaces := make([]string, 0, len(namespaceSet))
+	for namespace := range namespaceSet {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+	return namespaces, nil
 }
 
 //nolint:nilnil // A nil object with nil error means no conflicting targetName was found.

--- a/api/authorization/v1alpha1/binddefinition_webhook.go
+++ b/api/authorization/v1alpha1/binddefinition_webhook.go
@@ -317,28 +317,7 @@ func (v *BindDefinitionValidator) validateRoleBindingNameCollisions(
 	kind schema.GroupKind,
 	obj *BindDefinition,
 ) error {
-	claims := make(map[string]roleBindingNameClaim)
-	for i, binding := range obj.Spec.RoleBindings {
-		namespaces, err := v.resolveRoleBindingNamespacesForValidation(ctx, binding, i, obj.Name)
-		if err != nil {
-			return err
-		}
-		for _, namespace := range namespaces {
-			for j, roleRef := range binding.ClusterRoleRefs {
-				path := field.NewPath("spec", "roleBindings").Index(i).Child("clusterRoleRefs").Index(j)
-				if err := recordRoleBindingNameClaim(kind, obj.Name, obj.Spec.TargetName, claims, namespace, "ClusterRole", roleRef, path); err != nil {
-					return err
-				}
-			}
-			for j, roleRef := range binding.RoleRefs {
-				path := field.NewPath("spec", "roleBindings").Index(i).Child("roleRefs").Index(j)
-				if err := recordRoleBindingNameClaim(kind, obj.Name, obj.Spec.TargetName, claims, namespace, "Role", roleRef, path); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
+	return validateRoleBindingNameCollisionClaims(ctx, kind, obj.Name, obj.Spec.TargetName, obj.Spec.RoleBindings, v.resolveRoleBindingNamespacesForValidation)
 }
 
 func (v *BindDefinitionValidator) resolveRoleBindingNamespacesForValidation(

--- a/api/authorization/v1alpha1/binddefinition_webhook_test.go
+++ b/api/authorization/v1alpha1/binddefinition_webhook_test.go
@@ -333,6 +333,32 @@ var _ = Describe("BindDefinition Webhook", func() {
 			Expect(err.Error()).To(ContainSubstring("spec.roleBindings[0].roleRefs[0]"))
 			Expect(err.Error()).To(ContainSubstring("Duplicate value"))
 		})
+
+		It("should deny RoleBinding name collisions across separate roleBinding entries", func() {
+			bd := &BindDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-bd-cross-entry-rb-name-collision",
+				},
+				Spec: BindDefinitionSpec{
+					TargetName: "test-bd-cross-entry-rb-name-collision",
+					Subjects:   validSubjects,
+					RoleBindings: []NamespaceBinding{
+						{
+							Namespace:       "default",
+							ClusterRoleRefs: []string{"reader"},
+						},
+						{
+							Namespace: "default",
+							RoleRefs:  []string{"reader"},
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, bd)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.roleBindings[1].roleRefs[0]"))
+			Expect(err.Error()).To(ContainSubstring("collides with ClusterRole"))
+		})
 	})
 
 	Context("Subject Kind Validation", func() {

--- a/api/authorization/v1alpha1/restrictedbinddefinition_webhook.go
+++ b/api/authorization/v1alpha1/restrictedbinddefinition_webhook.go
@@ -302,22 +302,34 @@ func (v *RestrictedBindDefinitionValidator) validateRoleBindingNameCollisions(
 	kind schema.GroupKind,
 	obj *RestrictedBindDefinition,
 ) error {
+	return validateRoleBindingNameCollisionClaims(ctx, kind, obj.Name, obj.Spec.TargetName, obj.Spec.RoleBindings, v.resolveRoleBindingNamespacesForValidation)
+}
+
+type roleBindingNamespaceResolver func(context.Context, NamespaceBinding, int, string) ([]string, error)
+
+func validateRoleBindingNameCollisionClaims(
+	ctx context.Context,
+	kind schema.GroupKind,
+	objectName, targetName string,
+	bindings []NamespaceBinding,
+	resolveNamespaces roleBindingNamespaceResolver,
+) error {
 	claims := make(map[string]roleBindingNameClaim)
-	for i, binding := range obj.Spec.RoleBindings {
-		namespaces, err := v.resolveRoleBindingNamespacesForValidation(ctx, binding, i, obj.Name)
+	for i, binding := range bindings {
+		namespaces, err := resolveNamespaces(ctx, binding, i, objectName)
 		if err != nil {
 			return err
 		}
 		for _, namespace := range namespaces {
 			for j, roleRef := range binding.ClusterRoleRefs {
 				path := field.NewPath("spec", "roleBindings").Index(i).Child("clusterRoleRefs").Index(j)
-				if err := recordRoleBindingNameClaim(kind, obj.Name, obj.Spec.TargetName, claims, namespace, "ClusterRole", roleRef, path); err != nil {
+				if err := recordRoleBindingNameClaim(kind, objectName, targetName, claims, namespace, "ClusterRole", roleRef, path); err != nil {
 					return err
 				}
 			}
 			for j, roleRef := range binding.RoleRefs {
 				path := field.NewPath("spec", "roleBindings").Index(i).Child("roleRefs").Index(j)
-				if err := recordRoleBindingNameClaim(kind, obj.Name, obj.Spec.TargetName, claims, namespace, "Role", roleRef, path); err != nil {
+				if err := recordRoleBindingNameClaim(kind, objectName, targetName, claims, namespace, "Role", roleRef, path); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
## Summary
- reject BindDefinition roleBinding entries that would generate the same RoleBinding name for different Role/ClusterRole refs
- reuse the existing generated-name collision model already used by RestrictedBindDefinition
- add a webhook regression for cross-entry RoleBinding collisions

## Evidence
`helpers.BuildBindingName(targetName, roleRef)` does not include the role kind. A BindDefinition with one entry for `ClusterRole/reader` and another for `Role/reader` in the same namespace can only produce one `target-reader-binding`, silently dropping one requested grant.

## Validation
- `KUBEBUILDER_ASSETS=/Users/A92615428/git/GitHub/telekom/auth-operator/bin/k8s/1.34.1-darwin-arm64 go test ./api/authorization/v1alpha1 -run TestAPIs/BindDefinition_Webhook/When_creating_BindDefinition_under_Validating_Webhook/should_deny_RoleBinding_name_collisions_across_separate_roleBinding_entries -count=1`
- `KUBEBUILDER_ASSETS=/Users/A92615428/git/GitHub/telekom/auth-operator/bin/k8s/1.34.1-darwin-arm64 go test ./api/authorization/v1alpha1 -count=1`
- `make fmt vet`