### PR TITLE
fix(roledefinition): stop granting metrics access

### DIFF
--- a/internal/controller/authorization/roledefinition_controller.go
+++ b/internal/controller/authorization/roledefinition_controller.go
@@ -426,7 +426,7 @@ func (r *RoleDefinitionReconciler) discoverAndFilterResources(
 	}
 
 	// Build sorted final rules
-	finalRules := r.buildFinalRules(roleDefinition, rulesByAPIGroupAndVerbs)
+	finalRules := r.buildFinalRules(rulesByAPIGroupAndVerbs)
 
 	// Mark discovery and filtering conditions as complete
 	conditions.MarkTrue(roleDefinition, authorizationv1alpha1.APIFilteredCondition, roleDefinition.Generation,

--- a/internal/controller/authorization/roledefinition_helpers.go
+++ b/internal/controller/authorization/roledefinition_helpers.go
@@ -25,7 +25,6 @@ import (
 	"github.com/telekom/auth-operator/pkg/conditions"
 	"github.com/telekom/auth-operator/pkg/helpers"
 	"github.com/telekom/auth-operator/pkg/metrics"
-	"github.com/telekom/auth-operator/pkg/policy"
 	pkgssa "github.com/telekom/auth-operator/pkg/ssa"
 )
 
@@ -239,21 +238,11 @@ func (r *RoleDefinitionReconciler) removeRoleDefinitionFinalizer(
 
 // buildFinalRules builds the final policy rules from the filtered API resources.
 func (r *RoleDefinitionReconciler) buildFinalRules(
-	roleDefinition *authorizationv1alpha1.RoleDefinition,
 	rulesByAPIGroupAndVerbs map[string]*rbacv1.PolicyRule,
 ) []rbacv1.PolicyRule {
 	finalRules := make([]rbacv1.PolicyRule, 0, len(rulesByAPIGroupAndVerbs))
 	for _, rule := range rulesByAPIGroupAndVerbs {
 		finalRules = append(finalRules, *rule)
-	}
-
-	// Add non-resource URL rule for ClusterRoles only (namespaced Roles cannot have NonResourceURLs)
-	if roleDefinition.Spec.TargetRole == authorizationv1alpha1.DefinitionClusterRole &&
-		!policy.ContainsStringOrWildcard(roleDefinition.Spec.RestrictedVerbs, "get") {
-		finalRules = append(finalRules, rbacv1.PolicyRule{
-			NonResourceURLs: []string{"/metrics"},
-			Verbs:           []string{"get"},
-		})
 	}
 
 	// Sort resources within each rule for deterministic output

--- a/internal/controller/authorization/roledefinition_helpers_test.go
+++ b/internal/controller/authorization/roledefinition_helpers_test.go
@@ -296,14 +296,7 @@ func TestBuildFinalRules(t *testing.T) {
 		recorder: recorder,
 	}
 
-	t.Run("should include /metrics non-resource URL for ClusterRole", func(t *testing.T) {
-		rd := &authorizationv1alpha1.RoleDefinition{
-			Spec: authorizationv1alpha1.RoleDefinitionSpec{
-				TargetRole:      authorizationv1alpha1.DefinitionClusterRole,
-				RestrictedVerbs: []string{"delete"},
-			},
-		}
-
+	t.Run("should not include /metrics non-resource URL for ClusterRole", func(t *testing.T) {
 		rulesByAPIGroupAndVerbs := map[string]*rbacv1.PolicyRule{
 			"v1|[get list]": {
 				APIGroups: []string{""},
@@ -312,31 +305,20 @@ func TestBuildFinalRules(t *testing.T) {
 			},
 		}
 
-		rules := r.buildFinalRules(rd, rulesByAPIGroupAndVerbs)
+		rules := r.buildFinalRules(rulesByAPIGroupAndVerbs)
 
-		// Should have 2 rules: the resource rule + non-resource URL rule
-		if len(rules) != 2 {
-			t.Fatalf("expected 2 rules, got %d", len(rules))
+		if len(rules) != 1 {
+			t.Fatalf("expected 1 resource rule, got %d", len(rules))
 		}
 
-		// Last rule should be non-resource URL
-		lastRule := rules[len(rules)-1]
-		if len(lastRule.NonResourceURLs) == 0 {
-			t.Error("expected non-resource URL rule at end")
-		}
-		if lastRule.NonResourceURLs[0] != "/metrics" {
-			t.Errorf("expected /metrics, got %s", lastRule.NonResourceURLs[0])
+		for _, rule := range rules {
+			if len(rule.NonResourceURLs) > 0 {
+				t.Errorf("expected no non-resource URL rule, got %v", rule.NonResourceURLs)
+			}
 		}
 	})
 
 	t.Run("should NOT include /metrics when get is restricted", func(t *testing.T) {
-		rd := &authorizationv1alpha1.RoleDefinition{
-			Spec: authorizationv1alpha1.RoleDefinitionSpec{
-				TargetRole:      authorizationv1alpha1.DefinitionClusterRole,
-				RestrictedVerbs: []string{"get"},
-			},
-		}
-
 		rulesByAPIGroupAndVerbs := map[string]*rbacv1.PolicyRule{
 			"v1|[list]": {
 				APIGroups: []string{""},
@@ -345,7 +327,7 @@ func TestBuildFinalRules(t *testing.T) {
 			},
 		}
 
-		rules := r.buildFinalRules(rd, rulesByAPIGroupAndVerbs)
+		rules := r.buildFinalRules(rulesByAPIGroupAndVerbs)
 
 		for _, rule := range rules {
 			if len(rule.NonResourceURLs) > 0 {
@@ -355,14 +337,7 @@ func TestBuildFinalRules(t *testing.T) {
 	})
 
 	t.Run("should NOT include /metrics when wildcard is restricted", func(t *testing.T) {
-		rd := &authorizationv1alpha1.RoleDefinition{
-			Spec: authorizationv1alpha1.RoleDefinitionSpec{
-				TargetRole:      authorizationv1alpha1.DefinitionClusterRole,
-				RestrictedVerbs: []string{"*"},
-			},
-		}
-
-		rules := r.buildFinalRules(rd, map[string]*rbacv1.PolicyRule{})
+		rules := r.buildFinalRules(map[string]*rbacv1.PolicyRule{})
 
 		if len(rules) != 0 {
 			t.Fatalf("expected no rules when wildcard restricts get, got %d", len(rules))
@@ -370,13 +345,6 @@ func TestBuildFinalRules(t *testing.T) {
 	})
 
 	t.Run("should NOT include /metrics for namespaced Role", func(t *testing.T) {
-		rd := &authorizationv1alpha1.RoleDefinition{
-			Spec: authorizationv1alpha1.RoleDefinitionSpec{
-				TargetRole:      authorizationv1alpha1.DefinitionNamespacedRole,
-				RestrictedVerbs: []string{"delete"},
-			},
-		}
-
 		rulesByAPIGroupAndVerbs := map[string]*rbacv1.PolicyRule{
 			"v1|[get list]": {
 				APIGroups: []string{""},
@@ -385,7 +353,7 @@ func TestBuildFinalRules(t *testing.T) {
 			},
 		}
 
-		rules := r.buildFinalRules(rd, rulesByAPIGroupAndVerbs)
+		rules := r.buildFinalRules(rulesByAPIGroupAndVerbs)
 
 		for _, rule := range rules {
 			if len(rule.NonResourceURLs) > 0 {
@@ -395,12 +363,6 @@ func TestBuildFinalRules(t *testing.T) {
 	})
 
 	t.Run("should sort resources within rules deterministically", func(t *testing.T) {
-		rd := &authorizationv1alpha1.RoleDefinition{
-			Spec: authorizationv1alpha1.RoleDefinitionSpec{
-				TargetRole: authorizationv1alpha1.DefinitionNamespacedRole,
-			},
-		}
-
 		rulesByAPIGroupAndVerbs := map[string]*rbacv1.PolicyRule{
 			"v1|[get list]": {
 				APIGroups: []string{""},
@@ -409,7 +371,7 @@ func TestBuildFinalRules(t *testing.T) {
 			},
 		}
 
-		rules := r.buildFinalRules(rd, rulesByAPIGroupAndVerbs)
+		rules := r.buildFinalRules(rulesByAPIGroupAndVerbs)
 
 		if len(rules) != 1 {
 			t.Fatalf("expected 1 rule, got %d", len(rules))
@@ -430,21 +392,10 @@ func TestBuildFinalRules(t *testing.T) {
 	})
 
 	t.Run("should handle empty rules map", func(t *testing.T) {
-		rd := &authorizationv1alpha1.RoleDefinition{
-			Spec: authorizationv1alpha1.RoleDefinitionSpec{
-				TargetRole:      authorizationv1alpha1.DefinitionClusterRole,
-				RestrictedVerbs: []string{"delete"},
-			},
-		}
+		rules := r.buildFinalRules(map[string]*rbacv1.PolicyRule{})
 
-		rules := r.buildFinalRules(rd, map[string]*rbacv1.PolicyRule{})
-
-		// Should only have the /metrics rule
-		if len(rules) != 1 {
-			t.Fatalf("expected 1 rule (/metrics), got %d", len(rules))
-		}
-		if len(rules[0].NonResourceURLs) == 0 || rules[0].NonResourceURLs[0] != "/metrics" {
-			t.Error("expected /metrics non-resource URL rule")
+		if len(rules) != 0 {
+			t.Fatalf("expected no rules for empty discovery input, got %d", len(rules))
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- stop adding a hidden `GET /metrics` non-resource URL rule to every generated RoleDefinition ClusterRole
- keep authenticated metrics access on the explicit chart-managed `auth-operator-metrics-reader` RBAC path
- update `TestBuildFinalRules` to assert RoleDefinitions only emit discovered resource rules

## Evidence
`buildFinalRules` appended `NonResourceURLs: ["/metrics"]` whenever a RoleDefinition generated a ClusterRole and `get` was not restricted. That made ordinary generated ClusterRoles grant metrics access even though the documented metrics auth model is the dedicated scraper RBAC rendered by the Helm chart.

Duplicate check: open PRs #365-#369 do not touch this path. #367 covers the separate RoleDefinition double-delete bug only.

## Validation
- `go test ./internal/controller/authorization -run 'TestBuildFinalRules' -count=1`\n- `go test ./internal/controller/authorization -run 'Test.*RoleDefinition'`\n- `KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.34.1 --bin-dir ./bin -p path)" go test ./internal/controller/authorization`\n- `helm template auth-operator chart/auth-operator --set metrics.auth.enabled=true --set metrics.serviceMonitor.enabled=true --set metrics.serviceMonitor.scraperRBAC.create=true --set metrics.serviceMonitor.scraperRBAC.serviceAccount.name=e2e-metrics-scraper --set metrics.serviceMonitor.scraperRBAC.serviceAccount.namespace=auth-operator-system --set metrics.serviceMonitor.tlsConfig.insecureSkipVerify=true | yq 'select(.kind == "ClusterRole" and .metadata.name == "auth-operator-metrics-reader") | .rules'`\n- `git diff --check`

## Review follow-up

Resolved Copilot review discussion_r3486726694 on 2026-06-27 after verifying the current branch already removes the unused roleDefinition parameter from buildFinalRules and updates call sites/tests.

Duplicate check before review resolution:
- gh search prs --repo telekom/auth-operator "buildFinalRules unused roleDefinition parameter metrics access" --state open -> none.
- gh search prs --repo telekom/auth-operator "buildFinalRules unused roleDefinition parameter metrics access updated:>=2026-06-13" --merged -> none.

Validation:
- go test ./internal/controller/authorization -run "Test.*BuildFinalRules|TestRoleDefinition"

