### PR TITLE
fix(binddefinition): validate subject shapes in webhook

### DIFF
--- a/api/authorization/v1alpha1/binddefinition_webhook.go
+++ b/api/authorization/v1alpha1/binddefinition_webhook.go
@@ -527,7 +527,7 @@ func validateBindDefinitionRequiredFields(kind schema.GroupKind, obj *BindDefini
 		}
 	}
 	if !hasReferencedRole {
-		allErrs = append(allErrs, field.Required(field.NewPath("spec", "clusterRoleBindings", "clusterRoleRefs"), "at least one binding with a referenced role must be specified"))
+		allErrs = append(allErrs, field.Required(field.NewPath("spec"), "at least one binding with a referenced role must be specified"))
 	}
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(kind, obj.Name, allErrs)

--- a/api/authorization/v1alpha1/binddefinition_webhook.go
+++ b/api/authorization/v1alpha1/binddefinition_webhook.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -103,6 +104,14 @@ func (v *BindDefinitionValidator) validateBindDefinitionSpec(ctx context.Context
 	logger := log.FromContext(ctx).WithName("binddefinition-webhook")
 	var warnings admission.Warnings
 
+	kind := schema.GroupKind{Group: GroupVersion.Group, Kind: BindDefinitionKind}
+	if err := validateBindDefinitionRequiredFields(kind, r); err != nil {
+		return warnings, err
+	}
+	if err := validateBindDefinitionSubjects(kind, r.Name, r.Spec.Subjects); err != nil {
+		return warnings, err
+	}
+
 	existingBD, err := v.findBindDefinitionTargetNameConflict(ctx, r)
 	if err != nil {
 		logger.Error(err, "failed to list BindDefinitions", "targetName", r.Spec.TargetName)
@@ -125,23 +134,9 @@ func (v *BindDefinitionValidator) validateBindDefinitionSpec(ctx context.Context
 			fmt.Sprintf("targetName %s is already in use by RestrictedBindDefinition %q", r.Spec.TargetName, existingRBD.Name))
 	}
 
-	// Validate subject Kinds are one of the RBAC-supported types.
-	for i, subject := range r.Spec.Subjects {
-		switch subject.Kind {
-		case rbacv1.UserKind, rbacv1.GroupKind, rbacv1.ServiceAccountKind:
-			// valid
-		default:
-			fldErr := field.NotSupported(field.NewPath("spec", "subjects").Index(i).Child("kind"), subject.Kind, supportedSubjectKinds)
-			return warnings, apierrors.NewInvalid(
-				schema.GroupKind{Group: GroupVersion.Group, Kind: "BindDefinition"},
-				r.Name, field.ErrorList{fldErr})
-		}
-	}
-
 	// Determine the missing-role policy from annotation.
 	policy := r.GetMissingRolePolicy()
 
-	kind := schema.GroupKind{Group: GroupVersion.Group, Kind: BindDefinitionKind}
 	if err := validateNamespaceBindings(kind, r.Name, r.Spec.RoleBindings); err != nil {
 		logger.Info("validation failed: invalid roleBindings", "name", r.Name, "error", err.Error())
 		return warnings, err
@@ -512,6 +507,66 @@ func validateNamespaceBindings(kind schema.GroupKind, name string, bindings []Na
 						err.Error())})
 			}
 		}
+	}
+	return nil
+}
+
+func validateBindDefinitionRequiredFields(kind schema.GroupKind, obj *BindDefinition) error {
+	var allErrs field.ErrorList
+	if obj.Spec.TargetName == "" {
+		allErrs = append(allErrs, field.Required(field.NewPath("spec", "targetName"), "targetName is required"))
+	}
+	if len(obj.Spec.Subjects) == 0 {
+		allErrs = append(allErrs, field.Required(field.NewPath("spec", "subjects"), "at least one subject must be specified"))
+	}
+	hasReferencedRole := len(obj.Spec.ClusterRoleBindings.ClusterRoleRefs) > 0
+	for _, binding := range obj.Spec.RoleBindings {
+		if len(binding.ClusterRoleRefs) > 0 || len(binding.RoleRefs) > 0 {
+			hasReferencedRole = true
+			break
+		}
+	}
+	if !hasReferencedRole {
+		allErrs = append(allErrs, field.Required(field.NewPath("spec", "clusterRoleBindings", "clusterRoleRefs"), "at least one binding with a referenced role must be specified"))
+	}
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(kind, obj.Name, allErrs)
+	}
+	return nil
+}
+
+func validateBindDefinitionSubjects(kind schema.GroupKind, name string, subjects []rbacv1.Subject) error {
+	var allErrs field.ErrorList
+	for i, subject := range subjects {
+		subjectPath := field.NewPath("spec", "subjects").Index(i)
+		if subject.Name == "" {
+			allErrs = append(allErrs, field.Required(subjectPath.Child("name"), "subject name is required"))
+		}
+		switch subject.Kind {
+		case rbacv1.UserKind, rbacv1.GroupKind:
+			if subject.APIGroup != rbacv1.GroupName {
+				allErrs = append(allErrs, field.Invalid(subjectPath.Child("apiGroup"), subject.APIGroup, "User and Group subjects must use rbac.authorization.k8s.io"))
+			}
+			if subject.Namespace != "" {
+				allErrs = append(allErrs, field.Forbidden(subjectPath.Child("namespace"), "User and Group subjects must not set namespace"))
+			}
+		case rbacv1.ServiceAccountKind:
+			if subject.APIGroup != "" {
+				allErrs = append(allErrs, field.Forbidden(subjectPath.Child("apiGroup"), "ServiceAccount subjects must not set apiGroup"))
+			}
+			if subject.Namespace == "" {
+				allErrs = append(allErrs, field.Required(subjectPath.Child("namespace"), "ServiceAccount subjects must specify a namespace"))
+			} else {
+				for _, msg := range utilvalidation.IsDNS1123Label(subject.Namespace) {
+					allErrs = append(allErrs, field.Invalid(subjectPath.Child("namespace"), subject.Namespace, msg))
+				}
+			}
+		default:
+			allErrs = append(allErrs, field.NotSupported(subjectPath.Child("kind"), subject.Kind, supportedSubjectKinds))
+		}
+	}
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(kind, name, allErrs)
 	}
 	return nil
 }

