### PR TITLE
fix(authorizer): reload bearer token file

### DIFF
--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -266,6 +266,7 @@ func configureWebhooks(mgr manager.Manager, tp *tracing.Provider) error {
 		return err
 	}
 	authorizer.BearerToken = token
+	authorizer.BearerTokenFile = authorizeAuthTokenFile
 	if authorizeRateLimit > 0 {
 		authorizer.Limiter = rate.NewLimiter(rate.Limit(authorizeRateLimit), authorizeRateBurst)
 		log.Info("rate limiting enabled for /authorize",

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -893,7 +893,7 @@ func (wa *Authorizer) expectedBearerToken() (string, error) {
 	}
 	token := strings.TrimSpace(string(tokenBytes))
 	if token == "" {
-		return "", fmt.Errorf("bearer token file must not be empty")
+		return "", fmt.Errorf("bearer token file %q must not be empty", wa.BearerTokenFile)
 	}
 	return token, nil
 }

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -89,6 +90,10 @@ type Authorizer struct {
 	// BearerToken is optional. When set, /authorize requests must include
 	// Authorization: Bearer <token> before the request body is trusted.
 	BearerToken string
+	// BearerTokenFile is optional. When set, the token is loaded from this
+	// file for each request so projected Secret rotations take effect without
+	// restarting the webhook pod.
+	BearerTokenFile string
 	// Limiter is used as a per-subject limiter template. Each SAR subject gets
 	// an independent token bucket with this limit and burst, preventing one
 	// identity from consuming another identity's authorization budget.
@@ -860,16 +865,37 @@ func (wa *Authorizer) writeDeniedResponse(w http.ResponseWriter, reason string) 
 }
 
 func (wa *Authorizer) authenticateRequest(w http.ResponseWriter, r *http.Request) bool {
-	if wa.BearerToken == "" {
+	expectedToken, err := wa.expectedBearerToken()
+	if err != nil {
+		wa.Log.Error(err, "failed to load /authorize bearer token")
+		wa.writeDeniedResponse(w, reasonUnauthorized)
+		return false
+	}
+	if expectedToken == "" {
 		return true
 	}
 	token, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
-	if !ok || token == "" || !constantTimeTokenEqual(token, wa.BearerToken) {
+	if !ok || token == "" || !constantTimeTokenEqual(token, expectedToken) {
 		wa.Log.V(1).Info("rejecting unauthorized SubjectAccessReview request")
 		wa.writeDeniedResponse(w, reasonUnauthorized)
 		return false
 	}
 	return true
+}
+
+func (wa *Authorizer) expectedBearerToken() (string, error) {
+	if wa.BearerTokenFile == "" {
+		return wa.BearerToken, nil
+	}
+	tokenBytes, err := os.ReadFile(wa.BearerTokenFile)
+	if err != nil {
+		return "", fmt.Errorf("read bearer token file: %w", err)
+	}
+	token := strings.TrimSpace(string(tokenBytes))
+	if token == "" {
+		return "", fmt.Errorf("bearer token file must not be empty")
+	}
+	return token, nil
 }
 
 func constantTimeTokenEqual(a, b string) bool {

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -1402,6 +1402,69 @@ func TestAuthenticateRequest_ReloadsBearerTokenFile(t *testing.T) {
 	}
 }
 
+func TestAuthenticateRequest_DeniesWhenBearerTokenFileUnavailable(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T) string
+	}{
+		{
+			name: "missing file",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return t.TempDir() + "/missing-token"
+			},
+		},
+		{
+			name: "empty file",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				tokenFile := t.TempDir() + "/empty-token"
+				if err := os.WriteFile(tokenFile, []byte(" \n\t"), 0o600); err != nil {
+					t.Fatalf("write empty token: %v", err)
+				}
+				return tokenFile
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tokenFile := tc.setup(t)
+			handler := &Authorizer{
+				Log:             logr.Discard(),
+				BearerTokenFile: tokenFile,
+			}
+
+			if _, err := handler.expectedBearerToken(); err == nil {
+				t.Fatal("expected token file load to fail")
+			} else if !strings.Contains(err.Error(), tokenFile) {
+				t.Fatalf("expected error %q to include token file %q", err.Error(), tokenFile)
+			}
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", nil)
+			req.Header.Set("Authorization", "Bearer any-token")
+			rec := httptest.NewRecorder()
+			if handler.authenticateRequest(rec, req) {
+				t.Fatal("request should not authenticate when token file cannot be loaded")
+			}
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected denied SAR response to return %d, got %d", http.StatusOK, rec.Code)
+			}
+			var response authzv1.SubjectAccessReview
+			if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+				t.Fatalf("decode denied response: %v", err)
+			}
+			if response.Status.Allowed {
+				t.Fatal("response should have Allowed=false")
+			}
+			if !response.Status.Denied {
+				t.Fatal("response should have Denied=true")
+			}
+			if response.Status.Reason != reasonUnauthorized {
+				t.Fatalf("expected reason %q, got %q", reasonUnauthorized, response.Status.Reason)
+			}
+		})
+	}
+}
+
 func TestServeHTTP_RateLimitingIsPerSubject(t *testing.T) {
 	scheme := newScheme(t)
 	cl := newIndexedClient(scheme)

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -1356,6 +1357,48 @@ func TestServeHTTP_BearerTokenRequiredBeforeRateLimit(t *testing.T) {
 	}
 	if secondResponse.Status.Reason != "rate limit exceeded" {
 		t.Fatalf("expected second authenticated request to be rate-limited, got reason %q", secondResponse.Status.Reason)
+	}
+}
+
+func TestAuthenticateRequest_ReloadsBearerTokenFile(t *testing.T) {
+	tokenFile := t.TempDir() + "/authorize-token"
+	if err := os.WriteFile(tokenFile, []byte("old-token\n"), 0o600); err != nil {
+		t.Fatalf("write old token: %v", err)
+	}
+
+	handler := &Authorizer{
+		Log:             logr.Discard(),
+		BearerTokenFile: tokenFile,
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", nil)
+	req.Header.Set("Authorization", "Bearer old-token")
+	if !handler.authenticateRequest(httptest.NewRecorder(), req) {
+		t.Fatal("old token should authenticate before rotation")
+	}
+
+	if err := os.WriteFile(tokenFile, []byte("new-token\n"), 0o600); err != nil {
+		t.Fatalf("write new token: %v", err)
+	}
+
+	staleReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", nil)
+	staleReq.Header.Set("Authorization", "Bearer old-token")
+	staleRec := httptest.NewRecorder()
+	if handler.authenticateRequest(staleRec, staleReq) {
+		t.Fatal("old token should be rejected after rotation")
+	}
+	var staleResponse authzv1.SubjectAccessReview
+	if err := json.NewDecoder(staleRec.Body).Decode(&staleResponse); err != nil {
+		t.Fatalf("decode stale-token response: %v", err)
+	}
+	if staleResponse.Status.Reason != reasonUnauthorized {
+		t.Fatalf("expected stale-token reason %q, got %q", reasonUnauthorized, staleResponse.Status.Reason)
+	}
+
+	rotatedReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", nil)
+	rotatedReq.Header.Set("Authorization", "Bearer new-token")
+	if !handler.authenticateRequest(httptest.NewRecorder(), rotatedReq) {
+		t.Fatal("new token should authenticate after rotation")
 	}
 }
 


### PR DESCRIPTION
## Summary
- reload the `/authorize` bearer token file on each request when `--authorize-auth-token-file` is configured
- fail closed with the existing unauthorized SAR response if the token file becomes unreadable or empty
- keep static `BearerToken` behavior for tests and non-file callers

## Evidence
- `configureWebhooks` previously read `--authorize-auth-token-file` once at startup and stored the string in `Authorizer.BearerToken`.
- Kubernetes projected Secret rotations update the mounted file, but the in-memory token was not refreshed, so old tokens stayed valid and new tokens were rejected until pod restart.

## Validation
- `go test ./internal/webhook/authorization -run 'TestAuthenticateRequest_ReloadsBearerTokenFile|TestServeHTTP_BearerTokenRequiredBeforeRateLimit'`\n- `go test ./cmd -run 'TestValidateAuthorizeConfig|TestLoadAuthorizeAuthToken'`\n- `git diff --check`

## Evidence / duplicate check

Refresh before PR body update on 2026-06-27:
- Target verified: `gh repo view telekom/auth-operator --json nameWithOwner,isFork,defaultBranchRef,url` -> `telekom/auth-operator`, `isFork=false`, default branch `main`, URL `https://github.com/telekom/auth-operator`.
- PR target verified: `gh api repos/telekom/auth-operator/pulls/369` -> base `telekom/auth-operator:main`, head `MaxRink/auth-operator:codex/webhookauthorizer-token-reload`.
- Head-branch duplicate search: `gh pr list --repo telekom/auth-operator --state open --search "head:MaxRink:codex/webhookauthorizer-token-reload"` -> none.
- Open duplicate search: `gh search prs --repo telekom/auth-operator "reload bearer token file" --state open` -> #369.
- Recently merged duplicate search: `gh search prs --repo telekom/auth-operator "reload bearer token file updated:>=2026-06-13" --merged` -> none.




### Review follow-up 2026-06-27

- Target verification: refreshed PR #369 as targeting `telekom/auth-operator:main`; source branch remains `MaxRink/auth-operator:codex/webhookauthorizer-token-reload`.
- Duplicate check before branch update: `BearerTokenFile empty missing file unauthorized webhookauthorizer` open search returned no matches; recently merged search (`updated:>=2026-06-13`) returned no matches.
- Review fix: empty bearer-token files now include the configured file path in the load error, and missing/empty token files are covered by fail-closed unauthorized SubjectAccessReview response tests.
- Local validation: `GOCACHE=/private/tmp/auth-operator-go-build-cache go test -timeout=4m ./internal/webhook/authorization -run 'TestAuthenticateRequest_(ReloadsBearerTokenFile|DeniesWhenBearerTokenFileUnavailable)'`; `git -c core.fsmonitor=false diff --check`.
