### PR TITLE
Reject empty WebhookAuthorizer principals

### DIFF
--- a/api/authorization/v1alpha1/webhookauthorizer_types.go
+++ b/api/authorization/v1alpha1/webhookauthorizer_types.go
@@ -14,6 +14,7 @@ const (
 )
 
 // Principal represents a requesting user or service account identity.
+// +kubebuilder:validation:XValidation:rule="(has(self.user) && self.user != \"\") || (has(self.groups) && size(self.groups) > 0)",message="principal must specify user or at least one group"
 type Principal struct {
 	// User is the requesting user in SubjectAccessReview request.
 	// +kubebuilder:validation:Optional

--- a/api/authorization/v1alpha1/webhookauthorizer_webhook.go
+++ b/api/authorization/v1alpha1/webhookauthorizer_webhook.go
@@ -139,6 +139,10 @@ func validateWebhookAuthorizer(wa *WebhookAuthorizer) (admission.Warnings, error
 func validatePrincipalScopes(fieldName string, principals []Principal) error {
 	for i, p := range principals {
 		if p.Namespace == "" {
+			if p.User == "" && len(p.Groups) == 0 {
+				return apierrors.NewBadRequest(
+					fmt.Sprintf("spec.%s[%d] must specify user or at least one group", fieldName, i))
+			}
 			continue
 		}
 		if len(p.Groups) > 0 {

--- a/api/authorization/v1alpha1/webhookauthorizer_webhook_test.go
+++ b/api/authorization/v1alpha1/webhookauthorizer_webhook_test.go
@@ -133,6 +133,23 @@ var _ = Describe("WebhookAuthorizer CEL Validation", func() {
 			// Cleanup.
 			Expect(k8sClient.Delete(ctx, wa)).To(Succeed())
 		})
+
+		It("Should deny a WebhookAuthorizer with an empty principal item", func() {
+			wa := &WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cel-empty-principal",
+				},
+				Spec: WebhookAuthorizerSpec{
+					ResourceRules: validResourceRules,
+					AllowedPrincipals: []Principal{
+						{},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, wa)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("principal must specify user or at least one group"))
+		})
 	})
 })
 
@@ -245,6 +262,35 @@ func TestValidateCreate_WarnsEmptyAllowedPrincipals(t *testing.T) {
 	}
 	if len(warnings) == 0 {
 		t.Error("expected warning for empty allowedPrincipals")
+	}
+}
+
+func TestValidateCreate_RejectsEmptyAllowedPrincipal(t *testing.T) {
+	v := &WebhookAuthorizerValidator{}
+	wa := newTestWebhookAuthorizer(func(wa *WebhookAuthorizer) {
+		wa.Spec.AllowedPrincipals = []Principal{{}}
+	})
+	_, err := v.ValidateCreate(context.Background(), wa)
+	if err == nil {
+		t.Fatal("expected error for empty allowed principal")
+	}
+	if got := err.Error(); !containsAll(got, "allowedPrincipals[0]", "user", "group") {
+		t.Fatalf("expected empty principal error, got %q", got)
+	}
+}
+
+func TestValidateCreate_RejectsEmptyDeniedPrincipal(t *testing.T) {
+	v := &WebhookAuthorizerValidator{}
+	wa := newTestWebhookAuthorizer(func(wa *WebhookAuthorizer) {
+		wa.Spec.AllowedPrincipals = nil
+		wa.Spec.DeniedPrincipals = []Principal{{}}
+	})
+	_, err := v.ValidateCreate(context.Background(), wa)
+	if err == nil {
+		t.Fatal("expected error for empty denied principal")
+	}
+	if got := err.Error(); !containsAll(got, "deniedPrincipals[0]", "user", "group") {
+		t.Fatalf("expected empty principal error, got %q", got)
 	}
 }
 