--- a/api/authorization/v1alpha1/binddefinition_webhook_unit_test.go
+++ b/api/authorization/v1alpha1/binddefinition_webhook_unit_test.go
@@ -157,6 +157,103 @@ func TestBindDefinitionValidatorSanitizesInternalErrors(t *testing.T) {
 	}
 }
 
+func TestBindDefinitionValidatorRejectsRequiredAndSubjectShape(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := AddToScheme(scheme); err != nil {
+		t.Fatalf("add authorization scheme: %v", err)
+	}
+	if err := rbacv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add rbac scheme: %v", err)
+	}
+
+	validator := &BindDefinitionValidator{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithIndex(&BindDefinition{}, TargetNameField, func(obj client.Object) []string {
+				return []string{obj.(*BindDefinition).Spec.TargetName}
+			}).
+			WithIndex(&RestrictedBindDefinition{}, TargetNameField, func(obj client.Object) []string {
+				return []string{obj.(*RestrictedBindDefinition).Spec.TargetName}
+			}).
+			Build(),
+	}
+
+	testCases := []struct {
+		name string
+		bd   *BindDefinition
+		want []string
+	}{
+		{
+			name: "empty spec",
+			bd: &BindDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty-spec"},
+			},
+			want: []string{"spec.targetName", "spec.subjects", "at least one binding"},
+		},
+		{
+			name: "empty subject name",
+			bd: bindDefinitionForSubjectValidation("empty-subject-name", []rbacv1.Subject{{
+				Kind:     rbacv1.UserKind,
+				APIGroup: rbacv1.GroupName,
+			}}),
+			want: []string{"spec.subjects[0].name", "subject name is required"},
+		},
+		{
+			name: "user subject namespace",
+			bd: bindDefinitionForSubjectValidation("user-namespace", []rbacv1.Subject{{
+				Kind:      rbacv1.UserKind,
+				APIGroup:  rbacv1.GroupName,
+				Name:      "alice",
+				Namespace: "default",
+			}}),
+			want: []string{"spec.subjects[0].namespace", "must not set namespace"},
+		},
+		{
+			name: "group subject apiGroup",
+			bd: bindDefinitionForSubjectValidation("group-apigroup", []rbacv1.Subject{{
+				Kind:     rbacv1.GroupKind,
+				APIGroup: "",
+				Name:     "team-a",
+			}}),
+			want: []string{"spec.subjects[0].apiGroup", rbacv1.GroupName},
+		},
+		{
+			name: "serviceaccount subject apiGroup",
+			bd: bindDefinitionForSubjectValidation("serviceaccount-apigroup", []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				APIGroup:  rbacv1.GroupName,
+				Name:      "robot",
+				Namespace: "default",
+			}}),
+			want: []string{"spec.subjects[0].apiGroup", "must not set apiGroup"},
+		},
+		{
+			name: "serviceaccount subject invalid namespace",
+			bd: bindDefinitionForSubjectValidation("serviceaccount-invalid-namespace", []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "robot",
+				Namespace: "Bad/Name",
+			}}),
+			want: []string{"spec.subjects[0].namespace", "Bad/Name"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validator.validateBindDefinitionSpec(context.Background(), tc.bd)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			got := err.Error()
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("expected error to contain %q, got %q", want, got)
+				}
+			}
+		})
+	}
+}
+
 func bindDefinitionForSanitization(name string, subjects []rbacv1.Subject, mutate func(*BindDefinitionSpec)) *BindDefinition {
 	spec := BindDefinitionSpec{
 		TargetName: name,
@@ -166,5 +263,23 @@ func bindDefinitionForSanitization(name string, subjects []rbacv1.Subject, mutat
 	return &BindDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec:       spec,
+	}
+}
+
+func bindDefinitionForSubjectValidation(name string, subjects []rbacv1.Subject) *BindDefinition {
+	return &BindDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				MissingRolePolicyAnnotation: string(MissingRolePolicyIgnore),
+			},
+		},
+		Spec: BindDefinitionSpec{
+			TargetName: name,
+			Subjects:   subjects,
+			ClusterRoleBindings: ClusterBinding{
+				ClusterRoleRefs: []string{"view"},
+			},
+		},
 	}
 }

