### PR TITLE
fix(roledefinition): validate target fields in webhook

### DIFF
--- a/api/authorization/v1alpha1/restrictedroledefinition_types_test.go
+++ b/api/authorization/v1alpha1/restrictedroledefinition_types_test.go
@@ -5,6 +5,8 @@
 package v1alpha1
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -145,6 +147,56 @@ func TestRestrictedRoleDefinitionClusterRoleSpec(t *testing.T) {
 	}
 	if rrd.Spec.TargetNamespace != "" {
 		t.Errorf("expected empty targetNamespace, got %q", rrd.Spec.TargetNamespace)
+	}
+}
+
+func TestValidateRestrictedRoleDefinitionTargetFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		rrd     *RestrictedRoleDefinition
+		wantErr string
+	}{
+		{
+			name: "reject missing target fields",
+			rrd: &RestrictedRoleDefinition{
+				Spec: RestrictedRoleDefinitionSpec{},
+			},
+			wantErr: "targetRole is required",
+		},
+		{
+			name: "reject invalid targetRole",
+			rrd: &RestrictedRoleDefinition{
+				Spec: RestrictedRoleDefinitionSpec{
+					TargetRole: "InvalidRole",
+					TargetName: "tenant-role",
+				},
+			},
+			wantErr: "supported values: \"ClusterRole\", \"Role\"",
+		},
+		{
+			name: "reject invalid targetNamespace",
+			rrd: &RestrictedRoleDefinition{
+				Spec: RestrictedRoleDefinitionSpec{
+					TargetRole:      DefinitionNamespacedRole,
+					TargetName:      "tenant-role",
+					TargetNamespace: "Bad/Name",
+				},
+			},
+			wantErr: "spec.targetNamespace",
+		},
+	}
+
+	validator := &RestrictedRoleDefinitionValidator{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.validateRestrictedRoleDefinitionSpec(context.Background(), tt.rrd)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
 	}
 }
 

--- a/api/authorization/v1alpha1/restrictedroledefinition_types_test.go
+++ b/api/authorization/v1alpha1/restrictedroledefinition_types_test.go
@@ -184,6 +184,27 @@ func TestValidateRestrictedRoleDefinitionTargetFields(t *testing.T) {
 			},
 			wantErr: "spec.targetNamespace",
 		},
+		{
+			name: "reject Role without targetNamespace",
+			rrd: &RestrictedRoleDefinition{
+				Spec: RestrictedRoleDefinitionSpec{
+					TargetRole: DefinitionNamespacedRole,
+					TargetName: "tenant-role",
+				},
+			},
+			wantErr: "targetNamespace is required when targetRole is 'Role'",
+		},
+		{
+			name: "reject ClusterRole with targetNamespace",
+			rrd: &RestrictedRoleDefinition{
+				Spec: RestrictedRoleDefinitionSpec{
+					TargetRole:      DefinitionClusterRole,
+					TargetName:      "tenant-role",
+					TargetNamespace: "tenant-a",
+				},
+			},
+			wantErr: "targetNamespace must be empty when targetRole is 'ClusterRole'",
+		},
 	}
 
 	validator := &RestrictedRoleDefinitionValidator{}

