### PR TITLE
Use patch verb for namespace status RBAC

### DIFF
--- a/chart/auth-operator/templates/clusterrole.yaml
+++ b/chart/auth-operator/templates/clusterrole.yaml
@@ -21,7 +21,7 @@ rules:
   - namespaces/status
   verbs:
   - get
-  - update
+  - patch
 # --- ServiceAccount management (BindDefinition and RestrictedBindDefinition auto-create) ---
 - apiGroups:
   - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,7 +18,7 @@ rules:
   - namespaces/status
   verbs:
   - get
-  - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/authorization/rolebinding_terminator_controller.go
+++ b/internal/controller/authorization/rolebinding_terminator_controller.go
@@ -39,7 +39,7 @@ import (
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=namespaces/status,verbs=get;update
+// +kubebuilder:rbac:groups="",resources=namespaces/status,verbs=get;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
 // +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=create;patch;update
 


### PR DESCRIPTION
## Summary
- change the RoleBindingTerminator namespace status RBAC marker from `update` to `patch`
- regenerate `config/rbac/role.yaml`
- align the Helm ClusterRole template with the generated RBAC

## Evidence
RoleBindingTerminator updates namespace status using `client.Status().Patch(...)`, not `Update(...)`, so `namespaces/status` does not need the broader `update` verb.

## Validation
- `make manifests`
- `go test ./internal/controller/authorization -run TestRoleBindingTerminator -count=1`
- `helm template auth-operator chart/auth-operator | yq -r 'select(.kind == "ClusterRole" and .metadata.name == "auth-operator-controller-manager") | .rules[] | select(.resources[]? == "namespaces/status") | .verbs[]'` outputs `get` and `patch`
- `git diff --check`
