### PR TITLE
fix(webhookauthorizer): stall invalid legacy specs

### DIFF
--- a/api/authorization/v1alpha1/fuzz_test.go
+++ b/api/authorization/v1alpha1/fuzz_test.go
@@ -79,6 +79,6 @@ func FuzzWebhookAuthorizerValidation(f *testing.F) {
 		if err := json.Unmarshal(data, &webhookAuthorizer); err != nil {
 			return
 		}
-		_, _ = validateWebhookAuthorizer(&webhookAuthorizer)
+		_, _ = ValidateWebhookAuthorizer(&webhookAuthorizer)
 	})
 }

--- a/api/authorization/v1alpha1/webhookauthorizer_webhook.go
+++ b/api/authorization/v1alpha1/webhookauthorizer_webhook.go
@@ -35,7 +35,7 @@ func (wa *WebhookAuthorizer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 func (v *WebhookAuthorizerValidator) ValidateCreate(ctx context.Context, obj *WebhookAuthorizer) (admission.Warnings, error) {
 	logger := log.FromContext(ctx).WithName("webhookauthorizer-webhook")
 	logger.V(1).Info("validating create", "name", obj.Name)
-	return validateWebhookAuthorizer(obj)
+	return ValidateWebhookAuthorizer(obj)
 }
 
 // ValidateUpdate implements admission.Validator for WebhookAuthorizer.
@@ -45,7 +45,7 @@ func (v *WebhookAuthorizerValidator) ValidateCreate(ctx context.Context, obj *We
 func (v *WebhookAuthorizerValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *WebhookAuthorizer) (admission.Warnings, error) {
 	logger := log.FromContext(ctx).WithName("webhookauthorizer-webhook")
 	logger.V(1).Info("validating update", "name", newObj.Name)
-	return validateWebhookAuthorizer(newObj)
+	return ValidateWebhookAuthorizer(newObj)
 }
 
 // ValidateDelete implements admission.Validator for WebhookAuthorizer.
@@ -55,8 +55,8 @@ func (v *WebhookAuthorizerValidator) ValidateDelete(ctx context.Context, obj *We
 	return nil, nil
 }
 
-// validateWebhookAuthorizer performs semantic validation on the spec.
-func validateWebhookAuthorizer(wa *WebhookAuthorizer) (admission.Warnings, error) {
+// ValidateWebhookAuthorizer performs semantic validation on the spec.
+func ValidateWebhookAuthorizer(wa *WebhookAuthorizer) (admission.Warnings, error) {
 	var warnings admission.Warnings
 
 	// Validate NamespaceSelector is parseable.
@@ -101,7 +101,12 @@ func validateWebhookAuthorizer(wa *WebhookAuthorizer) (admission.Warnings, error
 		}
 	}
 
-	// Warn if allowed principals are empty.
+	if len(wa.Spec.AllowedPrincipals) == 0 && len(wa.Spec.DeniedPrincipals) == 0 {
+		return nil, apierrors.NewBadRequest(
+			"at least one of spec.allowedPrincipals or spec.deniedPrincipals must be non-empty")
+	}
+
+	// Warn if allowed principals are empty but denied principals are configured.
 	if len(wa.Spec.AllowedPrincipals) == 0 {
 		warnings = append(warnings,
 			"spec.allowedPrincipals is empty; no requests will be allowed by this authorizer")

--- a/api/authorization/v1alpha1/webhookauthorizer_webhook.go
+++ b/api/authorization/v1alpha1/webhookauthorizer_webhook.go
@@ -57,8 +57,6 @@ func (v *WebhookAuthorizerValidator) ValidateDelete(ctx context.Context, obj *We
 
 // ValidateWebhookAuthorizer performs semantic validation on the spec.
 func ValidateWebhookAuthorizer(wa *WebhookAuthorizer) (admission.Warnings, error) {
-	var warnings admission.Warnings
-
 	// Validate NamespaceSelector is parseable.
 	if !isLabelSelectorEmpty(&wa.Spec.NamespaceSelector) {
 		if _, err := metav1.LabelSelectorAsSelector(&wa.Spec.NamespaceSelector); err != nil {
@@ -67,24 +65,35 @@ func ValidateWebhookAuthorizer(wa *WebhookAuthorizer) (admission.Warnings, error
 		}
 	}
 
+	if err := validateWebhookAuthorizerRules(wa); err != nil {
+		return nil, err
+	}
+	return validateWebhookAuthorizerPrincipals(wa)
+}
+
+func validateWebhookAuthorizerRules(wa *WebhookAuthorizer) error {
 	// At least one of resourceRules or nonResourceRules must be defined.
 	if len(wa.Spec.ResourceRules) == 0 && len(wa.Spec.NonResourceRules) == 0 {
-		return nil, apierrors.NewBadRequest(
+		return apierrors.NewBadRequest(
 			"at least one of spec.resourceRules or spec.nonResourceRules must be non-empty")
+	}
+	if !isLabelSelectorEmpty(&wa.Spec.NamespaceSelector) && len(wa.Spec.NonResourceRules) > 0 {
+		return apierrors.NewBadRequest(
+			"spec.namespaceSelector cannot be combined with spec.nonResourceRules because non-resource requests have no namespace")
 	}
 
 	// Validate each resourceRule has at least one verb, apiGroup, and resource.
 	for i, rule := range wa.Spec.ResourceRules {
 		if len(rule.Verbs) == 0 {
-			return nil, apierrors.NewBadRequest(
+			return apierrors.NewBadRequest(
 				fmt.Sprintf("spec.resourceRules[%d] must have at least one verb", i))
 		}
 		if len(rule.APIGroups) == 0 {
-			return nil, apierrors.NewBadRequest(
+			return apierrors.NewBadRequest(
 				fmt.Sprintf("spec.resourceRules[%d] must have at least one apiGroup (use \"\" for core API group)", i))
 		}
 		if len(rule.Resources) == 0 {
-			return nil, apierrors.NewBadRequest(
+			return apierrors.NewBadRequest(
 				fmt.Sprintf("spec.resourceRules[%d] must have at least one resource", i))
 		}
 	}
@@ -92,14 +101,20 @@ func ValidateWebhookAuthorizer(wa *WebhookAuthorizer) (admission.Warnings, error
 	// Validate each nonResourceRule has at least one verb and one URL path.
 	for i, rule := range wa.Spec.NonResourceRules {
 		if len(rule.Verbs) == 0 {
-			return nil, apierrors.NewBadRequest(
+			return apierrors.NewBadRequest(
 				fmt.Sprintf("spec.nonResourceRules[%d] must have at least one verb", i))
 		}
 		if len(rule.NonResourceURLs) == 0 {
-			return nil, apierrors.NewBadRequest(
+			return apierrors.NewBadRequest(
 				fmt.Sprintf("spec.nonResourceRules[%d] must have at least one URL path", i))
 		}
 	}
+
+	return nil
+}
+
+func validateWebhookAuthorizerPrincipals(wa *WebhookAuthorizer) (admission.Warnings, error) {
+	var warnings admission.Warnings
 
 	if len(wa.Spec.AllowedPrincipals) == 0 && len(wa.Spec.DeniedPrincipals) == 0 {
 		return nil, apierrors.NewBadRequest(

--- a/api/authorization/v1alpha1/webhookauthorizer_webhook_test.go
+++ b/api/authorization/v1alpha1/webhookauthorizer_webhook_test.go
@@ -251,6 +251,25 @@ func TestValidateCreate_NonResourceRuleNoPaths(t *testing.T) {
 	}
 }
 
+func TestValidateCreate_RejectsNamespaceSelectorWithNonResourceRules(t *testing.T) {
+	v := &WebhookAuthorizerValidator{}
+	wa := newTestWebhookAuthorizer(func(wa *WebhookAuthorizer) {
+		wa.Spec.NonResourceRules = []authzv1.NonResourceRule{
+			{Verbs: []string{"get"}, NonResourceURLs: []string{"/logs"}},
+		}
+		wa.Spec.NamespaceSelector = metav1.LabelSelector{
+			MatchLabels: map[string]string{"environment": "prod"},
+		}
+	})
+	_, err := v.ValidateCreate(context.Background(), wa)
+	if err == nil {
+		t.Fatal("expected error for namespaceSelector with nonResourceRules")
+	}
+	if got := err.Error(); !containsAll(got, "namespaceSelector", "nonResourceRules", "no namespace") {
+		t.Fatalf("expected namespaceSelector/nonResourceRules error, got %q", got)
+	}
+}
+
 func TestValidateCreate_WarnsEmptyAllowedPrincipals(t *testing.T) {
 	v := &WebhookAuthorizerValidator{}
 	wa := newTestWebhookAuthorizer(func(wa *WebhookAuthorizer) {

--- a/api/authorization/v1alpha1/webhookauthorizer_webhook_test.go
+++ b/api/authorization/v1alpha1/webhookauthorizer_webhook_test.go
@@ -255,6 +255,7 @@ func TestValidateCreate_WarnsEmptyAllowedPrincipals(t *testing.T) {
 	v := &WebhookAuthorizerValidator{}
 	wa := newTestWebhookAuthorizer(func(wa *WebhookAuthorizer) {
 		wa.Spec.AllowedPrincipals = nil
+		wa.Spec.DeniedPrincipals = []Principal{{User: "blocked-user"}}
 	})
 	warnings, err := v.ValidateCreate(context.Background(), wa)
 	if err != nil {
@@ -262,6 +263,21 @@ func TestValidateCreate_WarnsEmptyAllowedPrincipals(t *testing.T) {
 	}
 	if len(warnings) == 0 {
 		t.Error("expected warning for empty allowedPrincipals")
+	}
+}
+
+func TestValidateCreate_RejectsNoPrincipals(t *testing.T) {
+	v := &WebhookAuthorizerValidator{}
+	wa := newTestWebhookAuthorizer(func(wa *WebhookAuthorizer) {
+		wa.Spec.AllowedPrincipals = nil
+		wa.Spec.DeniedPrincipals = nil
+	})
+	_, err := v.ValidateCreate(context.Background(), wa)
+	if err == nil {
+		t.Fatal("expected error for missing principals")
+	}
+	if got := err.Error(); !containsAll(got, "allowedPrincipals", "deniedPrincipals", "non-empty") {
+		t.Fatalf("expected missing principals error, got %q", got)
 	}
 }
 

--- a/config/samples/authorization_v1alpha1_webhookauthorizer.yaml
+++ b/config/samples/authorization_v1alpha1_webhookauthorizer.yaml
@@ -350,9 +350,6 @@ spec:
     - groups:
         - tenant-admins
         - tenant-developers@customer.com
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: kube-system
 
 ---
 # -----------------------------------------------------------------------------

--- a/internal/controller/authorization/webhookauthorizer_controller.go
+++ b/internal/controller/authorization/webhookauthorizer_controller.go
@@ -137,7 +137,20 @@ func (r *WebhookAuthorizerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("apply reconciling status for %s: %w", wa.Name, err)
 	}
 
-	// Step 3: Validate NamespaceSelector
+	// Step 3: Validate the same semantic contract enforced by admission so
+	// legacy or webhook-bypassed objects cannot be reported as configured.
+	if _, err := authorizationv1alpha1.ValidateWebhookAuthorizer(wa); err != nil {
+		if ssaErr := r.markStalled(ctx, wa, err); ssaErr != nil {
+			return ctrl.Result{}, fmt.Errorf("mark stalled after spec validation error: %w", ssaErr)
+		}
+		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerWebhookAuthorizer, metrics.ResultError).Inc()
+		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerWebhookAuthorizer, metrics.ErrorTypeValidation).Inc()
+		logger.Error(err, "webhook authorizer spec validation failed",
+			"webhookAuthorizer", wa.Name)
+		return ctrl.Result{}, nil
+	}
+
+	// Step 4: Validate NamespaceSelector against live namespaces for diagnostics.
 	if err := r.validateNamespaceSelector(ctx, wa); err != nil {
 		// Distinguish between permanent validation errors and transient errors.
 		// Only label selector parse errors are permanent user mistakes —
@@ -165,12 +178,12 @@ func (r *WebhookAuthorizerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("validate namespace selector for %s: %w", wa.Name, err)
 	}
 
-	// Step 4: Mark as configured and ready
+	// Step 5: Mark as configured and ready
 	wa.Status.AuthorizerConfigured = true
 	conditions.MarkReady(wa, wa.Generation,
 		authorizationv1alpha1.ReadyReasonReconciled, authorizationv1alpha1.ReadyMessageReconciled)
 
-	// Step 5: Apply status via SSA
+	// Step 6: Apply status via SSA
 	if err := ssa.ApplyWebhookAuthorizerStatus(ctx, r.client, wa); err != nil {
 		logger.Error(err, "failed to apply status via SSA",
 			"webhookAuthorizer", wa.Name)

--- a/internal/controller/authorization/webhookauthorizer_controller.go
+++ b/internal/controller/authorization/webhookauthorizer_controller.go
@@ -86,10 +86,11 @@ func (r *WebhookAuthorizerReconciler) SetupWithManager(mgr ctrl.Manager, concurr
 //
 // The reconciliation flow:
 //  1. Fetch the WebhookAuthorizer (return early if not found)
-//  2. Mark as Reconciling and set status.observedGeneration
-//  3. Validate NamespaceSelector can be parsed (stall on error)
-//  4. Set status.authorizerConfigured = true and mark Ready
-//  5. Apply status via SSA
+//  2. Validate semantic spec constraints (stall on error)
+//  3. Mark as Reconciling and set status.observedGeneration
+//  4. Validate NamespaceSelector can be parsed (stall on error)
+//  5. Set status.authorizerConfigured = true and mark Ready
+//  6. Apply status via SSA
 func (r *WebhookAuthorizerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	startTime := time.Now()
 	logger := log.FromContext(ctx)
@@ -122,22 +123,7 @@ func (r *WebhookAuthorizerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, fmt.Errorf("fetch WebhookAuthorizer %s: %w", req.Name, err)
 	}
 
-	// Step 2: Mark as Reconciling and persist via SSA so that users see
-	// progress even when subsequent steps fail transiently (e.g. API errors
-	// during namespace listing). Without this early apply, a transient error
-	// in Step 3 would return without updating the status.
-	conditions.MarkReconciling(wa, wa.Generation,
-		authorizationv1alpha1.ReconcilingReasonProgressing, authorizationv1alpha1.ReconcilingMessageProgressing)
-	wa.Status.ObservedGeneration = wa.Generation
-	if err := ssa.ApplyWebhookAuthorizerStatus(ctx, r.client, wa); err != nil {
-		logger.Error(err, "failed to apply Reconciling status via SSA",
-			"webhookAuthorizer", wa.Name)
-		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerWebhookAuthorizer, metrics.ResultError).Inc()
-		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerWebhookAuthorizer, metrics.ErrorTypeAPI).Inc()
-		return ctrl.Result{}, fmt.Errorf("apply reconciling status for %s: %w", wa.Name, err)
-	}
-
-	// Step 3: Validate the same semantic contract enforced by admission so
+	// Step 2: Validate the same semantic contract enforced by admission so
 	// legacy or webhook-bypassed objects cannot be reported as configured.
 	if _, err := authorizationv1alpha1.ValidateWebhookAuthorizer(wa); err != nil {
 		if ssaErr := r.markStalled(ctx, wa, err); ssaErr != nil {
@@ -148,6 +134,21 @@ func (r *WebhookAuthorizerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		logger.Error(err, "webhook authorizer spec validation failed",
 			"webhookAuthorizer", wa.Name)
 		return ctrl.Result{}, nil
+	}
+
+	// Step 3: Mark as Reconciling and persist via SSA so that users see
+	// progress even when subsequent steps fail transiently (e.g. API errors
+	// during namespace listing). Without this early apply, a transient error
+	// in Step 4 would return without updating the status.
+	conditions.MarkReconciling(wa, wa.Generation,
+		authorizationv1alpha1.ReconcilingReasonProgressing, authorizationv1alpha1.ReconcilingMessageProgressing)
+	wa.Status.ObservedGeneration = wa.Generation
+	if err := ssa.ApplyWebhookAuthorizerStatus(ctx, r.client, wa); err != nil {
+		logger.Error(err, "failed to apply Reconciling status via SSA",
+			"webhookAuthorizer", wa.Name)
+		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerWebhookAuthorizer, metrics.ResultError).Inc()
+		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerWebhookAuthorizer, metrics.ErrorTypeAPI).Inc()
+		return ctrl.Result{}, fmt.Errorf("apply reconciling status for %s: %w", wa.Name, err)
 	}
 
 	// Step 4: Validate NamespaceSelector against live namespaces for diagnostics.

--- a/internal/controller/authorization/webhookauthorizer_controller_test.go
+++ b/internal/controller/authorization/webhookauthorizer_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	authzv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -48,6 +49,19 @@ func ctxWithLogger() context.Context {
 	return ctrllog.IntoContext(context.Background(), logr.Discard())
 }
 
+func validWebhookAuthorizerSpec() authorizationv1alpha1.WebhookAuthorizerSpec {
+	return authorizationv1alpha1.WebhookAuthorizerSpec{
+		ResourceRules: []authzv1.ResourceRule{{
+			Verbs:     []string{"get"},
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+		}},
+		AllowedPrincipals: []authorizationv1alpha1.Principal{{
+			User: "admin",
+		}},
+	}
+}
+
 func TestReconcile_NotFound(t *testing.T) {
 	g := gomega.NewWithT(t)
 	r, _ := newWATestReconciler()
@@ -65,7 +79,7 @@ func TestReconcile_EmptySelector_Ready(t *testing.T) {
 			Name:       "test-authorizer",
 			Generation: 1,
 		},
-		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{},
+		Spec: validWebhookAuthorizerSpec(),
 	}
 
 	r, c := newWATestReconciler(wa)
@@ -98,11 +112,10 @@ func TestReconcile_WithMatchLabels_Ready(t *testing.T) {
 			Name:       "label-authorizer",
 			Generation: 2,
 		},
-		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{
-			NamespaceSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{"env": "dev"},
-			},
-		},
+		Spec: validWebhookAuthorizerSpec(),
+	}
+	wa.Spec.NamespaceSelector = metav1.LabelSelector{
+		MatchLabels: map[string]string{"env": "dev"},
 	}
 
 	r, c := newWATestReconciler(wa, ns)
@@ -132,15 +145,14 @@ func TestReconcile_WithMatchExpressions_Ready(t *testing.T) {
 			Name:       "expr-authorizer",
 			Generation: 1,
 		},
-		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{
-			NamespaceSelector: metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      "tier",
-						Operator: metav1.LabelSelectorOpIn,
-						Values:   []string{"frontend", "backend"},
-					},
-				},
+		Spec: validWebhookAuthorizerSpec(),
+	}
+	wa.Spec.NamespaceSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "tier",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"frontend", "backend"},
 			},
 		},
 	}
@@ -165,15 +177,14 @@ func TestReconcile_InvalidMatchExpression_Stalled(t *testing.T) {
 			Name:       "bad-authorizer",
 			Generation: 1,
 		},
-		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{
-			NamespaceSelector: metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      "tier",
-						Operator: metav1.LabelSelectorOperator("InvalidOp"),
-						Values:   []string{"frontend"},
-					},
-				},
+		Spec: validWebhookAuthorizerSpec(),
+	}
+	wa.Spec.NamespaceSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "tier",
+				Operator: metav1.LabelSelectorOperator("InvalidOp"),
+				Values:   []string{"frontend"},
 			},
 		},
 	}
@@ -195,6 +206,86 @@ func TestReconcile_InvalidMatchExpression_Stalled(t *testing.T) {
 	g.Expect(conditions.IsReady(&updated)).To(gomega.BeFalse())
 }
 
+func TestReconcile_InvalidSpec_Stalled(t *testing.T) {
+	tests := []struct {
+		name string
+		spec authorizationv1alpha1.WebhookAuthorizerSpec
+	}{
+		{
+			name: "empty spec",
+			spec: authorizationv1alpha1.WebhookAuthorizerSpec{},
+		},
+		{
+			name: "rules without principals",
+			spec: authorizationv1alpha1.WebhookAuthorizerSpec{
+				ResourceRules: []authzv1.ResourceRule{{
+					Verbs:     []string{"get"},
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+				}},
+			},
+		},
+		{
+			name: "empty allowed principal",
+			spec: authorizationv1alpha1.WebhookAuthorizerSpec{
+				ResourceRules: []authzv1.ResourceRule{{
+					Verbs:     []string{"get"},
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+				}},
+				AllowedPrincipals: []authorizationv1alpha1.Principal{{}},
+			},
+		},
+		{
+			name: "resource rule without verbs",
+			spec: authorizationv1alpha1.WebhookAuthorizerSpec{
+				ResourceRules: []authzv1.ResourceRule{{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+				}},
+				AllowedPrincipals: []authorizationv1alpha1.Principal{{User: "admin"}},
+			},
+		},
+		{
+			name: "non-resource rule without URLs",
+			spec: authorizationv1alpha1.WebhookAuthorizerSpec{
+				NonResourceRules: []authzv1.NonResourceRule{{
+					Verbs: []string{"get"},
+				}},
+				AllowedPrincipals: []authorizationv1alpha1.Principal{{User: "admin"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			wa := &authorizationv1alpha1.WebhookAuthorizer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "invalid-authorizer",
+					Generation: 1,
+				},
+				Spec: tt.spec,
+			}
+
+			r, c := newWATestReconciler(wa)
+
+			result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("invalid-authorizer"))
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+
+			var updated authorizationv1alpha1.WebhookAuthorizer
+			g.Expect(c.Get(ctxWithLogger(), types.NamespacedName{Name: "invalid-authorizer"}, &updated)).To(gomega.Succeed())
+			g.Expect(updated.Status.ObservedGeneration).To(gomega.Equal(int64(1)))
+			g.Expect(updated.Status.AuthorizerConfigured).To(gomega.BeFalse())
+			g.Expect(conditions.IsStalled(&updated)).To(gomega.BeTrue())
+			g.Expect(conditions.IsReady(&updated)).To(gomega.BeFalse())
+			g.Expect(conditions.IsReconciling(&updated)).To(gomega.BeFalse())
+		})
+	}
+}
+
 func TestReconcile_GenerationUpdate(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -203,7 +294,7 @@ func TestReconcile_GenerationUpdate(t *testing.T) {
 			Name:       "gen-authorizer",
 			Generation: 5,
 		},
-		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{},
+		Spec: validWebhookAuthorizerSpec(),
 	}
 
 	r, c := newWATestReconciler(wa)
@@ -226,6 +317,11 @@ func TestReconcile_WithPrincipals_Ready(t *testing.T) {
 			Generation: 1,
 		},
 		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{
+			ResourceRules: []authzv1.ResourceRule{{
+				Verbs:     []string{"get"},
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+			}},
 			AllowedPrincipals: []authorizationv1alpha1.Principal{
 				{User: "admin", Groups: []string{"system:masters"}},
 			},
@@ -256,11 +352,10 @@ func TestReconcile_NoMatchingNamespaces_StillReady(t *testing.T) {
 			Name:       "no-match-authorizer",
 			Generation: 1,
 		},
-		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{
-			NamespaceSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{"env": "staging"},
-			},
-		},
+		Spec: validWebhookAuthorizerSpec(),
+	}
+	wa.Spec.NamespaceSelector = metav1.LabelSelector{
+		MatchLabels: map[string]string{"env": "staging"},
 	}
 
 	r, c := newWATestReconciler(wa)
@@ -374,11 +469,10 @@ func TestReconcile_TransientNamespaceListError_ReturnsError(t *testing.T) {
 			Name:       "transient-authorizer",
 			Generation: 1,
 		},
-		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{
-			NamespaceSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{"env": "prod"},
-			},
-		},
+		Spec: validWebhookAuthorizerSpec(),
+	}
+	wa.Spec.NamespaceSelector = metav1.LabelSelector{
+		MatchLabels: map[string]string{"env": "prod"},
 	}
 
 	scheme := newTestScheme()

--- a/internal/controller/authorization/webhookauthorizer_controller_test.go
+++ b/internal/controller/authorization/webhookauthorizer_controller_test.go
@@ -255,6 +255,19 @@ func TestReconcile_InvalidSpec_Stalled(t *testing.T) {
 				AllowedPrincipals: []authorizationv1alpha1.Principal{{User: "admin"}},
 			},
 		},
+		{
+			name: "non-resource rule with namespace selector",
+			spec: authorizationv1alpha1.WebhookAuthorizerSpec{
+				NonResourceRules: []authzv1.NonResourceRule{{
+					Verbs:           []string{"get"},
+					NonResourceURLs: []string{"/logs"},
+				}},
+				AllowedPrincipals: []authorizationv1alpha1.Principal{{User: "admin"}},
+				NamespaceSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"environment": "prod"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/authorization/webhookauthorizer_controller_test.go
+++ b/internal/controller/authorization/webhookauthorizer_controller_test.go
@@ -14,6 +14,7 @@ import (
 	authzv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -297,6 +298,49 @@ func TestReconcile_InvalidSpec_Stalled(t *testing.T) {
 			g.Expect(conditions.IsReconciling(&updated)).To(gomega.BeFalse())
 		})
 	}
+}
+
+func TestReconcile_InvalidSpec_StalledWithoutReconcilingApply(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	wa := &authorizationv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "invalid-authorizer",
+			Generation: 1,
+		},
+		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{},
+	}
+
+	scheme := newTestScheme()
+	statusApplyCount := 0
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(wa).
+		WithStatusSubresource(&authorizationv1alpha1.WebhookAuthorizer{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceApply: func(ctx context.Context, cl client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+				if subResourceName == "status" {
+					statusApplyCount++
+				}
+				return cl.SubResource(subResourceName).Apply(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	recorder := events.NewFakeRecorder(10)
+	r := NewWebhookAuthorizerReconciler(c, scheme, recorder)
+
+	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("invalid-authorizer"))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(statusApplyCount).To(gomega.Equal(1), "invalid specs should skip the intermediate Reconciling status apply")
+
+	var updated authorizationv1alpha1.WebhookAuthorizer
+	g.Expect(c.Get(ctxWithLogger(), types.NamespacedName{Name: "invalid-authorizer"}, &updated)).To(gomega.Succeed())
+	g.Expect(updated.Status.ObservedGeneration).To(gomega.Equal(int64(1)))
+	g.Expect(updated.Status.AuthorizerConfigured).To(gomega.BeFalse())
+	g.Expect(conditions.IsStalled(&updated)).To(gomega.BeTrue())
+	g.Expect(conditions.IsReady(&updated)).To(gomega.BeFalse())
+	g.Expect(conditions.IsReconciling(&updated)).To(gomega.BeFalse())
 }
 
 func TestReconcile_GenerationUpdate(t *testing.T) {

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	authorizationv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
+	"github.com/telekom/auth-operator/pkg/conditions"
 	"github.com/telekom/auth-operator/pkg/helpers"
 	pkgmetrics "github.com/telekom/auth-operator/pkg/metrics"
 	"github.com/telekom/auth-operator/pkg/tracing"
@@ -506,7 +507,31 @@ func (wa *Authorizer) listAllAuthorizers(ctx context.Context) ([]authorizationv1
 	if err := wa.Client.List(listCtx, &allAuth); err != nil {
 		return nil, fmt.Errorf("list WebhookAuthorizers: %w", err)
 	}
-	return allAuth.Items, nil
+	items := make([]authorizationv1alpha1.WebhookAuthorizer, 0, len(allAuth.Items))
+	for _, item := range allAuth.Items {
+		if !authorizerReadyForEvaluation(item) {
+			wa.Log.V(2).Info("skipping unconfigured WebhookAuthorizer",
+				"authorizer", item.Name,
+				"generation", item.Generation,
+				"observedGeneration", item.Status.ObservedGeneration)
+			continue
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func authorizerReadyForEvaluation(item authorizationv1alpha1.WebhookAuthorizer) bool {
+	if item.Status.ObservedGeneration == 0 && len(item.Status.Conditions) == 0 {
+		return true
+	}
+	if item.Generation > 0 && item.Status.ObservedGeneration > 0 && item.Status.ObservedGeneration != item.Generation {
+		return false
+	}
+	if len(item.Status.Conditions) > 0 && !conditions.IsReady(&item) {
+		return false
+	}
+	return item.Status.AuthorizerConfigured
 }
 
 type namespaceLabelCacheEntry struct {

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	authzv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
+	"github.com/telekom/auth-operator/pkg/conditions"
 	"github.com/telekom/auth-operator/pkg/indexer"
 	pkgmetrics "github.com/telekom/auth-operator/pkg/metrics"
 )
@@ -2266,5 +2267,86 @@ func TestServeHTTP_NamespaceLabelCacheError_ReturnsDeniedSAR(t *testing.T) {
 	}
 	if resp.Status.Reason != "internal evaluation error" {
 		t.Fatalf("expected generic internal evaluation reason, got %q", resp.Status.Reason)
+	}
+}
+
+func TestServeHTTP_SkipsUnconfiguredAuthorizers(t *testing.T) {
+	scheme := newScheme(t)
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "team-a",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
+	stalled := &authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "aaa-stalled", Generation: 1},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			NamespaceSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "env",
+					Operator: metav1.LabelSelectorOpIn,
+				}},
+			},
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "alice"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+		},
+	}
+	conditions.MarkStalled(stalled, stalled.Generation,
+		authzv1alpha1.StalledReasonError, authzv1alpha1.StalledMessageError)
+	stalled.Status.ObservedGeneration = stalled.Generation
+	stalled.Status.AuthorizerConfigured = false
+
+	configured := &authzv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "zzz-configured", Generation: 1},
+		Spec: authzv1alpha1.WebhookAuthorizerSpec{
+			NamespaceSelector: metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+			AllowedPrincipals: []authzv1alpha1.Principal{{User: "alice"}},
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+		},
+	}
+	conditions.MarkReady(configured, configured.Generation,
+		authzv1alpha1.ReadyReasonReconciled, authzv1alpha1.ReadyMessageReconciled)
+	configured.Status.ObservedGeneration = configured.Generation
+	configured.Status.AuthorizerConfigured = true
+
+	handler := &Authorizer{
+		Client: newIndexedClient(scheme, ns, stalled, configured),
+		Log:    logr.Discard(),
+	}
+
+	pkgmetrics.AuthorizerActiveRules.Set(0)
+	sar := authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: "alice",
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Namespace: "team-a",
+				Verb:      "get",
+				Resource:  "pods",
+			},
+		},
+	}
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(marshalSAR(t, sar)))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d; body: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var resp authzv1.SubjectAccessReview
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !resp.Status.Allowed {
+		t.Fatalf("expected request to be allowed by configured authorizer, got %+v", resp.Status)
+	}
+	if resp.Status.Reason != "Access granted by WebhookAuthorizer" {
+		t.Fatalf("expected public allow reason, got %q", resp.Status.Reason)
+	}
+	if activeRules := testutil.ToFloat64(pkgmetrics.AuthorizerActiveRules); activeRules != 1 {
+		t.Fatalf("expected AuthorizerActiveRules to count only configured rules, got %v", activeRules)
 	}
 }

