### PR TITLE
fix(binddefinition): report missing explicit namespaces

### DIFF
--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -479,13 +479,16 @@ func (r *BindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// This avoids duplicate API calls to list namespaces.
 	logger.V(2).Info("Collecting namespaces for BindDefinition",
 		"bindDefinition", bindDefinition.Name)
-	namespaceSet, perRoleBindingNamespaces, err := r.collectNamespaces(ctx, bindDefinition)
+	namespaceSet, perRoleBindingNamespaces, missingTargetNamespaces, err := r.collectNamespaces(ctx, bindDefinition)
 	if err != nil {
 		logger.Error(err, "Unable to collect namespaces", "bindDefinitionName", bindDefinition.Name)
 		r.markStalled(ctx, bindDefinition, err)
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultError).Inc()
 		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerBindDefinition, metrics.ErrorTypeAPI).Inc()
 		return ctrl.Result{}, fmt.Errorf("collect namespaces for BindDefinition %s: %w", bindDefinition.Name, err)
+	}
+	if len(missingTargetNamespaces) > 0 {
+		return r.handleMissingTargetNamespaces(ctx, bindDefinition, missingTargetNamespaces)
 	}
 	logger.V(2).Info("Namespaces collected",
 		"bindDefinition", bindDefinition.Name,
@@ -1540,7 +1543,7 @@ func (r *BindDefinitionReconciler) deleteAllRoleBindings(
 ) error {
 	logger := log.FromContext(ctx)
 
-	namespaceSet, _, err := r.collectNamespaces(ctx, bindDef)
+	namespaceSet, _, _, err := r.collectNamespaces(ctx, bindDef)
 	if err != nil {
 		logger.Error(err, "failed to collect namespaces for RoleBinding cleanup",
 			"bindDefinitionName", bindDef.Name)
@@ -1680,21 +1683,63 @@ func (r *BindDefinitionReconciler) validateRoleReferences(
 // collectNamespaces resolves namespaces for each roleBinding and returns both an
 // aggregated set (for filtering/metrics) and a per-roleBinding slice (for ensureRoleBindings).
 // This avoids resolving namespaces twice per reconcile — once here and once in ensureRoleBindings.
-func (r *BindDefinitionReconciler) collectNamespaces(ctx context.Context, bindDefinition *authorizationv1alpha1.BindDefinition) (map[string]corev1.Namespace, [][]corev1.Namespace, error) {
+func (r *BindDefinitionReconciler) collectNamespaces(ctx context.Context, bindDefinition *authorizationv1alpha1.BindDefinition) (map[string]corev1.Namespace, [][]corev1.Namespace, []string, error) {
 	roleBindings := bindDefinition.Spec.RoleBindings
 	perRoleBinding := make([][]corev1.Namespace, len(roleBindings))
 	namespaceSet := make(map[string]corev1.Namespace)
+	missingTargetNamespaceSet := make(map[string]struct{})
 
 	for i, roleBinding := range roleBindings {
 		resolved, err := r.resolveRoleBindingNamespaces(ctx, roleBinding)
 		if err != nil {
-			return nil, nil, fmt.Errorf("collect namespaces for roleBinding: %w", err)
+			return nil, nil, nil, fmt.Errorf("collect namespaces for roleBinding: %w", err)
 		}
 		perRoleBinding[i] = resolved
+		if roleBinding.Namespace != "" && len(resolved) == 0 && roleBindingHasRefs(roleBinding) {
+			missingTargetNamespaceSet[roleBinding.Namespace] = struct{}{}
+		}
 		for _, ns := range resolved {
 			namespaceSet[ns.Name] = ns
 		}
 	}
 
-	return namespaceSet, perRoleBinding, nil
+	missingTargetNamespaces := make([]string, 0, len(missingTargetNamespaceSet))
+	for namespace := range missingTargetNamespaceSet {
+		missingTargetNamespaces = append(missingTargetNamespaces, namespace)
+	}
+	slices.Sort(missingTargetNamespaces)
+
+	return namespaceSet, perRoleBinding, missingTargetNamespaces, nil
+}
+
+func roleBindingHasRefs(roleBinding authorizationv1alpha1.NamespaceBinding) bool {
+	return len(roleBinding.ClusterRoleRefs) > 0 || len(roleBinding.RoleRefs) > 0
+}
+
+func (r *BindDefinitionReconciler) handleMissingTargetNamespaces(
+	ctx context.Context,
+	bindDefinition *authorizationv1alpha1.BindDefinition,
+	missingNamespaces []string,
+) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	conditions.MarkFalse(bindDefinition, authorizationv1alpha1.RoleRefValidCondition, bindDefinition.Generation,
+		authorizationv1alpha1.TargetNamespaceNotFoundReason,
+		authorizationv1alpha1.TargetNamespaceNotFoundMessage, missingNamespaces)
+	conditions.MarkNotReady(bindDefinition, bindDefinition.Generation,
+		authorizationv1alpha1.TargetNamespaceNotFoundReason,
+		authorizationv1alpha1.TargetNamespaceNotFoundMessage, missingNamespaces)
+	bindDefinition.Status.MissingRoleRefs = nil
+	bindDefinition.Status.BindReconciled = false
+	r.recorder.Eventf(bindDefinition, nil, corev1.EventTypeWarning,
+		authorizationv1alpha1.EventReasonTargetNamespaceNotFound, authorizationv1alpha1.EventActionValidate,
+		"Explicit target namespaces not found: %v. RoleBindings were not created for missing namespaces.", missingNamespaces)
+	if err := r.applyStatus(ctx, bindDefinition); err != nil {
+		logger.Error(err, "failed to apply BindDefinition status", "name", bindDefinition.Name)
+		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultError).Inc()
+		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerBindDefinition, metrics.ErrorTypeAPI).Inc()
+		return ctrl.Result{}, fmt.Errorf("apply BindDefinition %s status: %w", bindDefinition.Name, err)
+	}
+	metrics.RoleRefsMissing.WithLabelValues(bindDefinition.Name).Set(0)
+	metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultDegraded).Inc()
+	return ctrl.Result{RequeueAfter: DefaultRequeueInterval}, nil
 }

--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -551,7 +551,12 @@ func (r *BindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	if len(missingTargetNamespaces) > 0 {
-		return r.handleMissingTargetNamespaces(ctx, bindDefinition, missingTargetNamespaces)
+		requeueAfter := DefaultRequeueInterval
+		markRoleRefsInvalid := missingRoleRefCount == 0
+		if missingRoleRefCount > 0 {
+			requeueAfter = calculateMissingRoleRefBackoff(bindDefinition)
+		}
+		return r.handleMissingTargetNamespaces(ctx, bindDefinition, missingTargetNamespaces, markRoleRefsInvalid, requeueAfter)
 	}
 
 	// Mark Ready and apply final status via SSA (kstatus)
@@ -1729,11 +1734,15 @@ func (r *BindDefinitionReconciler) handleMissingTargetNamespaces(
 	ctx context.Context,
 	bindDefinition *authorizationv1alpha1.BindDefinition,
 	missingNamespaces []string,
+	markRoleRefsInvalid bool,
+	requeueAfter time.Duration,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	conditions.MarkFalse(bindDefinition, authorizationv1alpha1.RoleRefValidCondition, bindDefinition.Generation,
-		authorizationv1alpha1.TargetNamespaceNotFoundReason,
-		authorizationv1alpha1.TargetNamespaceNotFoundMessage, missingNamespaces)
+	if markRoleRefsInvalid {
+		conditions.MarkFalse(bindDefinition, authorizationv1alpha1.RoleRefValidCondition, bindDefinition.Generation,
+			authorizationv1alpha1.TargetNamespaceNotFoundReason,
+			authorizationv1alpha1.TargetNamespaceNotFoundMessage, missingNamespaces)
+	}
 	conditions.MarkNotReady(bindDefinition, bindDefinition.Generation,
 		authorizationv1alpha1.TargetNamespaceNotFoundReason,
 		authorizationv1alpha1.TargetNamespaceNotFoundMessage, missingNamespaces)
@@ -1748,5 +1757,5 @@ func (r *BindDefinitionReconciler) handleMissingTargetNamespaces(
 		return ctrl.Result{}, fmt.Errorf("apply BindDefinition %s status: %w", bindDefinition.Name, err)
 	}
 	metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultDegraded).Inc()
-	return ctrl.Result{RequeueAfter: DefaultRequeueInterval}, nil
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }

--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -1028,7 +1028,7 @@ func bindDefinitionDesiredBindingKeys(
 			return desiredCRBs, desiredRBs, fmt.Errorf("perRoleBindingNamespaces length (%d) does not match RoleBindings length (%d)",
 				len(perRoleBindingNamespaces), len(bindDef.Spec.RoleBindings))
 		}
-		targetNamespaces := perRoleBindingNamespaces[i] //nolint:gosec // Length equality is checked above and guarded before this parallel-slice access.
+		targetNamespaces := perRoleBindingNamespaces[i]
 		for _, ns := range targetNamespaces {
 			if conditions.IsNamespaceTerminating(&ns) {
 				continue
@@ -1683,10 +1683,18 @@ func (r *BindDefinitionReconciler) validateRoleReferences(
 // collectNamespaces resolves namespaces for each roleBinding and returns both an
 // aggregated set (for filtering/metrics) and a per-roleBinding slice (for ensureRoleBindings).
 // This avoids resolving namespaces twice per reconcile — once here and once in ensureRoleBindings.
-func (r *BindDefinitionReconciler) collectNamespaces(ctx context.Context, bindDefinition *authorizationv1alpha1.BindDefinition) (map[string]corev1.Namespace, [][]corev1.Namespace, []string, error) {
+func (r *BindDefinitionReconciler) collectNamespaces(
+	ctx context.Context,
+	bindDefinition *authorizationv1alpha1.BindDefinition,
+) (
+	namespaceSet map[string]corev1.Namespace,
+	perRoleBinding [][]corev1.Namespace,
+	missingTargetNamespaces []string,
+	err error,
+) {
 	roleBindings := bindDefinition.Spec.RoleBindings
-	perRoleBinding := make([][]corev1.Namespace, len(roleBindings))
-	namespaceSet := make(map[string]corev1.Namespace)
+	perRoleBinding = make([][]corev1.Namespace, len(roleBindings))
+	namespaceSet = make(map[string]corev1.Namespace)
 	missingTargetNamespaceSet := make(map[string]struct{})
 
 	for i, roleBinding := range roleBindings {
@@ -1703,7 +1711,7 @@ func (r *BindDefinitionReconciler) collectNamespaces(ctx context.Context, bindDe
 		}
 	}
 
-	missingTargetNamespaces := make([]string, 0, len(missingTargetNamespaceSet))
+	missingTargetNamespaces = make([]string, 0, len(missingTargetNamespaceSet))
 	for namespace := range missingTargetNamespaceSet {
 		missingTargetNamespaces = append(missingTargetNamespaces, namespace)
 	}

--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -487,9 +487,6 @@ func (r *BindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerBindDefinition, metrics.ErrorTypeAPI).Inc()
 		return ctrl.Result{}, fmt.Errorf("collect namespaces for BindDefinition %s: %w", bindDefinition.Name, err)
 	}
-	if len(missingTargetNamespaces) > 0 {
-		return r.handleMissingTargetNamespaces(ctx, bindDefinition, missingTargetNamespaces)
-	}
 	logger.V(2).Info("Namespaces collected",
 		"bindDefinition", bindDefinition.Name,
 		"totalNamespaces", len(namespaceSet))
@@ -551,6 +548,10 @@ func (r *BindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultError).Inc()
 		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerBindDefinition, metrics.ErrorTypeAPI).Inc()
 		return ctrl.Result{}, err
+	}
+
+	if len(missingTargetNamespaces) > 0 {
+		return r.handleMissingTargetNamespaces(ctx, bindDefinition, missingTargetNamespaces)
 	}
 
 	// Mark Ready and apply final status via SSA (kstatus)
@@ -1736,7 +1737,6 @@ func (r *BindDefinitionReconciler) handleMissingTargetNamespaces(
 	conditions.MarkNotReady(bindDefinition, bindDefinition.Generation,
 		authorizationv1alpha1.TargetNamespaceNotFoundReason,
 		authorizationv1alpha1.TargetNamespaceNotFoundMessage, missingNamespaces)
-	bindDefinition.Status.MissingRoleRefs = nil
 	bindDefinition.Status.BindReconciled = false
 	r.recorder.Eventf(bindDefinition, nil, corev1.EventTypeWarning,
 		authorizationv1alpha1.EventReasonTargetNamespaceNotFound, authorizationv1alpha1.EventActionValidate,
@@ -1747,7 +1747,6 @@ func (r *BindDefinitionReconciler) handleMissingTargetNamespaces(
 		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerBindDefinition, metrics.ErrorTypeAPI).Inc()
 		return ctrl.Result{}, fmt.Errorf("apply BindDefinition %s status: %w", bindDefinition.Name, err)
 	}
-	metrics.RoleRefsMissing.WithLabelValues(bindDefinition.Name).Set(0)
 	metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultDegraded).Inc()
 	return ctrl.Result{RequeueAfter: DefaultRequeueInterval}, nil
 }

--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -844,7 +844,7 @@ func (r *BindDefinitionReconciler) ensureRoleBindings(
 	}
 
 	for i, roleBinding := range bindDef.Spec.RoleBindings {
-		targetNamespaces := perRoleBindingNamespaces[i]
+		targetNamespaces := perRoleBindingNamespaces[i] // #nosec G602 -- Length equality is checked above and guarded before this parallel-slice access.
 
 		for _, ns := range targetNamespaces {
 			// Skip terminating namespaces

--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -1028,7 +1028,7 @@ func bindDefinitionDesiredBindingKeys(
 			return desiredCRBs, desiredRBs, fmt.Errorf("perRoleBindingNamespaces length (%d) does not match RoleBindings length (%d)",
 				len(perRoleBindingNamespaces), len(bindDef.Spec.RoleBindings))
 		}
-		targetNamespaces := perRoleBindingNamespaces[i]
+		targetNamespaces := perRoleBindingNamespaces[i] // #nosec G602 -- Length equality is checked above and guarded before this parallel-slice access.
 		for _, ns := range targetNamespaces {
 			if conditions.IsNamespaceTerminating(&ns) {
 				continue

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -4846,6 +4846,85 @@ func TestReconcile_MissingExplicitRoleBindingNamespaceNotReady(t *testing.T) {
 	g.Expect(roleRefCond.Message).To(ContainSubstring("missing-ns"))
 }
 
+func TestReconcile_MissingExplicitNamespacePreservesMissingRoleRefs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	s := runtime.NewScheme()
+	_ = authorizationv1alpha1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+
+	existingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "existing-ns"}}
+	bd := &authorizationv1alpha1.BindDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: authorizationv1alpha1.GroupVersion.String(),
+			Kind:       "BindDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "missing-ns-and-role-bd",
+			UID:        "missing-ns-and-role-bd-uid",
+			Finalizers: []string{authorizationv1alpha1.BindDefinitionFinalizer},
+			Annotations: map[string]string{
+				authorizationv1alpha1.MissingRolePolicyAnnotation: string(authorizationv1alpha1.MissingRolePolicyWarn),
+			},
+		},
+		Spec: authorizationv1alpha1.BindDefinitionSpec{
+			TargetName: "missing-ns-and-role-target",
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.UserKind, Name: "alice", APIGroup: rbacv1.GroupName},
+			},
+			ClusterRoleBindings: authorizationv1alpha1.ClusterBinding{ClusterRoleRefs: []string{"missing-role"}},
+			RoleBindings: []authorizationv1alpha1.NamespaceBinding{
+				{
+					Namespace:       "missing-ns",
+					ClusterRoleRefs: []string{"missing-role"},
+				},
+				{
+					Namespace:       "existing-ns",
+					ClusterRoleRefs: []string{"missing-role"},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(bd, existingNS).
+		WithStatusSubresource(bd).
+		Build()
+	r := &BindDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: bd.Name},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(RoleRefRequeueInterval))
+
+	var rb rbacv1.RoleBinding
+	g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "existing-ns", Name: "missing-ns-and-role-target-missing-role-binding"}, &rb)).
+		To(Succeed())
+	err = c.Get(ctx, types.NamespacedName{Namespace: "missing-ns", Name: "missing-ns-and-role-target-missing-role-binding"}, &rb)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+	var updated authorizationv1alpha1.BindDefinition
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: bd.Name}, &updated)).To(Succeed())
+	g.Expect(updated.Status.BindReconciled).To(BeFalse())
+	g.Expect(updated.Status.MissingRoleRefs).To(ContainElement("ClusterRole/missing-role"))
+	g.Expect(conditions.IsReady(&updated)).To(BeFalse())
+
+	roleRefCond := findCondition(updated.Status.Conditions, string(authorizationv1alpha1.RoleRefValidCondition))
+	g.Expect(roleRefCond).NotTo(BeNil(), "expected RoleRefsValid condition to be set")
+	g.Expect(roleRefCond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(roleRefCond.Reason).To(Equal(string(authorizationv1alpha1.RoleRefInvalidReason)))
+	g.Expect(roleRefCond.Message).To(ContainSubstring("missing-role"))
+
+	readyCond := findCondition(updated.Status.Conditions, string(authorizationv1alpha1.ReadyCondition))
+	g.Expect(readyCond).NotTo(BeNil(), "expected Ready condition to be set")
+	g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(readyCond.Reason).To(Equal(string(authorizationv1alpha1.TargetNamespaceNotFoundReason)))
+	g.Expect(readyCond.Message).To(ContainSubstring("missing-ns"))
+}
+
 // newBDWithPolicy creates a BindDefinition with the given missing-role policy
 // annotation and a reference to a non-existent ClusterRole.
 func newBDWithPolicy(name string, policy authorizationv1alpha1.MissingRolePolicy) *authorizationv1alpha1.BindDefinition {

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -4832,8 +4832,8 @@ func TestReconcile_MissingExplicitRoleBindingNamespaceNotReady(t *testing.T) {
 	var rb rbacv1.RoleBinding
 	g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "existing-ns", Name: "missing-ns-target-view-binding"}, &rb)).
 		To(Succeed())