--- a/api/authorization/v1alpha1/restrictedroledefinition_webhook.go
+++ b/api/authorization/v1alpha1/restrictedroledefinition_webhook.go
@@ -190,6 +190,16 @@ func (v *RestrictedRoleDefinitionValidator) defaultPolicyReader() client.Reader 
 func (v *RestrictedRoleDefinitionValidator) validateRestrictedRoleDefinitionSpec(ctx context.Context, obj *RestrictedRoleDefinition) error {
 	logger := log.FromContext(ctx).WithName("restrictedroledefinition-webhook")
 
+	if err := validateRoleTargetFields(
+		schema.GroupKind{Group: GroupVersion.Group, Kind: RestrictedRoleDefinitionKind},
+		obj.Name,
+		obj.Spec.TargetRole,
+		obj.Spec.TargetName,
+		obj.Spec.TargetNamespace,
+	); err != nil {
+		return err
+	}
+
 	// Check duplicate targetName. Collisions are scoped by targetRole and,
 	// for Role targets, targetNamespace.
 	existingRRD, err := v.findRestrictedRoleDefinitionTargetNameConflict(ctx, obj)

--- a/api/authorization/v1alpha1/roledefinition_types_test.go
+++ b/api/authorization/v1alpha1/roledefinition_types_test.go
@@ -224,6 +224,34 @@ func TestValidateRoleDefinitionSpec(t *testing.T) {
 			wantErr: "matchExpressions are not allowed",
 		},
 		{
+			name: "reject missing target fields",
+			rd: &RoleDefinition{
+				Spec: RoleDefinitionSpec{},
+			},
+			wantErr: "targetRole is required",
+		},
+		{
+			name: "reject invalid targetRole",
+			rd: &RoleDefinition{
+				Spec: RoleDefinitionSpec{
+					TargetRole: "InvalidRole",
+					TargetName: "test-role",
+				},
+			},
+			wantErr: "supported values: \"ClusterRole\", \"Role\"",
+		},
+		{
+			name: "reject invalid targetNamespace",
+			rd: &RoleDefinition{
+				Spec: RoleDefinitionSpec{
+					TargetRole:      DefinitionNamespacedRole,
+					TargetName:      "test-role",
+					TargetNamespace: "Bad/Name",
+				},
+			},
+			wantErr: "spec.targetNamespace",
+		},
+		{
 			name: "reject Role without targetNamespace",
 			rd: &RoleDefinition{
 				Spec: RoleDefinitionSpec{

--- a/api/authorization/v1alpha1/roledefinition_webhook.go
+++ b/api/authorization/v1alpha1/roledefinition_webhook.go
@@ -349,13 +349,14 @@ func validateRoleTargetFields(
 	targetNamespace string,
 ) error {
 	var allErrs field.ErrorList
-	if targetRole == "" {
+	switch {
+	case targetRole == "":
 		allErrs = append(allErrs, field.Required(field.NewPath("spec", "targetRole"), "targetRole is required"))
-	} else if targetRole != DefinitionClusterRole && targetRole != DefinitionNamespacedRole {
+	case targetRole != DefinitionClusterRole && targetRole != DefinitionNamespacedRole:
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "targetRole"), targetRole, []string{DefinitionClusterRole, DefinitionNamespacedRole}))
-	} else if targetRole == DefinitionNamespacedRole && targetNamespace == "" {
+	case targetRole == DefinitionNamespacedRole && targetNamespace == "":
 		allErrs = append(allErrs, field.Required(field.NewPath("spec", "targetNamespace"), "targetNamespace is required when targetRole is 'Role'"))
-	} else if targetRole == DefinitionClusterRole && targetNamespace != "" {
+	case targetRole == DefinitionClusterRole && targetNamespace != "":
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "targetNamespace"), "targetNamespace must be empty when targetRole is 'ClusterRole'"))
 	}
 	if targetName == "" {

--- a/api/authorization/v1alpha1/roledefinition_webhook.go
+++ b/api/authorization/v1alpha1/roledefinition_webhook.go
@@ -14,6 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -278,6 +279,16 @@ func (v *RoleDefinitionValidator) ValidateDelete(ctx context.Context, obj *RoleD
 
 // validateRoleDefinitionSpec validates the RoleDefinition spec fields.
 func validateRoleDefinitionSpec(obj *RoleDefinition) error {
+	if err := validateRoleTargetFields(
+		schema.GroupKind{Group: GroupVersion.Group, Kind: "RoleDefinition"},
+		obj.Name,
+		obj.Spec.TargetRole,
+		obj.Spec.TargetName,
+		obj.Spec.TargetNamespace,
+	); err != nil {
+		return err
+	}
+
 	// breakglassAllowed is only meaningful for ClusterRoles — Roles are
 	// namespace-scoped and not eligible for breakglass escalation.
 	if obj.Spec.BreakglassAllowed && obj.Spec.TargetRole == DefinitionNamespacedRole {
@@ -337,6 +348,33 @@ func validateRoleDefinitionSpec(obj *RoleDefinition) error {
 		}
 	}
 
+	return nil
+}
+
+func validateRoleTargetFields(
+	kind schema.GroupKind,
+	name string,
+	targetRole string,
+	targetName string,
+	targetNamespace string,
+) error {
+	var allErrs field.ErrorList
+	if targetRole == "" {
+		allErrs = append(allErrs, field.Required(field.NewPath("spec", "targetRole"), "targetRole is required"))
+	} else if targetRole != DefinitionClusterRole && targetRole != DefinitionNamespacedRole {
+		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "targetRole"), targetRole, []string{DefinitionClusterRole, DefinitionNamespacedRole}))
+	}
+	if targetName == "" {
+		allErrs = append(allErrs, field.Required(field.NewPath("spec", "targetName"), "targetName is required"))
+	}
+	if targetNamespace != "" {
+		for _, msg := range utilvalidation.IsDNS1123Label(targetNamespace) {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "targetNamespace"), targetNamespace, msg))
+		}
+	}
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(kind, name, allErrs)
+	}
 	return nil
 }
 

--- a/api/authorization/v1alpha1/roledefinition_webhook.go
+++ b/api/authorization/v1alpha1/roledefinition_webhook.go
@@ -306,16 +306,6 @@ func validateRoleDefinitionSpec(obj *RoleDefinition) error {
 		return err
 	}
 