@@ -369,6 +415,21 @@ func TestValidateUpdate_AlwaysValidates(t *testing.T) {
 	_, err := v.ValidateUpdate(context.Background(), oldObj, newObj)
 	if err == nil {
 		t.Fatal("expected error for invalid new spec even with same generation")
+	}
+}
+
+func TestValidateUpdate_RejectsEmptyPrincipal(t *testing.T) {
+	v := &WebhookAuthorizerValidator{}
+	oldObj := newTestWebhookAuthorizer()
+	newObj := newTestWebhookAuthorizer(func(wa *WebhookAuthorizer) {
+		wa.Spec.AllowedPrincipals = []Principal{{}}
+	})
+	_, err := v.ValidateUpdate(context.Background(), oldObj, newObj)
+	if err == nil {
+		t.Fatal("expected update to reject empty principal")
+	}
+	if got := err.Error(); !containsAll(got, "allowedPrincipals[0]", "user", "group") {
+		t.Fatalf("expected empty principal error, got %q", got)
 	}
 }
 

--- a/chart/auth-operator/crds/webhookauthorizers.authorization.t-caas.telekom.com.yaml
+++ b/chart/auth-operator/crds/webhookauthorizers.authorization.t-caas.telekom.com.yaml
@@ -76,6 +76,10 @@ spec:
                       maxLength: 253
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: principal must specify user or at least one group
+                    rule: (has(self.user) && self.user != "") || (has(self.groups)
+                      && size(self.groups) > 0)
                 maxItems: 256
                 type: array
               deniedPrincipals:
@@ -106,6 +110,10 @@ spec:
                       maxLength: 253
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: principal must specify user or at least one group
+                    rule: (has(self.user) && self.user != "") || (has(self.groups)
+                      && size(self.groups) > 0)
                 maxItems: 256
                 type: array
               namespaceSelector:

--- a/config/crd/bases/authorization.t-caas.telekom.com_webhookauthorizers.yaml
+++ b/config/crd/bases/authorization.t-caas.telekom.com_webhookauthorizers.yaml
@@ -75,6 +75,10 @@ spec:
                       maxLength: 253
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: principal must specify user or at least one group
+                    rule: (has(self.user) && self.user != "") || (has(self.groups)
+                      && size(self.groups) > 0)
                 maxItems: 256
                 type: array
               deniedPrincipals:
@@ -105,6 +109,10 @@ spec:
                       maxLength: 253
                       type: string
                   type: object
+                  x-kubernetes-validations:
+                  - message: principal must specify user or at least one group
+                    rule: (has(self.user) && self.user != "") || (has(self.groups)
+                      && size(self.groups) > 0)
                 maxItems: 256
                 type: array
               namespaceSelector:


### PR DESCRIPTION
## Summary
- reject empty `allowedPrincipals[]` / `deniedPrincipals[]` entries in the WebhookAuthorizer webhook
- add a CRD CEL rule so schema validation also rejects principal objects without a user or group
- add unit and envtest coverage, and regenerate CRD copies for Helm/config

## Evidence
`Principal` fields are all optional, so an entry like `{}` could pass validation while never matching any request at runtime. That leaves a WebhookAuthorizer looking configured but containing dead principal configuration.

## Validation
- `make manifests generate docs helm`
- `go test ./api/authorization/v1alpha1 -run 'TestValidate(Create|Update)_.*Principal|TestValidateCreate_WarnsEmptyAllowedPrincipals' -count=1`
- `KUBEBUILDER_ASSETS=/private/tmp/auth-operator-gh-rbd-sa-recovery/bin/k8s/1.34.1-darwin-arm64 go test ./api/authorization/v1alpha1 -run 'TestAPIs/WebhookAuthorizer' -count=1`
- `KUBEBUILDER_ASSETS=/private/tmp/auth-operator-gh-rbd-sa-recovery/bin/k8s/1.34.1-darwin-arm64 go test ./api/authorization/v1alpha1 -count=1`
- `git diff --check`

Note: local `golangci-lint run --timeout 5m --new-from-rev=origin/main ./api/authorization/v1alpha1` did not return useful output within the local time window and was stopped; CI will run the full lint job.
