### PR TITLE
fix(roledefinition): skip deleting unowned roles

### DIFF
--- a/internal/controller/authorization/roledefinition_controller_test.go
+++ b/internal/controller/authorization/roledefinition_controller_test.go
@@ -28,6 +28,17 @@ import (
 	pkgssa "github.com/telekom/auth-operator/pkg/ssa"
 )
 
+func roleDefinitionTestOwnerRef(rd *authorizationv1alpha1.RoleDefinition) metav1.OwnerReference {
+	controller := true
+	return metav1.OwnerReference{
+		APIVersion: authorizationv1alpha1.GroupVersion.String(),
+		Kind:       "RoleDefinition",
+		Name:       rd.Name,
+		UID:        rd.UID,
+		Controller: &controller,
+	}
+}
+
 var _ = Describe("RoleDefinition Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource"
@@ -99,6 +110,60 @@ var _ = Describe("RoleDefinition Controller", func() {
 		})
 	})
 })
+
+func TestRoleDefinitionHandleDeletionSkipsUnownedClusterRole(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	s := runtime.NewScheme()
+	_ = authorizationv1alpha1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
+
+	rd := &authorizationv1alpha1.RoleDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: authorizationv1alpha1.GroupVersion.String(),
+			Kind:       "RoleDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "delete-unowned-rd",
+			UID:        "delete-unowned-rd-uid",
+			Finalizers: []string{authorizationv1alpha1.RoleDefinitionFinalizer},
+			Generation: 1,
+		},
+		Spec: authorizationv1alpha1.RoleDefinitionSpec{
+			TargetName:      "shared-clusterrole",
+			TargetRole:      authorizationv1alpha1.DefinitionClusterRole,
+			ScopeNamespaced: false,
+		},
+	}
+	unownedClusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-clusterrole"},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"get"},
+		}},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rd, unownedClusterRole).
+		WithStatusSubresource(&authorizationv1alpha1.RoleDefinition{}).
+		Build()
+	r := &RoleDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
+
+	result, err := r.handleDeletion(ctx, rd, &rbacv1.ClusterRole{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(reconcile.Result{}))
+
+	var kept rbacv1.ClusterRole
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: unownedClusterRole.Name}, &kept)).To(Succeed())
+	g.Expect(kept.Rules).To(Equal(unownedClusterRole.Rules))
+
+	var updated authorizationv1alpha1.RoleDefinition
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: rd.Name}, &updated)).To(Succeed())
+	g.Expect(updated.Finalizers).NotTo(ContainElement(authorizationv1alpha1.RoleDefinitionFinalizer))
+}
 
 var _ = Describe("RoleDefinition Drift Detection and Rollback", func() {
 	ctx := context.Background()
@@ -2023,17 +2088,10 @@ func TestHandleDeletionDeleteAndStatusError(t *testing.T) {
 		},
 	}
 
-	cr := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "del-both-cr",
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: authorizationv1alpha1.GroupVersion.String(),
-				Kind:       "RoleDefinition",
-				Name:       rd.Name,
-				UID:        rd.UID,
-			}},
-		},
-	}
+	cr := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{
+		Name:            "del-both-cr",
+		OwnerReferences: []metav1.OwnerReference{roleDefinitionTestOwnerRef(rd)},
+	}}
 
 	statusPatchCount := 0
 	c := fake.NewClientBuilder().WithScheme(s).

