### PR TITLE
fix(restrictedbinddefinition): validate subject shapes

### DIFF
--- a/api/authorization/v1alpha1/restrictedbinddefinition_webhook.go
+++ b/api/authorization/v1alpha1/restrictedbinddefinition_webhook.go
@@ -231,6 +231,7 @@ func (v *RestrictedBindDefinitionValidator) validateRestrictedBindDefinitionSpec
 }
 
 func validateRestrictedBindDefinitionSubjects(kind schema.GroupKind, name string, subjects []rbacv1.Subject) error {
+	restrictedSupportedSubjectKinds := []string{rbacv1.UserKind, rbacv1.GroupKind, rbacv1.ServiceAccountKind}
 	var allErrs field.ErrorList
 	for i, subject := range subjects {
 		subjectPath := field.NewPath("spec", "subjects").Index(i)
@@ -240,7 +241,7 @@ func validateRestrictedBindDefinitionSubjects(kind schema.GroupKind, name string
 		switch subject.Kind {
 		case rbacv1.UserKind, rbacv1.GroupKind:
 			if subject.APIGroup != rbacv1.GroupName {
-				allErrs = append(allErrs, field.Invalid(subjectPath.Child("apiGroup"), subject.APIGroup, "User and Group subjects must use rbac.authorization.k8s.io"))
+				allErrs = append(allErrs, field.Invalid(subjectPath.Child("apiGroup"), subject.APIGroup, fmt.Sprintf("User and Group subjects must use %s", rbacv1.GroupName)))
 			}
 			if subject.Namespace != "" {
 				allErrs = append(allErrs, field.Forbidden(subjectPath.Child("namespace"), "User and Group subjects must not set namespace"))
@@ -257,7 +258,7 @@ func validateRestrictedBindDefinitionSubjects(kind schema.GroupKind, name string
 				}
 			}
 		default:
-			allErrs = append(allErrs, field.NotSupported(subjectPath.Child("kind"), subject.Kind, supportedSubjectKinds))
+			allErrs = append(allErrs, field.NotSupported(subjectPath.Child("kind"), subject.Kind, restrictedSupportedSubjectKinds))
 		}
 	}
 	if len(allErrs) > 0 {

--- a/api/authorization/v1alpha1/restrictedbinddefinition_webhook.go
+++ b/api/authorization/v1alpha1/restrictedbinddefinition_webhook.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -219,24 +220,50 @@ func (v *RestrictedBindDefinitionValidator) validateRestrictedBindDefinitionSpec
 				fmt.Sprintf("%s (already used by BindDefinition %q)", obj.Spec.TargetName, existingBD.Name))})
 	}
 
-	// Validate subject Kinds are one of the RBAC-supported types.
-	for i, subject := range obj.Spec.Subjects {
-		switch subject.Kind {
-		case rbacv1.UserKind, rbacv1.GroupKind, rbacv1.ServiceAccountKind:
-			// valid
-		default:
-			fldErr := field.NotSupported(field.NewPath("spec", "subjects").Index(i).Child("kind"), subject.Kind, supportedSubjectKinds)
-			return apierrors.NewInvalid(
-				schema.GroupKind{Group: GroupVersion.Group, Kind: RestrictedBindDefinitionKind},
-				obj.Name, field.ErrorList{fldErr})
-		}
-	}
-
 	kind := schema.GroupKind{Group: GroupVersion.Group, Kind: RestrictedBindDefinitionKind}
+	if err := validateRestrictedBindDefinitionSubjects(kind, obj.Name, obj.Spec.Subjects); err != nil {
+		return err
+	}
 	if err := validateNamespaceBindings(kind, obj.Name, obj.Spec.RoleBindings); err != nil {
 		return err
 	}
 	return v.validateRoleBindingNameCollisions(ctx, kind, obj)