--- a/api/authorization/v1alpha1/binddefinition_webhook_unit_test.go
+++ b/api/authorization/v1alpha1/binddefinition_webhook_unit_test.go
@@ -188,7 +188,7 @@ func TestBindDefinitionValidatorRejectsRequiredAndSubjectShape(t *testing.T) {
 			bd: &BindDefinition{
 				ObjectMeta: metav1.ObjectMeta{Name: "empty-spec"},
 			},
-			want: []string{"spec.targetName", "spec.subjects", "at least one binding"},
+			want: []string{"spec.targetName", "spec.subjects", "spec: Required value", "at least one binding"},
 		},
 		{
 			name: "empty subject name",

--- a/api/authorization/v1alpha1/default_policy_assignment_webhook_test.go
+++ b/api/authorization/v1alpha1/default_policy_assignment_webhook_test.go
@@ -229,7 +229,12 @@ func TestUnrestrictedValidatorsUseReaderForAdmissionCriticalLookups(t *testing.T
 			),
 		}
 		bd := &BindDefinition{
-			ObjectMeta: metav1.ObjectMeta{Name: "plain-binding"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "plain-binding",
+				Annotations: map[string]string{
+					MissingRolePolicyAnnotation: string(MissingRolePolicyIgnore),
+				},
+			},
 			Spec: BindDefinitionSpec{
 				TargetName: "shared-binding-target",
 				Subjects: []rbacv1.Subject{{
@@ -237,6 +242,9 @@ func TestUnrestrictedValidatorsUseReaderForAdmissionCriticalLookups(t *testing.T
 					APIGroup: rbacv1.GroupName,
 					Name:     "alice",
 				}},
+				ClusterRoleBindings: ClusterBinding{
+					ClusterRoleRefs: []string{"view"},
+				},
 			},
 		}
 


### PR DESCRIPTION
## Description

Admission validation for `BindDefinition` accepted empty specs and RBAC subjects whose shape would never be valid Kubernetes RBAC input. This adds a webhook backstop for:

- missing `spec.targetName`, missing subjects, and definitions with no referenced role
- empty subject names
- User/Group subjects with missing or wrong `apiGroup`, or an invalid namespace
- ServiceAccount subjects with an `apiGroup`, missing namespace, or invalid namespace

The stale-client admission-reader test fixture now includes a minimal valid binding so it still verifies the live `RestrictedBindDefinition` collision path instead of failing early on the new required-field validation.

Duplicate check: `gh pr list --repo telekom/auth-operator --state open --search 'BindDefinition subject shape targetName subjects validation' --json number,title,url,headRefName --limit 30` and `gh pr list --repo telekom/auth-operator --state open --search 'subject shape BindDefinition webhook empty spec targetName' --json number,title,url,headRefName --limit 20` both returned no matching open PRs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🧪 Test improvement
- [ ] 🏗️ Refactoring (no functional changes)

## Related Issues

Audit finding: webhook admitted invalid `BindDefinition` specs that later could not reconcile into valid RBAC.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## API Changes

- [x] No API changes
- [ ] New CRD fields added
- [ ] CRD fields modified
- [ ] CRD fields removed (breaking change)

## Testing

### Test Configuration

- Kubernetes version: envtest 1.34.1
- Operator version: local branch from `origin/main`
- Test environment: local

### Test Steps

1. `go test ./api/authorization/v1alpha1 -run 'TestBindDefinitionValidatorRejectsRequiredAndSubjectShape|TestUnrestrictedValidatorsUseReaderForAdmissionCriticalLookups' -count=1`
2. `golangci-lint run --timeout 10m ./api/authorization/v1alpha1/...`
3. `make envtest && KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.34.1 --bin-dir ./bin -p path)" go test ./api/authorization/v1alpha1 -count=1`
4. `git diff --check`

## Screenshots (if applicable)

N/A

## Additional Notes

This intentionally validates only the existing API fields and subject semantics. It does not add CRD schema fields or generated artifacts.

## Review follow-up

Addressed Copilot review discussion_r3486780223 on 2026-06-27 by attaching the missing referenced-role validation error to spec, matching the CRD cross-field rule, and tightening the unit test assertion.

Duplicate check before branch update:
- gh search prs --repo telekom/auth-operator "BindDefinition referenced role validation error spec clusterRoleRefs" --state open -> none.
- gh search prs --repo telekom/auth-operator "BindDefinition referenced role validation error spec clusterRoleRefs updated:>=2026-06-13" --merged -> broad adjacent historical hits (#342, #336, #335, #333, #343, #337, #334, #339, #271, #224), none duplicate this webhook error-path fix.

Validation:
- go test ./api/authorization/v1alpha1 -run TestBindDefinitionValidatorRejectsRequiredAndSubjectShape
- git -c core.fsmonitor=false diff --check

