### PR TITLE
docs: align debugging and metrics references

### DIFF
--- a/docs/debugging-guide.md
+++ b/docs/debugging-guide.md
@@ -43,7 +43,7 @@ kubectl get events -n auth-operator-system --sort-by='.lastTimestamp' | tail -20
 kubectl logs -n auth-operator-system -l control-plane=controller-manager --tail=100
 
 # View webhook logs (last 100 lines)
-kubectl logs -n auth-operator-system -l app=webhook-server --tail=100
+kubectl logs -n auth-operator-system -l control-plane=webhook-server --tail=100
 
 # Check CRD status summary
 kubectl get roledefinitions -A -o custom-columns='NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status,REASON:.status.conditions[?(@.type=="Ready")].reason'
@@ -132,13 +132,13 @@ kubectl top pod -n auth-operator-system
 
 ```bash
 # Check if controller is leader (HA mode)
-kubectl get lease -n auth-operator-system auth-operator-leader-election -o yaml
+kubectl get lease -n auth-operator-system auth.t-caas.telekom.com -o yaml
 
 # Check work queue metrics
 curl -s http://localhost:8080/metrics | grep workqueue
 
-# Enable verbose logging temporarily
-kubectl set env deployment/auth-operator-controller-manager -n auth-operator-system LOG_LEVEL=debug
+# For Helm-managed installs, enable verbose logging temporarily
+helm upgrade auth-operator <chart-ref> -n auth-operator-system --reuse-values --set global.logLevel=4
 ```
 
 **Common Causes:**
@@ -173,7 +173,7 @@ kubectl run test-curl --image=curlimages/curl --rm -it --restart=Never -- \
   curl -k https://auth-operator-webhook-service.auth-operator-system.svc:443/healthz
 
 # Check webhook pod logs
-kubectl logs -n auth-operator-system -l app=webhook-server --tail=100
+kubectl logs -n auth-operator-system -l control-plane=webhook-server --tail=100
 ```
 
 **Common Causes:**
@@ -425,13 +425,13 @@ kubectl get restrictedbinddefinitions,restrictedroledefinitions -o json | \
 
 ```bash
 # Check cert-controller rotation
-kubectl logs -n auth-operator-system -l app=webhook-server | grep -i cert
+kubectl logs -n auth-operator-system -l control-plane=webhook-server | grep -i cert
 
 # Verify certificate secret exists
-kubectl get secret -n auth-operator-system auth-operator-webhook-server-cert
+kubectl get secret -n auth-operator-system auth-operator-webhook-certs
 
 # Check certificate expiry
-kubectl get secret -n auth-operator-system auth-operator-webhook-server-cert -o jsonpath='{.data.tls\.crt}' | \
+kubectl get secret -n auth-operator-system auth-operator-webhook-certs -o jsonpath='{.data.tls\.crt}' | \
   base64 -d | openssl x509 -noout -dates
 
 # Verify CA bundle in webhook config
@@ -512,14 +512,16 @@ or BindDefinitions.
 
 ```bash
 # Temporarily increase log verbosity
-kubectl set env deployment/auth-operator-controller-manager \
+helm upgrade auth-operator <chart-ref> \
   -n auth-operator-system \
-  -- -zap-log-level=debug
+  --reuse-values \
+  --set global.logLevel=4
 
 # Revert to normal logging
-kubectl set env deployment/auth-operator-controller-manager \
+helm upgrade auth-operator <chart-ref> \
   -n auth-operator-system \
-  -- -zap-log-level=info
+  --reuse-values \
+  --set global.logLevel=0
 ```
 
 ### Common Log Patterns
@@ -579,7 +581,7 @@ kubectl describe pods -n "$NAMESPACE" > "$OUTPUT_DIR/pod-describe.txt" 2>&1
 
 # Logs
 kubectl logs -n "$NAMESPACE" -l control-plane=controller-manager --tail=1000 > "$OUTPUT_DIR/controller-logs.txt" 2>&1 || true
-kubectl logs -n "$NAMESPACE" -l app=webhook-server --tail=1000 > "$OUTPUT_DIR/webhook-logs.txt" 2>&1 || true
+kubectl logs -n "$NAMESPACE" -l control-plane=webhook-server --tail=1000 > "$OUTPUT_DIR/webhook-logs.txt" 2>&1 || true
 
 # CRD status
 kubectl get roledefinitions -A -o yaml > "$OUTPUT_DIR/roledefinitions.yaml" 2>&1 || true

