### PR TITLE
fix(restrictedbinddefinition): recover generated serviceaccounts

### DIFF
--- a/internal/controller/authorization/restrictedbinddefinition_controller.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller.go
@@ -1355,6 +1355,9 @@ func (r *RestrictedBindDefinitionReconciler) rbdClassifyExistingServiceAccount(
 			if r.rbdHasLiveGeneratedServiceAccountStatus(ctx, rbd, subject) {
 				return false, true, ""
 			}
+			if rbdHasRecoverableGeneratedServiceAccountMarkers(rbd, existing) {
+				return false, true, ""
+			}
 			logger.Info("ServiceAccount has this RestrictedBindDefinition controller ownerRef but no generated status record, skipping management",
 				"serviceAccount", subject.Name, "namespace", subject.Namespace,
 				"ownerName", ownerRBD.Name, "ownerUID", ownerRBD.UID)
@@ -1382,6 +1385,24 @@ func (r *RestrictedBindDefinitionReconciler) rbdClassifyExistingServiceAccount(
 	}
 
 	return false, true, ""
+}
+
+func rbdHasRecoverableGeneratedServiceAccountMarkers(
+	rbd *authorizationv1alpha1.RestrictedBindDefinition,
+	existing *corev1.ServiceAccount,
+) bool {
+	if existing.Labels[helpers.ManagedByLabelStandard] != helpers.ManagedByValue ||
+		existing.Annotations[helpers.SourceKindAnnotation] != authorizationv1alpha1.RestrictedBindDefinitionKind ||
+		existing.Annotations[helpers.SourceNameAnnotation] != rbd.Name {
+		return false
+	}
+	expectedFieldOwner := pkgssa.FieldOwnerFor(rbd.Name, authorizationv1alpha1.RestrictedBindDefinitionKind)
+	for _, field := range existing.ManagedFields {
+		if field.Manager == expectedFieldOwner && field.Operation == metav1.ManagedFieldsOperationApply {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *RestrictedBindDefinitionReconciler) rbdHasLiveGeneratedServiceAccountStatus(

--- a/internal/controller/authorization/restrictedbinddefinition_controller_test.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller_test.go
@@ -1771,6 +1771,84 @@ func TestRBD_Reconcile_DisableAdoptionTrue_PreservesSameOwnerServiceAccount(t *t
 	g.Expect(updated.Status.ExternalServiceAccounts).To(gomega.BeEmpty())
 }
 
+func TestRBD_Reconcile_RecoversGeneratedServiceAccountAfterFinalStatusApplyFailure(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	subject := rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "retry-sa", Namespace: "retry-ns"}
+	pol := &authorizationv1alpha1.RBACPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "retry-policy", Generation: 1},
+		Spec: authorizationv1alpha1.RBACPolicySpec{
+			AppliesTo: authorizationv1alpha1.PolicyScope{Namespaces: []string{"retry-ns"}},
+			SubjectLimits: &authorizationv1alpha1.SubjectLimits{
+				AllowedKinds: []string{rbacv1.ServiceAccountKind},
+				ServiceAccountLimits: &authorizationv1alpha1.ServiceAccountLimits{
+					Creation: &authorizationv1alpha1.SACreationConfig{
+						AllowAutoCreate: true,
+						DisableAdoption: true,
+					},
+				},
+			},
+		},
+	}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "retry-ns"}}
+	rbd := &authorizationv1alpha1.RestrictedBindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "retry-rbd", UID: types.UID("retry-rbd-uid"), Generation: 1},
+		Spec: authorizationv1alpha1.RestrictedBindDefinitionSpec{
+			PolicyRef:  authorizationv1alpha1.RBACPolicyReference{Name: pol.Name},
+			TargetName: "retry-target",
+			Subjects:   []rbacv1.Subject{subject},
+			ClusterRoleBindings: &authorizationv1alpha1.ClusterBinding{
+				ClusterRoleRefs: []string{"view"},
+			},
+		},
+	}
+	clusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "view"}}
+
+	scheme := newTestScheme()
+	statusApplyCalls := 0
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(rbdPolicyWithDefaultAllowances(pol), rbd, ns, clusterRole).
+		WithReturnManagedFields().
+		WithStatusSubresource(
+			&authorizationv1alpha1.RestrictedBindDefinition{},
+			&authorizationv1alpha1.RBACPolicy{},
+		).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceApply: func(ctx context.Context, c client.Client, subResource string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+				statusApplyCalls++
+				if statusApplyCalls == 1 {
+					return fmt.Errorf("injected final status error")
+				}
+				return c.SubResource(subResource).Apply(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := NewRestrictedBindDefinitionReconciler(c, scheme, events.NewFakeRecorder(10))
+
+	_, err := r.Reconcile(rbdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rbd.Name}})
+	g.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("injected final status error")))
+
+	var firstCRB rbacv1.ClusterRoleBinding
+	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Name: "retry-target-view-binding"}, &firstCRB)).To(gomega.Succeed())
+	g.Expect(firstCRB.Subjects).To(gomega.ConsistOf(subject))
+
+	result, err := r.Reconcile(rbdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rbd.Name}})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
+
+	var updated authorizationv1alpha1.RestrictedBindDefinition
+	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Name: rbd.Name}, &updated)).To(gomega.Succeed())
+	g.Expect(updated.Status.GeneratedServiceAccounts).To(gomega.ConsistOf(subject))
+	g.Expect(updated.Status.ExternalServiceAccounts).To(gomega.BeEmpty())
+	g.Expect(updated.Status.SkippedServiceAccounts).To(gomega.BeEmpty())
+	g.Expect(conditions.IsReady(&updated)).To(gomega.BeTrue())
+
+	var recoveredCRB rbacv1.ClusterRoleBinding
+	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Name: "retry-target-view-binding"}, &recoveredCRB)).To(gomega.Succeed())
+	g.Expect(recoveredCRB.Subjects).To(gomega.ConsistOf(subject))
+}
+
 func TestRBD_EnsureServiceAccounts_CreateRaceDoesNotAdoptExternalServiceAccount(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -3769,7 +3847,7 @@ func TestRBD_ClassifyServiceAccountUsesLiveGeneratedStatus(t *testing.T) {
 	g.Expect(externalSA).To(gomega.BeEmpty())
 }
 
-func TestRBD_ClassifyServiceAccountSkipsSameOwnerRefWithoutGeneratedStatus(t *testing.T) {
+func TestRBD_ClassifyServiceAccountSkipsBareSameOwnerRefWithoutGeneratedStatus(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	subject := rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "runner", Namespace: "default"}
@@ -3799,6 +3877,55 @@ func TestRBD_ClassifyServiceAccountSkipsSameOwnerRefWithoutGeneratedStatus(t *te
 
 	g.Expect(bindSubject).To(gomega.BeFalse())
 	g.Expect(manageSA).To(gomega.BeFalse())
+	g.Expect(externalSA).To(gomega.BeEmpty())
+}
+
+func TestRBD_ClassifyServiceAccountRecoversGeneratedMarkersWithoutStatus(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	subject := rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "runner", Namespace: "default"}
+	rbdUID := types.UID("same-owner-generated-rbd-uid")
+	rbd := &authorizationv1alpha1.RestrictedBindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-owner-generated-rbd", UID: rbdUID},
+		Spec: authorizationv1alpha1.RestrictedBindDefinitionSpec{
+			Subjects: []rbacv1.Subject{subject},
+		},
+	}
+	ownedSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      subject.Name,
+			Namespace: subject.Namespace,
+			Labels: map[string]string{
+				helpers.ManagedByLabelStandard: helpers.ManagedByValue,
+			},
+			Annotations: map[string]string{
+				helpers.SourceKindAnnotation: authorizationv1alpha1.RestrictedBindDefinitionKind,
+				helpers.SourceNameAnnotation: rbd.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				restrictedTestOwnerRef(authorizationv1alpha1.RestrictedBindDefinitionKind, rbd.Name, rbdUID),
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{
+					APIVersion: authorizationv1alpha1.GroupVersion.String(),
+					Manager:    pkgssa.FieldOwnerFor(rbd.Name, authorizationv1alpha1.RestrictedBindDefinitionKind),
+					Operation:  metav1.ManagedFieldsOperationApply,
+				},
+			},
+		},
+	}
+
+	scheme := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(rbd).
+		Build()
+	r := NewRestrictedBindDefinitionReconciler(c, scheme, events.NewFakeRecorder(10))
+
+	bindSubject, manageSA, externalSA := r.rbdClassifyExistingServiceAccount(rbdCtx(), rbd, subject, ownedSA, nil)
+
+	g.Expect(bindSubject).To(gomega.BeFalse())
+	g.Expect(manageSA).To(gomega.BeTrue())
 	g.Expect(externalSA).To(gomega.BeEmpty())
 }
 