--- a/test/e2e/complex_e2e_test.go
+++ b/test/e2e/complex_e2e_test.go
@@ -550,10 +550,8 @@ var _ = Describe("Complex Feature Combinations", Ordered, Label("complex"), func
 			deniedPrincipals := spec["deniedPrincipals"].([]interface{})
 			Expect(deniedPrincipals).To(HaveLen(3), "Should have 3 deniedPrincipals")
 
-			// Verify namespaceSelector
-			nsSelector := spec["namespaceSelector"].(map[string]interface{})
-			Expect(nsSelector).To(HaveKey("matchLabels"))
-			Expect(nsSelector).To(HaveKey("matchExpressions"))
+			_, hasNamespaceSelector := spec["namespaceSelector"]
+			Expect(hasNamespaceSelector).To(BeFalse(), "NonResourceRules cannot be combined with namespaceSelector")
 		})
 	})
 

--- a/test/e2e/testdata/complex/webhookauthorizer-full-featured.yaml
+++ b/test/e2e/testdata/complex/webhookauthorizer-full-featured.yaml
@@ -3,7 +3,6 @@
 # - NonResourceRules for URLs
 # - AllowedPrincipals with users and groups
 # - DeniedPrincipals (deny takes precedence)
-# - NamespaceSelector
 apiVersion: authorization.t-caas.telekom.com/v1alpha1
 kind: WebhookAuthorizer
 metadata:
