### PR TITLE
fix(binddefinition): requeue selector bindings on label removal

### DIFF
--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -308,9 +308,12 @@ func bindDefinitionMatchesNamespace(bd *authorizationv1alpha1.BindDefinition, ns
 	}
 
 	for _, rb := range bd.Spec.RoleBindings {
-		// Explicit namespace match.
-		if rb.Namespace == ns.Name {
-			return true
+		// Explicit namespace takes precedence over selectors for the same binding.
+		if rb.Namespace != "" {
+			if rb.Namespace == ns.Name {
+				return true
+			}
+			continue
 		}
 		// Any selector can be affected by label changes on this namespace.
 		if len(rb.NamespaceSelector) > 0 {

--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -12,7 +12,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -289,11 +288,13 @@ func namespaceLabelOrPhaseChangePredicate() predicate.Predicate {
 	}
 }
 
-// bindDefinitionMatchesNamespace reports whether a BindDefinition has any
-// roleBinding whose namespace selector or explicit namespace field could
-// match the given namespace. BindDefinitions with no roleBindings (cluster-only)
-// are skipped. During namespace termination, all BDs with roleBindings are
-// matched to ensure finalizer cleanup.
+// bindDefinitionMatchesNamespace reports whether a Namespace event can affect a
+// BindDefinition's desired RoleBindings. Selector-backed bindings must
+// reconcile on namespace label events even when the current labels no longer
+// match, because label removals need immediate stale RoleBinding cleanup.
+// BindDefinitions with no roleBindings (cluster-only) are skipped. During
+// namespace termination, all BDs with roleBindings are matched to ensure
+// finalizer cleanup.
 func bindDefinitionMatchesNamespace(bd *authorizationv1alpha1.BindDefinition, ns *corev1.Namespace) bool {
 	if len(bd.Spec.RoleBindings) == 0 {
 		// Cluster-only BD — no namespace-scoped work needed.
@@ -311,19 +312,9 @@ func bindDefinitionMatchesNamespace(bd *authorizationv1alpha1.BindDefinition, ns
 		if rb.Namespace == ns.Name {
 			return true
 		}
-		// Label selector match. An empty LabelSelector ({}) produces
-		// labels.Everything() and matches all namespaces, consistent with
-		// Kubernetes semantics and the BindDefinition validating webhook.
-		for _, sel := range rb.NamespaceSelector {
-			selector, err := metav1.LabelSelectorAsSelector(&sel)
-			if err != nil {
-				// Invalid selector — include this BD so reconciliation
-				// can report the error via conditions.
-				return true
-			}
-			if selector.Matches(labels.Set(ns.GetLabels())) {
-				return true
-			}
+		// Any selector can be affected by label changes on this namespace.
+		if len(rb.NamespaceSelector) > 0 {
+			return true
 		}
 	}
 	return false

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -3209,6 +3209,28 @@ func TestBindDefinitionMatchesNamespace(t *testing.T) {
 		})).To(BeFalse())
 	})
 
+	t.Run("explicit namespace ignores selector for other namespaces", func(t *testing.T) {
+		g := NewWithT(t)
+		bd := &authorizationv1alpha1.BindDefinition{
+			Spec: authorizationv1alpha1.BindDefinitionSpec{
+				RoleBindings: []authorizationv1alpha1.NamespaceBinding{
+					{
+						Namespace: "target-ns",
+						NamespaceSelector: []metav1.LabelSelector{
+							{MatchLabels: map[string]string{"env": "prod"}},
+						},
+					},
+				},
+			},
+		}
+		g.Expect(bindDefinitionMatchesNamespace(bd, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "target-ns", Labels: map[string]string{"env": "dev"}},
+		})).To(BeTrue())
+		g.Expect(bindDefinitionMatchesNamespace(bd, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Labels: map[string]string{"env": "prod"}},
+		})).To(BeFalse())
+	})
+
 	t.Run("label selector routes regardless of current labels", func(t *testing.T) {
 		g := NewWithT(t)
 		bd := &authorizationv1alpha1.BindDefinition{

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -3042,7 +3042,7 @@ func TestNamespaceToBindDefinitionRequests(t *testing.T) {
 		g.Expect(requests).To(BeEmpty())
 	})
 
-	t.Run("skips BindDefinitions with non-matching selectors", func(t *testing.T) {
+	t.Run("queues BindDefinitions with selectors after labels stop matching", func(t *testing.T) {
 		g := NewWithT(t)
 
 		bd := &authorizationv1alpha1.BindDefinition{
@@ -3067,7 +3067,9 @@ func TestNamespaceToBindDefinitionRequests(t *testing.T) {
 			Labels: map[string]string{"env": "staging"},
 		}}
 		requests := r.namespaceToBindDefinitionRequests(ctx, ns)
-		g.Expect(requests).To(BeEmpty())
+		g.Expect(requests).To(ConsistOf(reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "non-matching-bd"},
+		}))
 	})
 
 	t.Run("matches all BDs with roleBindings during namespace termination", func(t *testing.T) {
@@ -3207,7 +3209,7 @@ func TestBindDefinitionMatchesNamespace(t *testing.T) {
 		})).To(BeFalse())
 	})
 
