### PR TITLE
fix(binddefinition): prune bindings on missing role errors

### DIFF
--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -404,6 +404,7 @@ func (r *BindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if apierrors.IsNotFound(err) {
 			logger.V(1).Info("BindDefinition not found (deleted), skipping reconcile",
 				"bindDefinition", req.Name)
+			deleteBindDefinitionMetricSeries(req.Name)
 			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultSkipped).Inc()
 			return ctrl.Result{}, nil
 		}
@@ -438,12 +439,7 @@ func (r *BindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			logger.V(1).Info("Delete reconcile completed successfully",
 				"bindDefinition", bindDefinition.Name)
 			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultFinalized).Inc()
-			// Clean up per-BD gauge series so they don't linger with stale values.
-			metrics.DeleteManagedResourceSeries(metrics.ControllerBindDefinition, bindDefinition.Name)
-			metrics.RoleRefsMissing.DeleteLabelValues(bindDefinition.Name)
-			metrics.NamespacesActive.DeleteLabelValues(bindDefinition.Name)
-			metrics.ExternalSAsReferenced.DeleteLabelValues(bindDefinition.Name)
-			metrics.ServiceAccountSkippedPreExisting.DeleteLabelValues(bindDefinition.Name)
+			deleteBindDefinitionMetricSeries(bindDefinition.Name)
 		}
 		return result, err
 	}
@@ -524,6 +520,7 @@ func (r *BindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				metrics.ReconcileErrors.WithLabelValues(metrics.ControllerBindDefinition, metrics.ErrorTypeAPI).Inc()
 				return ctrl.Result{}, fmt.Errorf("prune BindDefinition %s bindings after missing role refs: %w", bindDefinition.Name, pruneErr)
 			}
+			metrics.DeleteManagedResourceSeries(metrics.ControllerBindDefinition, bindDefinition.Name)
 			r.markStalled(ctx, bindDefinition, err)
 			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultDegraded).Inc()
 			return ctrl.Result{RequeueAfter: RoleRefRequeueInterval}, nil
@@ -1417,11 +1414,7 @@ func (r *BindDefinitionReconciler) reconcileDelete(
 	logger.V(1).Info("BindDefinition marked for deletion - cleaning up resources",
 		"bindDefinitionName", bindDefinition.Name)
 
-	// Remove per-BD gauge metrics so they don't persist after deletion.
-	metrics.RoleRefsMissing.DeleteLabelValues(bindDefinition.Name)
-	metrics.NamespacesActive.DeleteLabelValues(bindDefinition.Name)
-	metrics.ExternalSAsReferenced.DeleteLabelValues(bindDefinition.Name)
-	metrics.ServiceAccountSkippedPreExisting.DeleteLabelValues(bindDefinition.Name)
+	deleteBindDefinitionMetricSeries(bindDefinition.Name)
 
 	conditions.MarkTrue(bindDefinition, authorizationv1alpha1.DeleteCondition, bindDefinition.Generation,
 		authorizationv1alpha1.DeleteReason, authorizationv1alpha1.DeleteMessage)
@@ -1468,6 +1461,14 @@ func (r *BindDefinitionReconciler) reconcileDelete(
 	logger.V(1).Info("reconcileDelete completed successfully", "bindDefinitionName", bindDefinition.Name)
 
 	return ctrl.Result{}, nil
+}
+
+func deleteBindDefinitionMetricSeries(name string) {
+	metrics.DeleteManagedResourceSeries(metrics.ControllerBindDefinition, name)
+	metrics.RoleRefsMissing.DeleteLabelValues(name)
+	metrics.NamespacesActive.DeleteLabelValues(name)
+	metrics.ExternalSAsReferenced.DeleteLabelValues(name)
+	metrics.ServiceAccountSkippedPreExisting.DeleteLabelValues(name)
 }
 
 // deleteSubjectServiceAccounts deletes ServiceAccounts specified in current

--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -516,6 +516,14 @@ func (r *BindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			logger.Info("Reconciliation blocked by missing-role-policy=error",
 				"bindDefinition", bindDefinition.Name,
 				"missingCount", missingRoleRefCount)
+			if pruneErr := r.pruneStaleBindingResources(ctx, bindDefinition, map[string]struct{}{}, map[string]struct{}{}, r.client); pruneErr != nil {
+				logger.Error(pruneErr, "Failed to prune BindDefinition bindings after missing-role-policy=error",
+					"bindDefinition", bindDefinition.Name)
+				r.markStalled(ctx, bindDefinition, pruneErr)
+				metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultError).Inc()
+				metrics.ReconcileErrors.WithLabelValues(metrics.ControllerBindDefinition, metrics.ErrorTypeAPI).Inc()
+				return ctrl.Result{}, fmt.Errorf("prune BindDefinition %s bindings after missing role refs: %w", bindDefinition.Name, pruneErr)
+			}
 			r.markStalled(ctx, bindDefinition, err)
 			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultDegraded).Inc()
 			return ctrl.Result{RequeueAfter: RoleRefRequeueInterval}, nil

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -5094,6 +5094,85 @@ func TestReconcile_MissingRolePolicy_Error(t *testing.T) {
 	g.Expect(rbList.Items).To(BeEmpty(), "expected no RoleBindings to be created in error mode")
 }
 