@@ -82,13 +81,3 @@ spec:
         - temporary-access
     - user: restricted-sa
       namespace: kube-system
-  # Only allow in matching namespaces
-  namespaceSelector:
-    matchLabels:
-      authorization.t-caas.telekom.com/managed: "true"
-    matchExpressions:
-      - key: environment
-        operator: In
-        values:
-          - development
-          - staging


### PR DESCRIPTION
## Summary
- export and reuse the WebhookAuthorizer semantic validator from admission in the reconciler
- reject missing principals in the Go validator, matching the CRD/CEL contract used by admission
- reject `namespaceSelector` with `nonResourceRules`, because non-resource requests do not carry namespaces and scoped authorizers are skipped for them
- keep legacy or webhook-bypassed invalid WebhookAuthorizers unconfigured and Stalled instead of Ready
- skip explicitly unconfigured, non-ready, or stale-generation WebhookAuthorizers in the runtime `/authorize` path
- remove invalid `namespaceSelector` usage from the sample and complex e2e fixture that still combined it with `nonResourceRules`

## Evidence
A WebhookAuthorizer with an empty or semantically invalid spec can exist if admission/CEL was bypassed or from legacy state. The reconciler previously only validated `namespaceSelector` and then set `authorizerConfigured=true` and Ready=True.