+}
+
+func validateRestrictedBindDefinitionSubjects(kind schema.GroupKind, name string, subjects []rbacv1.Subject) error {
+	var allErrs field.ErrorList
+	for i, subject := range subjects {
+		subjectPath := field.NewPath("spec", "subjects").Index(i)
+		if subject.Name == "" {
+			allErrs = append(allErrs, field.Required(subjectPath.Child("name"), "subject name is required"))
+		}
+		switch subject.Kind {
+		case rbacv1.UserKind, rbacv1.GroupKind:
+			if subject.APIGroup != rbacv1.GroupName {
+				allErrs = append(allErrs, field.Invalid(subjectPath.Child("apiGroup"), subject.APIGroup, "User and Group subjects must use rbac.authorization.k8s.io"))
+			}
+			if subject.Namespace != "" {
+				allErrs = append(allErrs, field.Forbidden(subjectPath.Child("namespace"), "User and Group subjects must not set namespace"))
+			}
+		case rbacv1.ServiceAccountKind:
+			if subject.APIGroup != "" {
+				allErrs = append(allErrs, field.Forbidden(subjectPath.Child("apiGroup"), "ServiceAccount subjects must not set apiGroup"))
+			}
+			if subject.Namespace == "" {
+				allErrs = append(allErrs, field.Required(subjectPath.Child("namespace"), "ServiceAccount subjects must specify a namespace"))
+			} else {
+				for _, msg := range utilvalidation.IsDNS1123Label(subject.Namespace) {
+					allErrs = append(allErrs, field.Invalid(subjectPath.Child("namespace"), subject.Namespace, msg))
+				}
+			}
+		default:
+			allErrs = append(allErrs, field.NotSupported(subjectPath.Child("kind"), subject.Kind, supportedSubjectKinds))
+		}
+	}
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(kind, name, allErrs)
+	}
+	return nil
 }
 
 //nolint:nilnil // A nil object with nil error means no conflicting targetName was found.

--- a/api/authorization/v1alpha1/restrictedbinddefinition_webhook_test.go
+++ b/api/authorization/v1alpha1/restrictedbinddefinition_webhook_test.go
@@ -282,6 +282,80 @@ var _ = Describe("RestrictedBindDefinition Webhook", func() {
 			Expect(err.Error()).To(ContainSubstring("ServiceAccount subjects must specify a namespace"))
 		})
 