+func TestReconcile_MissingRolePolicy_ErrorPrunesOwnedBindings(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	s := runtime.NewScheme()
+	_ = authorizationv1alpha1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+
+	bd := newBDWithPolicy("policy-error-prune-bd", authorizationv1alpha1.MissingRolePolicyError)
+	bd.Spec.RoleBindings = []authorizationv1alpha1.NamespaceBinding{{
+		Namespace:       "policy-error-ns",
+		ClusterRoleRefs: []string{"nonexistent-role"},
+	}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "policy-error-ns"}}
+	ownerRef := metav1.OwnerReference{
+		APIVersion:         authorizationv1alpha1.GroupVersion.String(),
+		Kind:               "BindDefinition",
+		Name:               bd.Name,
+		UID:                bd.UID,
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
+	}
+	bindingName := helpers.BuildBindingName(bd.Spec.TargetName, "nonexistent-role")
+	ownedCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            bindingName,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		RoleRef:  rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "nonexistent-role"},
+		Subjects: bd.Spec.Subjects,
+	}
+	ownedRB := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            bindingName,
+			Namespace:       ns.Name,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		RoleRef:  rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "nonexistent-role"},
+		Subjects: bd.Spec.Subjects,
+	}
+	unownedCRB := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "unowned-" + bindingName},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "nonexistent-role"},
+		Subjects:   bd.Spec.Subjects,
+	}
+	unownedRB := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "unowned-" + bindingName, Namespace: ns.Name},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "nonexistent-role"},
+		Subjects:   bd.Spec.Subjects,
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(bd, ns, ownedCRB, ownedRB, unownedCRB, unownedRB).
+		WithStatusSubresource(bd).
+		Build()
+	r := &BindDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: bd.Name},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(RoleRefRequeueInterval))
+
+	var crb rbacv1.ClusterRoleBinding
+	err = c.Get(ctx, types.NamespacedName{Name: ownedCRB.Name}, &crb)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "owned ClusterRoleBinding should be pruned")
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: unownedCRB.Name}, &crb)).To(Succeed(), "unowned ClusterRoleBinding should be preserved")
+
+	var rb rbacv1.RoleBinding
+	err = c.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: ownedRB.Name}, &rb)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "owned RoleBinding should be pruned")
+	g.Expect(c.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: unownedRB.Name}, &rb)).To(Succeed(), "unowned RoleBinding should be preserved")
+
+	var updated authorizationv1alpha1.BindDefinition
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: bd.Name}, &updated)).To(Succeed())
+	g.Expect(updated.Status.MissingRoleRefs).To(ContainElement("ClusterRole/nonexistent-role"))
+}
+
 func TestReconcile_MissingRolePolicy_Ignore(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -4792,20 +4793,56 @@ func TestReconcileDeleteCleansUpGaugeMetrics(t *testing.T) {
 	// Simulate metrics being set during a prior reconciliation
 	metrics.RoleRefsMissing.WithLabelValues(bdName).Set(2)
 	metrics.NamespacesActive.WithLabelValues(bdName).Set(5)
+	metrics.ExternalSAsReferenced.WithLabelValues(bdName).Set(3)
+	metrics.ServiceAccountSkippedPreExisting.WithLabelValues(bdName).Inc()
+	metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceClusterRoleBinding, bdName).Set(1)
+	metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceRoleBinding, bdName).Set(2)
+	metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceServiceAccount, bdName).Set(3)
 
 	_, err := r.reconcileDelete(ctx, bd)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	// After deletion the per-BD gauge label sets should be cleaned up.