-	t.Run("label selector match", func(t *testing.T) {
+	t.Run("label selector routes regardless of current labels", func(t *testing.T) {
 		g := NewWithT(t)
 		bd := &authorizationv1alpha1.BindDefinition{
 			Spec: authorizationv1alpha1.BindDefinitionSpec{
@@ -3223,7 +3225,7 @@ func TestBindDefinitionMatchesNamespace(t *testing.T) {
 		})).To(BeTrue())
 		g.Expect(bindDefinitionMatchesNamespace(bd, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: "ns1", Labels: map[string]string{"env": "dev"}},
-		})).To(BeFalse())
+		})).To(BeTrue())
 	})
 
 	t.Run("terminating namespace matches all BDs with roleBindings", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- enqueue selector-backed BindDefinitions on namespace label events even when the namespace no longer matches the selector
- keep cluster-only BindDefinitions skipped and explicit namespace routing unchanged
- update fan-out tests to cover label-removal cleanup routing

## Evidence
- Before this change, `namespaceToBindDefinitionRequests` filtered selector-backed BindDefinitions by the namespace’s current labels.
- When a label was removed, the changed namespace no longer matched, so the BindDefinition was not reconciled and stale owned RoleBindings remained until another reconcile.
- `RestrictedBindDefinition` already routes selector-backed definitions on namespace events for this cleanup reason.

## Validation
- `go test ./internal/controller/authorization -run 'TestNamespaceToBindDefinitionRequests|TestBindDefinitionMatchesNamespace|TestBindDefinitionReconcilePrunesSelectorStaleRoleBinding'`\n- `git diff --check`

## Evidence / duplicate check

Refresh before PR body update on 2026-06-27:
- Target verified: `gh repo view telekom/auth-operator --json nameWithOwner,isFork,defaultBranchRef,url` -> `telekom/auth-operator`, `isFork=false`, default branch `main`, URL `https://github.com/telekom/auth-operator`.
- PR target verified: `gh api repos/telekom/auth-operator/pulls/368` -> base `telekom/auth-operator:main`, head `MaxRink/auth-operator:codex/bd-selector-label-requeue`.
- Head-branch duplicate search: `gh pr list --repo telekom/auth-operator --state open --search "head:MaxRink:codex/bd-selector-label-requeue"` -> none.
- Open duplicate search: `gh search prs --repo telekom/auth-operator "requeue selector bindings on label removal" --state open` -> #368.
- Recently merged duplicate search: `gh search prs --repo telekom/auth-operator "requeue selector bindings on label removal updated:>=2026-06-13" --merged` -> #224.




### Review follow-up 2026-06-27

- Target verification: refreshed `telekom/auth-operator` as non-fork upstream with default branch `main`; PR #368 base remains `telekom/auth-operator:main`.
- Duplicate check before branch update: `resolveRoleBindingNamespaces NamespaceBinding explicit Namespace selector precedence` open search returned no matches; recently merged search (`updated:>=2026-06-13`) returned no matches.
- Review fix: aligned `bindDefinitionMatchesNamespace` with explicit-namespace precedence and added a regression test that selector labels on another namespace no longer route the BindDefinition.
- Local validation: `GOCACHE=/private/tmp/auth-operator-go-build-cache go test -timeout=4m ./internal/controller/authorization -run TestBindDefinitionMatchesNamespace`; `git -c core.fsmonitor=false diff --check`.