-	g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "missing-ns", Name: "missing-ns-target-view-binding"}, &rb)).
-		To(HaveOccurred())
+	err = c.Get(ctx, types.NamespacedName{Namespace: "missing-ns", Name: "missing-ns-target-view-binding"}, &rb)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
 	var updated authorizationv1alpha1.BindDefinition
 	g.Expect(c.Get(ctx, types.NamespacedName{Name: bd.Name}, &updated)).To(Succeed())

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -4784,6 +4784,7 @@ func TestReconcile_MissingExplicitRoleBindingNamespaceNotReady(t *testing.T) {
 	_ = corev1.AddToScheme(s)
 
 	clusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "view"}}
+	existingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "existing-ns"}}
 	bd := &authorizationv1alpha1.BindDefinition{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: authorizationv1alpha1.GroupVersion.String(),
@@ -4799,15 +4800,22 @@ func TestReconcile_MissingExplicitRoleBindingNamespaceNotReady(t *testing.T) {
 			Subjects: []rbacv1.Subject{
 				{Kind: rbacv1.UserKind, Name: "alice", APIGroup: rbacv1.GroupName},
 			},
-			RoleBindings: []authorizationv1alpha1.NamespaceBinding{{
-				Namespace:       "missing-ns",
-				ClusterRoleRefs: []string{"view"},
-			}},
+			ClusterRoleBindings: authorizationv1alpha1.ClusterBinding{ClusterRoleRefs: []string{"view"}},
+			RoleBindings: []authorizationv1alpha1.NamespaceBinding{
+				{
+					Namespace:       "missing-ns",
+					ClusterRoleRefs: []string{"view"},
+				},
+				{
+					Namespace:       "existing-ns",
+					ClusterRoleRefs: []string{"view"},
+				},
+			},
 		},
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).
-		WithObjects(bd, clusterRole).
+		WithObjects(bd, clusterRole, existingNS).
 		WithStatusSubresource(bd).
 		Build()
 	r := &BindDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