--- a/internal/controller/authorization/roledefinition_helpers.go
+++ b/internal/controller/authorization/roledefinition_helpers.go
@@ -186,7 +186,7 @@ func (r *RoleDefinitionReconciler) handleDeletion(
 	} else if err := r.client.Delete(ctx, role); apierrors.IsNotFound(err) {
 		logger.V(2).Info("Role disappeared before deletion - removing finalizer",
 			"roleDefinitionName", roleDefinition.Name, "roleName", roleDefinition.Spec.TargetName)
-	} else if err != nil {
+	} else if err := r.client.Delete(ctx, role); err != nil && !apierrors.IsNotFound(err) {
 		logger.Error(err, "Failed to delete role",
 			"roleDefinitionName", roleDefinition.Name, "roleName", roleDefinition.Spec.TargetName)
 		return r.markDeletionFailed(ctx, roleDefinition, err)
@@ -209,11 +209,11 @@ func (r *RoleDefinitionReconciler) markDeletionFailed(
 	// consumers who may not have elevated RBAC. The full error is
 	// logged by the caller for operator administrators.
 	conditions.MarkFalse(roleDefinition, authorizationv1alpha1.DeleteCondition, roleDefinition.Generation,
-		authorizationv1alpha1.DeleteReason, "failed to delete managed resource (check operator logs for details)")
+		authorizationv1alpha1.DeleteReason, "failed to clean up managed resource (check operator logs for details)")
 	if updateErr := ssa.ApplyRoleDefinitionStatus(ctx, r.client, roleDefinition); updateErr != nil {
 		logger.Error(updateErr, "Failed to apply status after deletion error",
 			"roleDefinitionName", roleDefinition.Name)
-		return ctrl.Result{}, errors.Join(err, fmt.Errorf("update role definition status after deletion failure: %w", updateErr))
+		return ctrl.Result{}, fmt.Errorf("apply status after role cleanup failure: %w", errors.Join(err, updateErr))
 	}
 	return ctrl.Result{}, err
 }

--- a/internal/controller/authorization/roledefinition_helpers_test.go
+++ b/internal/controller/authorization/roledefinition_helpers_test.go
@@ -750,13 +750,8 @@ func TestHandleDeletion(t *testing.T) {
 
 		cr := &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "del-cluster-role",
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: authorizationv1alpha1.GroupVersion.String(),
-					Kind:       "RoleDefinition",
-					Name:       rd.Name,
-					UID:        rd.UID,
-				}},
+				Name:            "del-cluster-role",
+				OwnerReferences: []metav1.OwnerReference{roleDefinitionTestOwnerRef(rd)},
 			},
 		}
 
@@ -907,14 +902,9 @@ func TestHandleDeletion(t *testing.T) {
 
 		role := &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "existing-role",
-				Namespace: "test-ns",
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: authorizationv1alpha1.GroupVersion.String(),
-					Kind:       "RoleDefinition",
-					Name:       rd.Name,
-					UID:        rd.UID,
-				}},
+				Name:            "existing-role",
+				Namespace:       "test-ns",
+				OwnerReferences: []metav1.OwnerReference{roleDefinitionTestOwnerRef(rd)},
 			},
 		}
 
@@ -1430,17 +1420,10 @@ func TestHandleDeletionDeleteError(t *testing.T) {
 		},
 	}
 
-	cr := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "del-err-cr",
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: authorizationv1alpha1.GroupVersion.String(),
-				Kind:       "RoleDefinition",
-				Name:       rd.Name,
-				UID:        rd.UID,
-			}},
-		},
-	}
+	cr := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{
+		Name:            "del-err-cr",
+		OwnerReferences: []metav1.OwnerReference{roleDefinitionTestOwnerRef(rd)},
+	}}
 
 	c := fake.NewClientBuilder().WithScheme(s).
 		WithObjects(rd, cr).


### PR DESCRIPTION
## Summary
- check target Role/ClusterRole ownership before deletion cleanup
- leave unowned RBAC resources intact and remove the RoleDefinition finalizer instead of deleting foreign resources
- add a regression proving an unowned ClusterRole survives deletion handling

## Evidence
Normal RoleDefinition reconciliation rejects existing targets not owned by the RoleDefinition, but deletion previously called `Delete` on the configured target name directly. A stale or conflicting RoleDefinition could delete a Role/ClusterRole it did not own.

## Validation
- `go test ./internal/controller/authorization -run TestRoleDefinitionHandleDeletionSkipsUnownedClusterRole -count=1`
- `go test ./internal/controller/authorization -run 'TestRoleDefinitionHandleDeletionSkipsUnownedClusterRole|TestHandleDeletion$|TestHandleDeletionDeleteError|TestHandleDeletionDeleteAndStatusError' -count=1`\n- `KUBEBUILDER_ASSETS=/Users/A92615428/git/GitHub/telekom/auth-operator/bin/k8s/1.34.1-darwin-arm64 go test ./internal/controller/authorization -run 'TestRoleDefinition|RoleDefinition' -count=1`\n- `KUBEBUILDER_ASSETS=/Users/A92615428/git/GitHub/telekom/auth-operator/bin/k8s/1.34.1-darwin-arm64 go test ./internal/controller/authorization -count=1`\n- `make fmt vet`