--- a/internal/controller/authorization/restrictedbinddefinition_controller_test.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller_test.go
@@ -3907,7 +3907,7 @@ func TestRBD_ClassifyServiceAccountRecoversGeneratedMarkersWithoutStatus(t *test
 			},
 			ManagedFields: []metav1.ManagedFieldsEntry{
 				{
-					APIVersion: authorizationv1alpha1.GroupVersion.String(),
+					APIVersion: corev1.SchemeGroupVersion.String(),
 					Manager:    pkgssa.FieldOwnerFor(rbd.Name, authorizationv1alpha1.RestrictedBindDefinitionKind),
 					Operation:  metav1.ManagedFieldsOperationApply,
 				},


### PR DESCRIPTION
## Summary

Recover generated RestrictedBindDefinition ServiceAccounts after a transient final status apply failure. If the ServiceAccount was already created by this RBD but the generated status entry was lost, the next reconcile now trusts the controller-generated markers and SSA field manager instead of clearing the binding subjects. Bare same-ownerRef spoofing remains untrusted.

## Evidence

Before this fix, a retry after final Ready status apply failed could find the generated ServiceAccount, skip it because status did not yet list it, apply bindings with empty subjects, and report Ready.

## Validation

- `go test ./internal/controller/authorization -run 'TestRBD_Reconcile_RecoversGeneratedServiceAccountAfterFinalStatusApplyFailure|TestRBD_ClassifyServiceAccountRecoversGeneratedMarkersWithoutStatus|TestRBD_ClassifyServiceAccountSkipsBareSameOwnerRefWithoutGeneratedStatus|TestRBD_Reconcile_DisableAdoptionTrue_DoesNotTrustSpoofedOwnerRef' -count=1`\n- `go test ./internal/controller/authorization -run 'TestRBD_' -count=1`\n- `KUBEBUILDER_ASSETS=$(pwd)/bin/k8s/1.34.1-darwin-arm64 go test ./internal/controller/authorization -count=1`\n- `golangci-lint run --timeout 10m --new-from-rev=origin/main ./internal/controller/authorization/...`\n