@@ -4818,7 +4826,12 @@ func TestReconcile_MissingExplicitRoleBindingNamespaceNotReady(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.RequeueAfter).To(Equal(DefaultRequeueInterval))
 
+	var crb rbacv1.ClusterRoleBinding
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: "missing-ns-target-view-binding"}, &crb)).To(Succeed())
+
 	var rb rbacv1.RoleBinding
+	g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "existing-ns", Name: "missing-ns-target-view-binding"}, &rb)).
+		To(Succeed())
 	g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "missing-ns", Name: "missing-ns-target-view-binding"}, &rb)).
 		To(HaveOccurred())
 

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -1910,7 +1910,7 @@ func TestCollectNamespaces(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-		nsSet, _, err := r.collectNamespaces(ctx, bindDef)
+		nsSet, _, _, err := r.collectNamespaces(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(nsSet).To(HaveKey("my-ns"))
 	})
@@ -1932,9 +1932,10 @@ func TestCollectNamespaces(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-		nsSet, _, err := r.collectNamespaces(ctx, bindDef)
+		nsSet, _, missingNamespaces, err := r.collectNamespaces(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(nsSet).To(BeEmpty())
+		g.Expect(missingNamespaces).To(ConsistOf("nonexistent"))
 	})
 
 	t.Run("should collect namespaces by label selector", func(t *testing.T) {
@@ -1968,7 +1969,7 @@ func TestCollectNamespaces(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns1, ns2, ns3).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-		nsSet, _, err := r.collectNamespaces(ctx, bindDef)
+		nsSet, _, _, err := r.collectNamespaces(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(nsSet).To(HaveLen(2))
 		g.Expect(nsSet).To(HaveKey("ns-1"))
@@ -2001,7 +2002,7 @@ func TestCollectNamespaces(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-		nsSet, _, err := r.collectNamespaces(ctx, bindDef)
+		nsSet, _, _, err := r.collectNamespaces(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(nsSet).To(HaveLen(1), "same namespace should be deduplicated")
 	})
@@ -2032,7 +2033,7 @@ func TestCollectNamespaces(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns1, ns2).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-		nsSet, _, err := r.collectNamespaces(ctx, bindDef)
+		nsSet, _, _, err := r.collectNamespaces(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(nsSet).To(HaveLen(2), "empty LabelSelector should match all namespaces per Kubernetes semantics")
 		g.Expect(nsSet).To(HaveKey("ns-a"))
@@ -2424,7 +2425,7 @@ func TestEnsureRoleBindings(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, ns).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-		_, perRoleBindingNamespaces, err := r.collectNamespaces(ctx, bindDef)
+		_, perRoleBindingNamespaces, _, err := r.collectNamespaces(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		err = r.ensureRoleBindings(ctx, bindDef, perRoleBindingNamespaces)
@@ -2491,7 +2492,7 @@ func TestEnsureRoleBindings(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, ns, existing).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-		_, perRoleBindingNamespaces, err := r.collectNamespaces(ctx, bindDef)
+		_, perRoleBindingNamespaces, _, err := r.collectNamespaces(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		err = r.ensureRoleBindings(ctx, bindDef, perRoleBindingNamespaces)
@@ -2542,7 +2543,7 @@ func TestEnsureRoleBindings(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, ns).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-		_, perRoleBindingNamespaces, err := r.collectNamespaces(ctx, bindDef)
+		_, perRoleBindingNamespaces, _, err := r.collectNamespaces(ctx, bindDef)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		err = r.ensureRoleBindings(ctx, bindDef, perRoleBindingNamespaces)
@@ -4772,6 +4773,65 @@ func TestReconcileDeleteCleansUpGaugeMetrics(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Missing-role policy tests (#52)
 // ---------------------------------------------------------------------------
+
+func TestReconcile_MissingExplicitRoleBindingNamespaceNotReady(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	s := runtime.NewScheme()
+	_ = authorizationv1alpha1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+
+	clusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "view"}}
+	bd := &authorizationv1alpha1.BindDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: authorizationv1alpha1.GroupVersion.String(),
+			Kind:       "BindDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "missing-ns-bd",
+			UID:        "missing-ns-bd-uid",
+			Finalizers: []string{authorizationv1alpha1.BindDefinitionFinalizer},
+		},
+		Spec: authorizationv1alpha1.BindDefinitionSpec{
+			TargetName: "missing-ns-target",
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.UserKind, Name: "alice", APIGroup: rbacv1.GroupName},
+			},
+			RoleBindings: []authorizationv1alpha1.NamespaceBinding{{
+				Namespace:       "missing-ns",
+				ClusterRoleRefs: []string{"view"},
+			}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(bd, clusterRole).
+		WithStatusSubresource(bd).
+		Build()
+	r := &BindDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: bd.Name},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(DefaultRequeueInterval))
+
+	var rb rbacv1.RoleBinding
+	g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "missing-ns", Name: "missing-ns-target-view-binding"}, &rb)).
+		To(HaveOccurred())
+
+	var updated authorizationv1alpha1.BindDefinition
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: bd.Name}, &updated)).To(Succeed())
+	g.Expect(updated.Status.BindReconciled).To(BeFalse())
+	g.Expect(conditions.IsReady(&updated)).To(BeFalse())
+	roleRefCond := findCondition(updated.Status.Conditions, string(authorizationv1alpha1.RoleRefValidCondition))
+	g.Expect(roleRefCond).NotTo(BeNil(), "expected RoleRefsValid condition to be set")
+	g.Expect(roleRefCond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(roleRefCond.Reason).To(Equal(string(authorizationv1alpha1.TargetNamespaceNotFoundReason)))
+	g.Expect(roleRefCond.Message).To(ContainSubstring("missing-ns"))
+}
 
 // newBDWithPolicy creates a BindDefinition with the given missing-role policy
 // annotation and a reference to a non-existent ClusterRole.


### PR DESCRIPTION
## Summary
- keep BindDefinitions NotReady when explicit roleBinding namespaces are missing
- surface `RoleRefsValid=False` with `TargetNamespaceNotFound` instead of silently skipping the namespace and reporting Ready
- add controller regressions for namespace collection and reconcile status

## Evidence
`resolveRoleBindingNamespaces` returned an empty namespace slice for missing explicit namespaces. Reconcile then created no RoleBinding but continued to mark the BindDefinition Ready. RestrictedBindDefinition already handles the same situation as `TargetNamespaceNotFound`.

## Validation
- `go test ./internal/controller/authorization -run TestReconcile_MissingExplicitRoleBindingNamespaceNotReady -count=1`
- `go test ./internal/controller/authorization -run TestCollectNamespaces -count=1`
- `KUBEBUILDER_ASSETS=/Users/A92615428/git/GitHub/telekom/auth-operator/bin/k8s/1.34.1-darwin-arm64 go test ./internal/controller/authorization -count=1`
- `make fmt vet`