A WebhookAuthorizer that combines `namespaceSelector` with `nonResourceRules` is also misleading: non-resource SubjectAccessReviews have no namespace, so scoped authorizers are not evaluated for them. After the validator started rejecting that combination, CI failed because `test/e2e/testdata/complex/webhookauthorizer-full-featured.yaml` still used the invalid combination.

Runtime audit also found that a Stalled authorizer could still be evaluated by `/authorize`. For a legacy invalid scoped authorizer, that could fail closed with `internal evaluation error` before a valid configured authorizer was considered. The runtime now evaluates statusless fixtures/fresh objects, but skips statuses that are explicitly Stalled/Reconciling, unconfigured, or stale for their generation.

Duplicate check: `gh pr list --repo telekom/auth-operator --state open --search 'WebhookAuthorizer stalled authorizerConfigured runtime authorize' --json number,title,url,headRefName --limit 20` returned no matching open PRs.

## Validation
- `go test ./internal/webhook/authorization -run 'TestServeHTTP_SkipsUnconfiguredAuthorizers|TestServeHTTP_NamespaceLabelCacheError_ReturnsDeniedSAR|TestMetrics_ActiveRulesCountsMixedGlobalAndScopedAuthorizers' -count=1`
- `go test ./internal/webhook/authorization -count=1`
- `go test ./api/authorization/v1alpha1 ./internal/controller/authorization -count=1`
- `golangci-lint run --timeout 10m --new-from-rev origin/main ./internal/webhook/authorization/...`
- `go test -tags e2e ./test/e2e/ -run TestE2E -count=0`
- `SKIP_E2E_CLEANUP=false E2E_RECREATE_CLUSTER=true make test-e2e-complex` (29 passed, 0 failed)
- `git diff --check`

