### PR TITLE
fix(webhookauthorizer): refresh active rules gauge

### DIFF
--- a/internal/controller/authorization/webhookauthorizer_controller.go
+++ b/internal/controller/authorization/webhookauthorizer_controller.go
@@ -113,6 +113,11 @@ func (r *WebhookAuthorizerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			logger.V(1).Info("WebhookAuthorizer not found (deleted), cleaning up metrics",
 				"webhookAuthorizer", req.Name)
 			metrics.DeleteAuthorizerSeries(req.Name)
+			if metricErr := r.refreshAuthorizerActiveRulesMetric(ctx); metricErr != nil {
+				logger.Error(metricErr, "failed to refresh active rules metric after WebhookAuthorizer deletion",
+					"webhookAuthorizer", req.Name)
+				metrics.ReconcileErrors.WithLabelValues(metrics.ControllerWebhookAuthorizer, metrics.ErrorTypeAPI).Inc()
+			}
 			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerWebhookAuthorizer, metrics.ResultSkipped).Inc()
 			return ctrl.Result{}, nil
 		}
@@ -122,6 +127,13 @@ func (r *WebhookAuthorizerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerWebhookAuthorizer, metrics.ErrorTypeAPI).Inc()
 		return ctrl.Result{}, fmt.Errorf("fetch WebhookAuthorizer %s: %w", req.Name, err)
 	}
+	defer func() {
+		if err := r.refreshAuthorizerActiveRulesMetric(ctx); err != nil {
+			logger.Error(err, "failed to refresh active rules metric",
+				"webhookAuthorizer", wa.Name)
+			metrics.ReconcileErrors.WithLabelValues(metrics.ControllerWebhookAuthorizer, metrics.ErrorTypeAPI).Inc()
+		}
+	}()
 
 	// Step 2: Validate the same semantic contract enforced by admission so
 	// legacy or webhook-bypassed objects cannot be reported as configured.