--- a/docs/debugging-guide.md
+++ b/docs/debugging-guide.md
@@ -521,7 +521,7 @@ helm upgrade auth-operator <chart-ref> \
 helm upgrade auth-operator <chart-ref> \
   -n auth-operator-system \
   --reuse-values \
-  --set global.logLevel=0
+  --set global.logLevel=2
 ```
 
 ### Common Log Patterns

--- a/docs/metrics-and-alerting.md
+++ b/docs/metrics-and-alerting.md
@@ -84,7 +84,9 @@ resources:
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `auth_operator_rbac_resources_applied_total` | Counter | `resource_type` | Resources created or updated via SSA. Types: `ClusterRole`, `Role`, `ClusterRoleBinding`, `RoleBinding`, `ServiceAccount`. |
+| `auth_operator_rbac_resources_skipped_total` | Counter | `resource_type` | RBAC resources where SSA was skipped because the cached object already matched desired state. |
 | `auth_operator_rbac_resources_deleted_total` | Counter | `resource_type` | Resources deleted during finalizer cleanup. |
+| `auth_operator_status_resources_skipped_total` | Counter | `resource_type` | Status updates skipped because the cached status already matched desired state. |
 | `auth_operator_managed_resources` | Gauge | `controller`, `resource_type`, `name` | Current number of managed resources per source resource. Use `sum by (resource_type)(…)` for cluster-wide totals. |
 
 ### Binding Health
@@ -94,6 +96,9 @@ resources:
 | `auth_operator_role_refs_missing` | Gauge | `binddefinition` | Number of referenced Roles/ClusterRoles that do not exist for a BindDefinition or RestrictedBindDefinition. Non-zero triggers a faster 10 s requeue. |
 | `auth_operator_namespaces_active` | Gauge | `binddefinition` | Number of active (non-terminating) namespaces matching selectors. |
 | `auth_operator_serviceaccount_skipped_preexisting_total` | Counter | `binddefinition` | Pre-existing ServiceAccounts that were intentionally not adopted (no OwnerRef added). |
+| `auth_operator_external_serviceaccounts_referenced` | Gauge | `binddefinition` | External pre-existing ServiceAccounts referenced by each BindDefinition. These ServiceAccounts are used but not managed by the operator. |
+| `auth_operator_namespace_fanout_skipped_total` | Counter | — | BindDefinitions filtered out during namespace-event fan-out because no namespace field or selector matched. |
+| `auth_operator_namespace_fanout_enqueued_total` | Counter | — | BindDefinitions enqueued during namespace-event fan-out because namespace routing matched. |
 
 ### Policy Compliance (Restricted CRDs)
 


### PR DESCRIPTION
## Summary
- update debugging guide selectors, leader-election lease, webhook certificate secret, and log verbosity commands to match rendered/runtime behavior
- add missing custom metrics to the metrics reference

## Evidence
Confirmed against `origin/main` source and rendered outputs:
- webhook pods use `control-plane=webhook-server`
- controller leader election ID is `auth.t-caas.telekom.com`
- rendered webhook cert Secret is `auth-operator-webhook-certs`
- controller/webhook use `--verbosity={{ .Values.global.logLevel }}` rather than `LOG_LEVEL` or `-zap-log-level`
- `pkg/metrics/metrics.go` registers the added metrics

Duplicate check: open PRs #365-#370 do not touch `docs/debugging-guide.md` or `docs/metrics-and-alerting.md`.

## Validation
- `rg -n 'control-plane=webhook-server|auth\\.t-caas\\.telekom\\.com|auth-operator-webhook-certs|global.logLevel|--verbosity' docs/debugging-guide.md chart/auth-operator/templates cmd config/default -S`\n- `rg -n 'rbac_resources_skipped_total|status_resources_skipped_total|external_serviceaccounts_referenced|namespace_fanout_skipped_total|namespace_fanout_enqueued_total' docs/metrics-and-alerting.md pkg/metrics/metrics.go`\n- `! rg -n 'app=webhook-server|auth-operator-leader-election|auth-operator-webhook-server-cert|LOG_LEVEL|zap-log-level' docs/debugging-guide.md`\n- `git diff --check`

## Review follow-up

Addressed Copilot review discussion_r3486728685 on 2026-06-27 by changing the debug guide normal-logging Helm example to restore chart default global.logLevel=2.

Duplicate check before branch update:
- gh search prs --repo telekom/auth-operator "debugging guide global.logLevel normal logging default 2" --state open -> none.
- gh search prs --repo telekom/auth-operator "debugging guide global.logLevel normal logging default 2 updated:>=2026-06-13" --merged -> none.

Validation:
- git -c core.fsmonitor=false diff --check

