### PR TITLE
fix(roledefinition): clear reconciled status on stall

### DIFF
--- a/internal/controller/authorization/roledefinition_helpers.go
+++ b/internal/controller/authorization/roledefinition_helpers.go
@@ -69,6 +69,7 @@ func (r *RoleDefinitionReconciler) markStalled(
 	// Copy status and apply stalled condition
 	conditions.MarkStalled(roleDefinition, roleDefinition.Generation,
 		authorizationv1alpha1.StalledReasonError, authorizationv1alpha1.StalledMessageError, "check operator logs for details")
+	roleDefinition.Status.RoleReconciled = false
 	roleDefinition.Status.ObservedGeneration = roleDefinition.Generation
 	if updateErr := ssa.ApplyRoleDefinitionStatus(ctx, r.client, roleDefinition); updateErr != nil {
 		logger.Error(updateErr, "failed to apply Stalled status via SSA", "roleDefinitionName", roleDefinition.Name)

--- a/internal/controller/authorization/roledefinition_helpers_test.go
+++ b/internal/controller/authorization/roledefinition_helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	authorizationv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
+	authorizationv1alpha1ac "github.com/telekom/auth-operator/api/authorization/v1alpha1/applyconfiguration/authorization/v1alpha1"
 	"github.com/telekom/auth-operator/pkg/discovery"
 )
 
@@ -698,11 +699,25 @@ func TestRoleDefinitionMarkStalled(t *testing.T) {
 				TargetName: "stalled-role",
 				TargetRole: authorizationv1alpha1.DefinitionClusterRole,
 			},
+			Status: authorizationv1alpha1.RoleDefinitionStatus{
+				RoleReconciled: true,
+			},
 		}
 
+		var appliedRoleReconciled *bool
 		c := fake.NewClientBuilder().WithScheme(s).
 			WithObjects(rd).
 			WithStatusSubresource(rd).
+			WithInterceptorFuncs(interceptor.Funcs{
+				SubResourceApply: func(_ context.Context, _ client.Client, subResourceName string, obj runtime.ApplyConfiguration, _ ...client.SubResourceApplyOption) error {
+					if subResourceName == "status" {
+						if ac, ok := obj.(*authorizationv1alpha1ac.RoleDefinitionApplyConfiguration); ok && ac.Status != nil {
+							appliedRoleReconciled = ac.Status.RoleReconciled
+						}
+					}
+					return nil
+				},
+			}).
 			Build()
 		r := &RoleDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
 
@@ -710,6 +725,7 @@ func TestRoleDefinitionMarkStalled(t *testing.T) {
 
 		// Verify condition was set in-memory
 		g.Expect(rd.Status.ObservedGeneration).To(Equal(int64(5)))
+		g.Expect(rd.Status.RoleReconciled).To(BeFalse())
 		stalledFound := false
 		for _, cond := range rd.Status.Conditions {
 			if cond.Type == "Stalled" {
@@ -719,6 +735,8 @@ func TestRoleDefinitionMarkStalled(t *testing.T) {
 			}
 		}
 		g.Expect(stalledFound).To(BeTrue(), "Stalled condition should be set")
+		g.Expect(appliedRoleReconciled).NotTo(BeNil())
+		g.Expect(*appliedRoleReconciled).To(BeFalse())
 	})
 }
 


### PR DESCRIPTION
## Summary
- clear `status.roleReconciled` when a RoleDefinition is marked Stalled
- extend the existing stall unit test to start from `roleReconciled=true` and assert the SSA status payload carries `false`

## Evidence
A successful RoleDefinition sets `status.roleReconciled=true`, but `markStalled` only updated the Stalled condition and observed generation. A later failure could therefore report Stalled while still exposing stale `roleReconciled=true`. RestrictedRoleDefinition already clears the analogous field on stall.

Duplicate check before opening: open PRs #367, #370, #373, and #376 are related to RoleDefinition behavior, but none changes the RoleDefinition stall status path or clears `RoleReconciled`.

## Validation
- `go test ./internal/controller/authorization -run TestRoleDefinitionMarkStalled -count=1`
- `golangci-lint run --timeout 10m --new-from-rev origin/main ./internal/controller/authorization/...`
- `git diff --check`