+		It("Should deny malformed RBAC subject shapes", func() {
+			testCases := []struct {
+				name       string
+				objectName string
+				subject    rbacv1.Subject
+				want       []string
+			}{
+				{
+					name:       "empty subject name",
+					objectName: "test-rbd-subject-empty-name",
+					subject:    rbacv1.Subject{Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName},
+					want:       []string{"spec.subjects[0].name", "subject name is required"},
+				},
+				{
+					name:       "user subject apiGroup",
+					objectName: "test-rbd-subject-user-apigroup",
+					subject:    rbacv1.Subject{Kind: rbacv1.UserKind, Name: "alice"},
+					want:       []string{"spec.subjects[0].apiGroup", rbacv1.GroupName},
+				},
+				{
+					name:       "user subject namespace",
+					objectName: "test-rbd-subject-user-namespace",
+					subject:    rbacv1.Subject{Kind: rbacv1.UserKind, APIGroup: rbacv1.GroupName, Name: "alice", Namespace: "default"},
+					want:       []string{"spec.subjects[0].namespace", "must not set namespace"},
+				},
+				{
+					name:       "group subject apiGroup",
+					objectName: "test-rbd-subject-group-apigroup",
+					subject:    rbacv1.Subject{Kind: rbacv1.GroupKind, Name: "team-a"},
+					want:       []string{"spec.subjects[0].apiGroup", rbacv1.GroupName},
+				},
+				{
+					name:       "serviceaccount subject apiGroup",
+					objectName: "test-rbd-subject-sa-apigroup",
+					subject:    rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, APIGroup: rbacv1.GroupName, Name: "runner", Namespace: "default"},
+					want:       []string{"spec.subjects[0].apiGroup", "must not set apiGroup"},
+				},
+				{
+					name:       "serviceaccount subject invalid namespace",
+					objectName: "test-rbd-subject-sa-bad-ns",
+					subject:    rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "runner", Namespace: "Bad/Name"},
+					want:       []string{"spec.subjects[0].namespace", "Bad/Name"},
+				},
+				{
+					name:       "unsupported subject kind",
+					objectName: "test-rbd-subject-bad-kind",
+					subject:    rbacv1.Subject{Kind: "Robot", Name: "bot"},
+					want:       []string{"spec.subjects[0].kind", "Unsupported value"},
+				},
+			}
+
+			for _, tc := range testCases {
+				By(tc.name)
+				rbd := &RestrictedBindDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tc.objectName,
+					},
+					Spec: RestrictedBindDefinitionSpec{
+						PolicyRef:  RBACPolicyReference{Name: policy.Name},
+						TargetName: tc.objectName,
+						Subjects:   []rbacv1.Subject{tc.subject},
+						ClusterRoleBindings: &ClusterBinding{
+							ClusterRoleRefs: []string{"view"},
+						},
+					},
+				}
+				err := k8sClient.Create(ctx, rbd)
+				Expect(err).To(HaveOccurred())
+				for _, want := range tc.want {
+					Expect(err.Error()).To(ContainSubstring(want))
+				}
+			}
+		})
+
 		It("Should deny a RestrictedBindDefinition roleBinding with refs but no namespace target", func() {
 			rbd := &RestrictedBindDefinition{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description

`RestrictedBindDefinition` admission only checked `subjects[].kind`, so malformed Kubernetes RBAC subjects could be accepted and then fail later when generated RBAC was applied. This adds webhook validation for the existing subject fields:

- required subject name
- User/Group `apiGroup: rbac.authorization.k8s.io`
- no namespace on User/Group subjects
- no `apiGroup` on ServiceAccount subjects
- required and DNS-label-valid ServiceAccount namespace
- existing unsupported kind rejection remains covered

Duplicate check: `gh pr list --repo telekom/auth-operator --state open --search 'RestrictedBindDefinition subject shape apiGroup namespace validation' --json number,title,url,headRefName --limit 30` only returned #374, which is the equivalent `BindDefinition` fix and does not touch `RestrictedBindDefinition`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [x] 🧪 Test improvement
- [ ] 🏗️ Refactoring (no functional changes)

## Related Issues

Audit finding: malformed `RestrictedBindDefinition` subjects were admitted and only failed during generated RBAC apply.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## API Changes

- [x] No API changes
- [ ] New CRD fields added
- [ ] CRD fields modified
- [ ] CRD fields removed (breaking change)

## Testing

### Test Configuration

- Kubernetes version: envtest 1.34.1
- Operator version: local branch from `origin/main`
- Test environment: local

### Test Steps

1. `make envtest && KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.34.1 --bin-dir ./bin -p path)" go test ./api/authorization/v1alpha1 -run 'TestAPIs/RestrictedBindDefinition_Webhook' -count=1`
2. `KUBEBUILDER_ASSETS="$(pwd)/$(./bin/setup-envtest use 1.34.1 --bin-dir ./bin -p path)" go test ./api/authorization/v1alpha1 -count=1`
3. `golangci-lint run --timeout 10m ./api/authorization/v1alpha1/...`
4. `git diff --check`

## Screenshots (if applicable)

N/A

## Additional Notes

This is webhook-only validation of existing fields. It intentionally does not edit CRD markers or generated artifacts.

## Review follow-up

Addressed Copilot reviews discussion_r3486818325 and discussion_r3486818332 on 2026-06-27:
- RestrictedBindDefinition subject validation now builds the User/Group apiGroup message from rbacv1.GroupName.
- The helper uses a local supported subject-kind list instead of coupling to the BindDefinition-specific supportedSubjectKinds variable.

Duplicate check before branch update:
- gh search prs --repo telekom/auth-operator "RestrictedBindDefinition subject shapes rbacv1.GroupName supportedSubjectKinds" --state open -> none.
- gh search prs --repo telekom/auth-operator "RestrictedBindDefinition subject shapes rbacv1.GroupName supportedSubjectKinds updated:>=2026-06-13" --merged -> none.

Validation:
- setup-envtest use 1.34.1 --bin-dir ./bin -p path
- go test ./api/authorization/v1alpha1
- git -c core.fsmonitor=false diff --check