-	// Prometheus GetMetricWithLabelValues returns an existing metric if it
-	// was previously registered; after DeleteLabelValues the metric entry
-	// should no longer be present. We verify by checking that a fresh Get
-	// returns a gauge with value 0 (Prometheus creates a new default-0 entry).
-	roleGauge, _ := metrics.RoleRefsMissing.GetMetricWithLabelValues(bdName)
-	g.Expect(roleGauge).NotTo(BeNil())
+	expectBindDefinitionMetricSeriesCleared(g, bdName)
+}
 
-	nsGauge, _ := metrics.NamespacesActive.GetMetricWithLabelValues(bdName)
-	g.Expect(nsGauge).NotTo(BeNil())
+func TestReconcile_NotFoundCleansUpMetricSeries(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	s := runtime.NewScheme()
+	_ = authorizationv1alpha1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+
+	bdName := "metrics-not-found-bd"
+	metrics.RoleRefsMissing.WithLabelValues(bdName).Set(2)
+	metrics.NamespacesActive.WithLabelValues(bdName).Set(5)
+	metrics.ExternalSAsReferenced.WithLabelValues(bdName).Set(3)
+	metrics.ServiceAccountSkippedPreExisting.WithLabelValues(bdName).Inc()
+	metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceClusterRoleBinding, bdName).Set(1)
+	metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceRoleBinding, bdName).Set(2)
+	metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceServiceAccount, bdName).Set(3)
+
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	r := &BindDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: bdName},
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(reconcile.Result{}))
+
+	expectBindDefinitionMetricSeriesCleared(g, bdName)
+}
+
+func expectBindDefinitionMetricSeriesCleared(g *WithT, name string) {
+	g.Expect(testutil.ToFloat64(metrics.RoleRefsMissing.WithLabelValues(name))).To(Equal(float64(0)))
+	g.Expect(testutil.ToFloat64(metrics.NamespacesActive.WithLabelValues(name))).To(Equal(float64(0)))
+	g.Expect(testutil.ToFloat64(metrics.ExternalSAsReferenced.WithLabelValues(name))).To(Equal(float64(0)))
+	g.Expect(testutil.ToFloat64(metrics.ServiceAccountSkippedPreExisting.WithLabelValues(name))).To(Equal(float64(0)))
+	g.Expect(testutil.ToFloat64(metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceClusterRoleBinding, name))).To(Equal(float64(0)))
+	g.Expect(testutil.ToFloat64(metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceRoleBinding, name))).To(Equal(float64(0)))
+	g.Expect(testutil.ToFloat64(metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceServiceAccount, name))).To(Equal(float64(0)))
 }
 
 // ---------------------------------------------------------------------------
