### PR TITLE
Reject RestrictedBindDefinition cluster binding name collisions

### DIFF
--- a/api/authorization/v1alpha1/binddefinition_webhook.go
+++ b/api/authorization/v1alpha1/binddefinition_webhook.go
@@ -317,7 +317,7 @@ func (v *BindDefinitionValidator) validateRoleBindingNameCollisions(
 	kind schema.GroupKind,
 	obj *BindDefinition,
 ) error {
-	return validateRoleBindingNameCollisionClaims(ctx, kind, obj.Name, obj.Spec.TargetName, obj.Spec.RoleBindings, v.resolveRoleBindingNamespacesForValidation)
+	return validateRoleBindingNameCollisionClaims(ctx, kind, obj.Name, obj.Spec.TargetName, nil, obj.Spec.RoleBindings, v.resolveRoleBindingNamespacesForValidation)
 }
 
 func (v *BindDefinitionValidator) resolveRoleBindingNamespacesForValidation(

--- a/api/authorization/v1alpha1/restrictedbinddefinition_webhook.go
+++ b/api/authorization/v1alpha1/restrictedbinddefinition_webhook.go
@@ -302,7 +302,19 @@ func (v *RestrictedBindDefinitionValidator) validateRoleBindingNameCollisions(
 	kind schema.GroupKind,
 	obj *RestrictedBindDefinition,
 ) error {
-	return validateRoleBindingNameCollisionClaims(ctx, kind, obj.Name, obj.Spec.TargetName, obj.Spec.RoleBindings, v.resolveRoleBindingNamespacesForValidation)
+	var clusterRoleRefs []string
+	if obj.Spec.ClusterRoleBindings != nil {
+		clusterRoleRefs = obj.Spec.ClusterRoleBindings.ClusterRoleRefs
+	}
+	return validateRoleBindingNameCollisionClaims(
+		ctx,
+		kind,
+		obj.Name,
+		obj.Spec.TargetName,
+		clusterRoleRefs,
+		obj.Spec.RoleBindings,
+		v.resolveRoleBindingNamespacesForValidation,
+	)
 }
 
 type roleBindingNamespaceResolver func(context.Context, NamespaceBinding, int, string) ([]string, error)
@@ -311,10 +323,17 @@ func validateRoleBindingNameCollisionClaims(
 	ctx context.Context,
 	kind schema.GroupKind,
 	objectName, targetName string,
+	clusterRoleRefs []string,
 	bindings []NamespaceBinding,
 	resolveNamespaces roleBindingNamespaceResolver,
 ) error {
 	claims := make(map[string]roleBindingNameClaim)
+	for i, roleRef := range clusterRoleRefs {
+		path := field.NewPath("spec", "clusterRoleBindings").Child("clusterRoleRefs").Index(i)
+		if err := recordRoleBindingNameClaim(kind, objectName, targetName, claims, "", "ClusterRole", roleRef, path); err != nil {
+			return err
+		}
+	}
 	for i, binding := range bindings {
 		namespaces, err := resolveNamespaces(ctx, binding, i, objectName)
 		if err != nil {

--- a/api/authorization/v1alpha1/restrictedbinddefinition_webhook_test.go
+++ b/api/authorization/v1alpha1/restrictedbinddefinition_webhook_test.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -355,6 +356,31 @@ var _ = Describe("RestrictedBindDefinition Webhook", func() {
 			err := k8sClient.Create(ctx, rbd)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("spec.roleBindings[1].roleRefs[0]"))
+			Expect(err.Error()).To(ContainSubstring("collides with ClusterRole"))
+		})
+
+		It("Should deny ClusterRoleBinding name collisions", func() {
+			rbd := &RestrictedBindDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rbd-crb-name-collision",
+				},
+				Spec: RestrictedBindDefinitionSpec{
+					PolicyRef:  RBACPolicyReference{Name: policy.Name},
+					TargetName: strings.Repeat("t", 200),
+					Subjects: []rbacv1.Subject{
+						{Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName, Name: "test-group"},
+					},
+					ClusterRoleBindings: &ClusterBinding{
+						ClusterRoleRefs: []string{
+							strings.Repeat("r", 43) + "-00009021",
+							strings.Repeat("r", 43) + "-00015513",
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, rbd)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.clusterRoleBindings.clusterRoleRefs[1]"))
 			Expect(err.Error()).To(ContainSubstring("collides with ClusterRole"))
 		})
 	})

--- a/internal/controller/authorization/restrictedbinddefinition_controller.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller.go
@@ -992,7 +992,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdValidateRoleBindingNameCollision
 	claims := make(map[string]rbdRoleBindingNameClaim)
 	for _, clusterRoleRef := range restrictedClusterRoleRefs(rbd.Spec.ClusterRoleBindings) {
 		if err := rbdRecordRoleBindingNameClaim(rbd.Spec.TargetName, claims, "", "ClusterRole", clusterRoleRef); err != nil {
-			return err
+			return fmt.Errorf("ClusterRoleBinding name collision: %w", err)
 		}
 	}
 	for _, roleBinding := range rbd.Spec.RoleBindings {

--- a/internal/controller/authorization/restrictedbinddefinition_controller.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller.go
@@ -990,6 +990,11 @@ func (r *RestrictedBindDefinitionReconciler) rbdValidateRoleBindingNameCollision
 	rbd *authorizationv1alpha1.RestrictedBindDefinition,
 ) error {
 	claims := make(map[string]rbdRoleBindingNameClaim)
+	for _, clusterRoleRef := range restrictedClusterRoleRefs(rbd.Spec.ClusterRoleBindings) {
+		if err := rbdRecordRoleBindingNameClaim(rbd.Spec.TargetName, claims, "", "ClusterRole", clusterRoleRef); err != nil {
+			return err
+		}
+	}
 	for _, roleBinding := range rbd.Spec.RoleBindings {
 		targetNamespaces, err := r.rbdResolveNamespaces(ctx, roleBinding)
 		if err != nil {

--- a/internal/controller/authorization/restrictedbinddefinition_controller_test.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -3331,6 +3332,42 @@ func TestRBD_ReconcileResources_RejectsRoleBindingNameCollision(t *testing.T) {
 		Name:      "rb-collision-target-view-binding",
 		Namespace: "collision-ns",
 	}, &rb)).To(gomega.MatchError(gomega.ContainSubstring("not found")))
+}
+
+func TestRBD_ReconcileResources_RejectsClusterRoleBindingNameCollision(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	collidingRoleRefs := []string{
+		strings.Repeat("r", 43) + "-00009021",
+		strings.Repeat("r", 43) + "-00015513",
+	}
+	rbd := &authorizationv1alpha1.RestrictedBindDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "crb-collision-rbd",
+			Generation: 1,
+			Finalizers: []string{authorizationv1alpha1.RestrictedBindDefinitionFinalizer},
+		},
+		Spec: authorizationv1alpha1.RestrictedBindDefinitionSpec{
+			TargetName: strings.Repeat("t", 200),
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.GroupKind, Name: "devs"},
+			},
+			ClusterRoleBindings: &authorizationv1alpha1.ClusterBinding{
+				ClusterRoleRefs: collidingRoleRefs,
+			},
+		},
+	}
+
+	r, c := newRBDTestReconciler(rbd)
+	err := r.rbdReconcileResources(rbdCtx(), rbd, c, nil)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("RoleBinding name collision"))
+	g.Expect(err.Error()).To(gomega.ContainSubstring(helpers.BuildBindingName(rbd.Spec.TargetName, collidingRoleRefs[0])))
+
+	var crb rbacv1.ClusterRoleBinding
+	g.Expect(c.Get(rbdCtx(), types.NamespacedName{
+		Name: helpers.BuildBindingName(rbd.Spec.TargetName, collidingRoleRefs[0]),
+	}, &crb)).To(gomega.MatchError(gomega.ContainSubstring("not found")))
 }
 
 func TestRBD_ReconcileResources_PrunesStaleBindingsOnNameCollision(t *testing.T) {


### PR DESCRIPTION
## Summary
- include `spec.clusterRoleBindings.clusterRoleRefs` in RestrictedBindDefinition generated binding name collision validation
- fail reconciliation before creating colliding ClusterRoleBindings if admission was bypassed
- add webhook and controller regression tests for long-name ClusterRoleBinding collisions

## Evidence
`RestrictedBindDefinition` already rejected generated RoleBinding name collisions across namespaced role bindings, but cluster-scoped `clusterRoleBindings.clusterRoleRefs` were not recorded in the same claim set. Two long ClusterRole refs can therefore produce the same `helpers.BuildBindingName()` output and race through the same generated ClusterRoleBinding name.

## Validation
- `go test ./internal/controller/authorization -run 'TestRBD_ReconcileResources_RejectsClusterRoleBindingNameCollision|TestRBD_ReconcileResources_RejectsRoleBindingNameCollision' -count=1`
- `KUBEBUILDER_ASSETS=/private/tmp/auth-operator-gh-rbd-sa-recovery/bin/k8s/1.34.1-darwin-arm64 go test ./api/authorization/v1alpha1 -run 'TestAPIs/RestrictedBindDefinition_Webhook' -count=1`
- `KUBEBUILDER_ASSETS=/private/tmp/auth-operator-gh-rbd-sa-recovery/bin/k8s/1.34.1-darwin-arm64 go test ./internal/controller/authorization -count=1`
- `KUBEBUILDER_ASSETS=/private/tmp/auth-operator-gh-rbd-sa-recovery/bin/k8s/1.34.1-darwin-arm64 go test ./api/authorization/v1alpha1 -count=1`
- `git diff --check`
