### PR TITLE
fix(roledefinition): delete owned targets once

### DIFF
--- a/internal/controller/authorization/roledefinition_helpers.go
+++ b/internal/controller/authorization/roledefinition_helpers.go
@@ -186,7 +186,7 @@ func (r *RoleDefinitionReconciler) handleDeletion(
 	} else if err := r.client.Delete(ctx, role); apierrors.IsNotFound(err) {
 		logger.V(2).Info("Role disappeared before deletion - removing finalizer",
 			"roleDefinitionName", roleDefinition.Name, "roleName", roleDefinition.Spec.TargetName)
-	} else if err := r.client.Delete(ctx, role); err != nil && !apierrors.IsNotFound(err) {
+	} else if err != nil {
 		logger.Error(err, "Failed to delete role",
 			"roleDefinitionName", roleDefinition.Name, "roleName", roleDefinition.Spec.TargetName)
 		return r.markDeletionFailed(ctx, roleDefinition, err)

--- a/internal/controller/authorization/roledefinition_helpers_test.go
+++ b/internal/controller/authorization/roledefinition_helpers_test.go
@@ -755,9 +755,18 @@ func TestHandleDeletion(t *testing.T) {
 			},
 		}
 
+		deleteCount := 0
 		c := fake.NewClientBuilder().WithScheme(s).
 			WithObjects(rd, cr).
 			WithStatusSubresource(rd).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if _, ok := obj.(*rbacv1.ClusterRole); ok {
+						deleteCount++
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			}).
 			Build()
 		r := &RoleDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
 
@@ -768,6 +777,7 @@ func TestHandleDeletion(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		// First call triggers delete and requeues
 		g.Expect(result.RequeueAfter).NotTo(BeZero())
+		g.Expect(deleteCount).To(Equal(1))
 	})
 
 	t.Run("wraps deletion and status update errors", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- avoid issuing two delete calls for the same owned RoleDefinition target
- keep the existing deletion requeue behavior after a successful delete
- add a fake-client regression assertion that the owned ClusterRole is deleted once

## Evidence
- `handleDeletion` previously called `r.client.Delete(ctx, role)` in one `else if` condition and called it again in the next branch when the first call returned nil.
- The second call could duplicate admission/audit side effects and mask the first delete result.

## Duplicate/overlap check
- Target verified before update: `telekom/auth-operator` (`https://github.com/telekom/auth-operator`), non-fork, default branch `main`; this PR targets `main`.
- Open PR search `handleDeletion RoleDefinition Delete roledefinition_helpers.go delete once owned target` only returned this PR (#367).
- Recently merged PR search with the same terms returned no matches.

## Validation
- `go test ./internal/controller/authorization -run 'TestHandleDeletion'`
- `git diff --check`