@@ -5151,6 +5188,9 @@ func TestReconcile_MissingRolePolicy_ErrorPrunesOwnedBindings(t *testing.T) {
 		WithStatusSubresource(bd).
 		Build()
 	r := &BindDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
+	metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceClusterRoleBinding, bd.Name).Set(1)
+	metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceRoleBinding, bd.Name).Set(1)
+	metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceServiceAccount, bd.Name).Set(1)
 
 	result, err := r.Reconcile(ctx, reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: bd.Name},
@@ -5171,6 +5211,10 @@ func TestReconcile_MissingRolePolicy_ErrorPrunesOwnedBindings(t *testing.T) {
 	var updated authorizationv1alpha1.BindDefinition
 	g.Expect(c.Get(ctx, types.NamespacedName{Name: bd.Name}, &updated)).To(Succeed())
 	g.Expect(updated.Status.MissingRoleRefs).To(ContainElement("ClusterRole/nonexistent-role"))
+	g.Expect(testutil.ToFloat64(metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceClusterRoleBinding, bd.Name))).To(Equal(float64(0)))
+	g.Expect(testutil.ToFloat64(metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceRoleBinding, bd.Name))).To(Equal(float64(0)))
+	g.Expect(testutil.ToFloat64(metrics.ManagedResources.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResourceServiceAccount, bd.Name))).To(Equal(float64(0)))
+	g.Expect(testutil.ToFloat64(metrics.RoleRefsMissing.WithLabelValues(bd.Name))).To(Equal(float64(1)))
 }
 
 func TestReconcile_MissingRolePolicy_Ignore(t *testing.T) {


### PR DESCRIPTION
## Summary
- prune owned ClusterRoleBindings and RoleBindings when `missing-role-policy=error` blocks BindDefinition reconciliation
- clear stale `auth_operator_managed_resources` gauges on that degraded cleanup path
- clean per-BindDefinition metric series when the object is deleted or already gone
- preserve unowned RBAC resources during cleanup and add regression coverage

## Evidence
- `Reconcile` previously returned from the `ErrMissingRoleRefs` path before `pruneStaleBindingResources` ran.
- That meant a BindDefinition that had already created bindings could leave those bindings active after the referenced role disappeared and the policy switched into blocking behavior.
- The same early return also skipped managed-resource gauge updates, leaving stale `auth_operator_managed_resources` values after the owned bindings were removed.

## Validation
- `go test ./internal/controller/authorization -run 'TestReconcile_MissingRolePolicy_(Error|Warn|Ignore|Default|ErrorWithAllRefsValid)|TestReconcileReturnsShortRequeueOnMissingRoleRefs'`\n- `go test ./internal/controller/authorization -run 'TestReconcileDeleteCleansUpGaugeMetrics|TestReconcile_NotFoundCleansUpMetricSeries|TestReconcile_MissingRolePolicy_ErrorPrunesOwnedBindings' -count=1`\n- `golangci-lint run --timeout 10m ./internal/controller/authorization/...`\n- `KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.34.1 --bin-dir ./bin -p path)" go test ./internal/controller/authorization -count=1`\n- `git diff --check`

## Evidence / duplicate check

Refresh before PR body update on 2026-06-27:
- Target verified: `gh repo view telekom/auth-operator --json nameWithOwner,isFork,defaultBranchRef,url` -> `telekom/auth-operator`, `isFork=false`, default branch `main`, URL `https://github.com/telekom/auth-operator`.
- PR target verified: `gh api repos/telekom/auth-operator/pulls/366` -> base `telekom/auth-operator:main`, head `MaxRink/auth-operator:codex/bd-missing-role-cleanup`.
- Head-branch duplicate search: `gh pr list --repo telekom/auth-operator --state open --search "head:MaxRink:codex/bd-missing-role-cleanup"` -> none.
- Open duplicate search: `gh search prs --repo telekom/auth-operator "prune bindings on missing role errors" --state open` -> #366.
- Recently merged duplicate search: `gh search prs --repo telekom/auth-operator "prune bindings on missing role errors updated:>=2026-06-13" --merged` -> #321, #336.