Previous validation before this update also covered the exported validator and controller stalling paths:
- `go test ./internal/controller/authorization -run 'TestReconcile_(EmptySelector_Ready|WithMatchLabels_Ready|WithMatchExpressions_Ready|InvalidMatchExpression_Stalled|InvalidSpec_Stalled|GenerationUpdate|WithPrincipals_Ready|NoMatchingNamespaces_StillReady|TransientNamespaceListError_ReturnsError)' -count=1`
- `go test ./api/authorization/v1alpha1 -run 'TestValidateCreate_(ValidMinimal|EmptyRules|RejectsNoPrincipals|RejectsEmptyAllowedPrincipal|RejectsEmptyDeniedPrincipal|WarnsEmptyAllowedPrincipals|RejectsNamespaceSelectorWithNonResourceRules)|TestValidateUpdate_RejectsEmptyPrincipal' -count=1`
- `KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.34.1 --bin-dir ./bin -p path)" go test ./api/authorization/v1alpha1 -count=1`
- `KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.34.1 --bin-dir ./bin -p path)" go test ./internal/controller/authorization -count=1`



### Review follow-up 2026-06-27

- Target verification: refreshed PR #372 as targeting upstream `telekom/auth-operator:main`; source branch remains `telekom/auth-operator:codex/webhookauthorizer-invalid-spec`.
- Duplicate check before branch update: `WebhookAuthorizer invalid legacy spec Stalled Reconciling semantic validation` open search returned no matches; recently merged search (`updated:>=2026-06-13`) returned #224 as adjacent Restricted CRD work, not the WebhookAuthorizer invalid-spec stall path.
- Review fix: semantic spec validation now runs before the early Reconciling status apply, the step comments are renumbered, and invalid legacy specs have a regression test proving a single direct Stalled status apply without Reconciling flicker.
- Local validation: `GOCACHE=/private/tmp/auth-operator-go-build-cache go test -timeout=4m ./internal/controller/authorization -run 'TestReconcile_(InvalidSpec_Stalled|InvalidSpec_StalledWithoutReconcilingApply|InvalidMatchExpression_Stalled|TransientNamespaceListError_ReturnsError)$'`; `git -c core.fsmonitor=false diff --check`.