-	// Validate TargetNamespace is required when TargetRole is Role
-	if obj.Spec.TargetRole == DefinitionNamespacedRole && obj.Spec.TargetNamespace == "" {
-		return apierrors.NewBadRequest("targetNamespace is required when targetRole is 'Role'")
-	}
-
-	// Validate TargetNamespace must not be set when TargetRole is ClusterRole
-	if obj.Spec.TargetRole == DefinitionClusterRole && obj.Spec.TargetNamespace != "" {
-		return apierrors.NewBadRequest("targetNamespace must be empty when targetRole is 'ClusterRole'")
-	}
-
 	// Metadata labels propagate to the generated Role or ClusterRole. Reject
 	// Kubernetes RBAC aggregation labels for every targetRole so reconciliation
 	// does not silently drop admitted input.
@@ -363,11 +353,15 @@ func validateRoleTargetFields(
 		allErrs = append(allErrs, field.Required(field.NewPath("spec", "targetRole"), "targetRole is required"))
 	} else if targetRole != DefinitionClusterRole && targetRole != DefinitionNamespacedRole {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "targetRole"), targetRole, []string{DefinitionClusterRole, DefinitionNamespacedRole}))
+	} else if targetRole == DefinitionNamespacedRole && targetNamespace == "" {
+		allErrs = append(allErrs, field.Required(field.NewPath("spec", "targetNamespace"), "targetNamespace is required when targetRole is 'Role'"))
+	} else if targetRole == DefinitionClusterRole && targetNamespace != "" {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "targetNamespace"), "targetNamespace must be empty when targetRole is 'ClusterRole'"))
 	}
 	if targetName == "" {
 		allErrs = append(allErrs, field.Required(field.NewPath("spec", "targetName"), "targetName is required"))
 	}
-	if targetNamespace != "" {
+	if targetNamespace != "" && targetRole != DefinitionClusterRole {
 		for _, msg := range utilvalidation.IsDNS1123Label(targetNamespace) {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "targetNamespace"), targetNamespace, msg))
 		}


### PR DESCRIPTION
## Summary
- add a shared admission backstop for RoleDefinition and RestrictedRoleDefinition target fields
- reject missing `targetRole` / `targetName` before duplicate lookups or reconciliation
- reject unsupported target roles and malformed `targetNamespace` values when webhook/schema validation is bypassed
- cover both RoleDefinition families with direct validator tests

## Evidence
The CRD schema requires target fields inside `spec`, but `spec` itself can be omitted and webhook validation did not explicitly reject empty target fields. `targetNamespace` was also an unconstrained string in both RoleDefinition APIs and is passed directly into generated Role objects.

## Validation
- `go test ./api/authorization/v1alpha1 -run 'TestValidateRoleDefinitionSpec|TestValidateRestrictedRoleDefinitionTargetFields' -count=1`\n- `golangci-lint run --timeout 10m ./api/authorization/v1alpha1/...`\n- `KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.34.1 --bin-dir ./bin -p path)" go test ./api/authorization/v1alpha1 -count=1`\n- `git diff --check`


### Review follow-up 2026-06-27

- Target verification: refreshed PR #373 as targeting upstream `telekom/auth-operator:main`; source branch remains `telekom/auth-operator:codex/roledefinition-target-validation`.
- Duplicate check before branch update: `RestrictedRoleDefinition targetNamespace Role ClusterRole webhook validation` open search returned no matches; recently merged search (`updated:>=2026-06-13`) returned adjacent authz/CI/dependency work (#342, #339, #343, #335, #333, #337, #336, #334, #224, #271), none covering this RestrictedRoleDefinition target-field webhook backstop.
- Review fix: moved Role/ClusterRole targetNamespace invariants into the shared target-field validator and added RestrictedRoleDefinition regression cases for missing Role targetNamespace and forbidden ClusterRole targetNamespace.
- Local validation: `GOCACHE=/private/tmp/auth-operator-go-build-cache go test -timeout=4m ./api/authorization/v1alpha1 -run 'TestValidate(RoleDefinitionSpec|RestrictedRoleDefinitionTargetFields)$'`; `git -c core.fsmonitor=false diff --check`.



### CI follow-up 2026-06-27

- Target verification: refreshed PR #373 as targeting upstream `telekom/auth-operator:main`; source branch remains `telekom/auth-operator:codex/roledefinition-target-validation`.
- Duplicate check before branch update: `validateRoleTargetFields ifElseChain switch targetNamespace RestrictedRoleDefinition` open and recently merged searches returned no matches.
- CI fix: rewrote the target-role validation chain as a switch to satisfy gocritic `ifElseChain` without changing validation semantics.
- Local validation: `GOCACHE=/private/tmp/auth-operator-go-build-cache go test -timeout=4m ./api/authorization/v1alpha1 -run 'TestValidate(RoleDefinitionSpec|RestrictedRoleDefinitionTargetFields)$'`; `git -c core.fsmonitor=false diff --check`.