@@ -244,6 +256,36 @@ func (r *WebhookAuthorizerReconciler) validateNamespaceSelector(
 // convertLabelSelector converts a metav1.LabelSelector to a labels.Selector.
 func convertLabelSelector(ls *metav1.LabelSelector) (labels.Selector, error) {
 	return metav1.LabelSelectorAsSelector(ls)
+}
+
+func (r *WebhookAuthorizerReconciler) refreshAuthorizerActiveRulesMetric(ctx context.Context) error {
+	list := &authorizationv1alpha1.WebhookAuthorizerList{}
+	if err := r.client.List(ctx, list); err != nil {
+		return fmt.Errorf("list WebhookAuthorizers for active rules metric: %w", err)
+	}
+
+	total := 0
+	for i := range list.Items {
+		if !webhookAuthorizerReadyForActiveRulesMetric(list.Items[i]) {
+			continue
+		}
+		total += len(list.Items[i].Spec.ResourceRules) + len(list.Items[i].Spec.NonResourceRules)
+	}
+	metrics.AuthorizerActiveRules.Set(float64(total))
+	return nil
+}
+
+func webhookAuthorizerReadyForActiveRulesMetric(item authorizationv1alpha1.WebhookAuthorizer) bool {
+	if item.Status.ObservedGeneration == 0 && len(item.Status.Conditions) == 0 {
+		return true
+	}
+	if item.Generation > 0 && item.Status.ObservedGeneration > 0 && item.Status.ObservedGeneration != item.Generation {
+		return false
+	}
+	if len(item.Status.Conditions) > 0 && !conditions.IsReady(&item) {
+		return false
+	}
+	return item.Status.AuthorizerConfigured
 }
 
 // markStalled marks the WebhookAuthorizer as stalled with the given error.

--- a/internal/controller/authorization/webhookauthorizer_controller_test.go
+++ b/internal/controller/authorization/webhookauthorizer_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	authzv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +26,7 @@ import (
 
 	authorizationv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
 	"github.com/telekom/auth-operator/pkg/conditions"
+	"github.com/telekom/auth-operator/pkg/metrics"
 
 	"github.com/onsi/gomega"
 )
@@ -72,6 +74,29 @@ func TestReconcile_NotFound(t *testing.T) {
 	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
 }
 
+func TestReconcile_NotFoundRefreshesActiveRulesGauge(t *testing.T) {
+	g := gomega.NewWithT(t)
+	remaining := &authorizationv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{Name: "remaining-authorizer"},
+		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+			NonResourceRules: []authzv1.NonResourceRule{
+				{Verbs: []string{"get"}, NonResourceURLs: []string{"/healthz"}},
+			},
+		},
+	}
+	r, _ := newWATestReconciler(remaining)
+	metrics.AuthorizerActiveRules.Set(99)
+
+	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("deleted-authorizer"))
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(testutil.ToFloat64(metrics.AuthorizerActiveRules)).To(gomega.Equal(float64(2)))
+}
+
 func TestReconcile_EmptySelector_Ready(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -97,6 +122,129 @@ func TestReconcile_EmptySelector_Ready(t *testing.T) {
 	g.Expect(conditions.IsReady(&updated)).To(gomega.BeTrue())
 	g.Expect(conditions.IsStalled(&updated)).To(gomega.BeFalse())
 	g.Expect(conditions.IsReconciling(&updated)).To(gomega.BeFalse())
+}
+
+func TestReconcile_RefreshesActiveRulesGauge(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	wa := &authorizationv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "gauge-authorizer",
+			Generation: 1,
+		},
+		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{
+			ResourceRules: []authzv1.ResourceRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+				{Verbs: []string{"list"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+			AllowedPrincipals: []authorizationv1alpha1.Principal{{User: "admin"}},
+		},
+	}
+	other := &authorizationv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "other-gauge-authorizer",
+			Generation: 1,
+		},
+		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{
+			NonResourceRules: []authzv1.NonResourceRule{
+				{Verbs: []string{"get"}, NonResourceURLs: []string{"/readyz"}},
+			},
+		},
+	}
+
+	r, _ := newWATestReconciler(wa, other)
+	metrics.AuthorizerActiveRules.Set(99)
+
+	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("gauge-authorizer"))
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
+	g.Expect(testutil.ToFloat64(metrics.AuthorizerActiveRules)).To(gomega.Equal(float64(3)))
+}
+
+func TestReconcile_ActiveRulesGaugeExcludesStalledAuthorizersAfterReconcile(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	ready := &authorizationv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "ready-authorizer",
+			Generation: 1,
+		},
+		Spec: validWebhookAuthorizerSpec(),
+	}
+	conditions.MarkReady(ready, ready.Generation,
+		authorizationv1alpha1.ReadyReasonReconciled, authorizationv1alpha1.ReadyMessageReconciled)
+	ready.Status.ObservedGeneration = ready.Generation
+	ready.Status.AuthorizerConfigured = true
+
+	invalid := &authorizationv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "invalid-gauge-authorizer",
+			Generation: 1,
+		},
+		Spec: authorizationv1alpha1.WebhookAuthorizerSpec{
+			ResourceRules: []authzv1.ResourceRule{{
+				Verbs:     []string{"get"},
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+			}},
+		},
+	}
+
+	r, c := newWATestReconciler(ready, invalid)
+	metrics.AuthorizerActiveRules.Set(99)
+
+	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("invalid-gauge-authorizer"))
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(testutil.ToFloat64(metrics.AuthorizerActiveRules)).To(gomega.Equal(float64(1)))
+
+	var updated authorizationv1alpha1.WebhookAuthorizer
+	g.Expect(c.Get(ctxWithLogger(), types.NamespacedName{Name: "invalid-gauge-authorizer"}, &updated)).To(gomega.Succeed())
+	g.Expect(updated.Status.AuthorizerConfigured).To(gomega.BeFalse())
+	g.Expect(conditions.IsStalled(&updated)).To(gomega.BeTrue())
+	g.Expect(conditions.IsReady(&updated)).To(gomega.BeFalse())
+}
+
+func TestReconcile_ActiveRulesGaugeRefreshErrorIsBestEffort(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	wa := &authorizationv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "best-effort-authorizer",
+			Generation: 1,
+		},
+		Spec: validWebhookAuthorizerSpec(),
+	}
+
+	scheme := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(wa).
+		WithStatusSubresource(&authorizationv1alpha1.WebhookAuthorizer{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*authorizationv1alpha1.WebhookAuthorizerList); ok {
+					return errors.New("simulated metric list error")
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+	recorder := events.NewFakeRecorder(10)
+	r := NewWebhookAuthorizerReconciler(c, scheme, recorder)
+
+	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("best-effort-authorizer"))
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
+
+	var updated authorizationv1alpha1.WebhookAuthorizer
+	g.Expect(c.Get(ctxWithLogger(), types.NamespacedName{Name: "best-effort-authorizer"}, &updated)).To(gomega.Succeed())
+	g.Expect(updated.Status.ObservedGeneration).To(gomega.Equal(int64(1)))
+	g.Expect(updated.Status.AuthorizerConfigured).To(gomega.BeTrue())
+	g.Expect(conditions.IsReady(&updated)).To(gomega.BeTrue())
 }
 
 func TestReconcile_WithMatchLabels_Ready(t *testing.T) {


### PR DESCRIPTION
## Summary
- refresh the unlabeled `auth_operator_authorizer_active_rules` gauge from WebhookAuthorizer reconcile events
- update the gauge after authorizer deletion using the remaining authorizers
- add controller tests for update and delete paths

## Evidence
Before this change, `AuthorizerActiveRules` was only set from `/authorize` request handling. Deleting a WebhookAuthorizer or reducing its rules could leave the gauge stale until another authorization request arrived.

Duplicate check before opening: open PRs #365, #369, #371, and #372 touch nearby WebhookAuthorizer or metrics areas, but none refreshes `AuthorizerActiveRules` from the reconciler or updates it after deletion.

## Validation
- `go test ./internal/controller/authorization -run 'TestReconcile_(NotFoundRefreshesActiveRulesGauge|RefreshesActiveRulesGauge|NotFound|EmptySelector_Ready)' -count=1`\n- `golangci-lint run --timeout 10m --new-from-rev origin/main ./internal/controller/authorization/...`\n- `git diff --check`