### PR TITLE
fix(binddefinition): clear reconciled status on stall

### DIFF
--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	authorizationv1alpha1 "github.com/telekom/auth-operator/api/authorization/v1alpha1"
+	authorizationv1alpha1ac "github.com/telekom/auth-operator/api/authorization/v1alpha1/applyconfiguration/authorization/v1alpha1"
 	"github.com/telekom/auth-operator/pkg/conditions"
 	"github.com/telekom/auth-operator/pkg/helpers"
 	"github.com/telekom/auth-operator/pkg/indexer"
@@ -2756,11 +2757,25 @@ func TestMarkStalledBindDefinition(t *testing.T) {
 				TargetName: "stalled",
 				Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "g", APIGroup: rbacv1.GroupName}},
 			},
+			Status: authorizationv1alpha1.BindDefinitionStatus{
+				BindReconciled: true,
+			},
 		}
 
+		var appliedBindReconciled *bool
 		c := fake.NewClientBuilder().WithScheme(scheme).
 			WithObjects(bindDef).
 			WithStatusSubresource(bindDef).
+			WithInterceptorFuncs(interceptor.Funcs{
+				SubResourceApply: func(_ context.Context, _ client.Client, subResourceName string, obj runtime.ApplyConfiguration, _ ...client.SubResourceApplyOption) error {
+					if subResourceName == "status" {
+						if ac, ok := obj.(*authorizationv1alpha1ac.BindDefinitionApplyConfiguration); ok && ac.Status != nil {
+							appliedBindReconciled = ac.Status.BindReconciled
+						}
+					}
+					return nil
+				},
+			}).
 			Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
@@ -2768,6 +2783,7 @@ func TestMarkStalledBindDefinition(t *testing.T) {
 
 		// Verify condition was set in-memory
 		g.Expect(bindDef.Status.ObservedGeneration).To(Equal(int64(3)))
+		g.Expect(bindDef.Status.BindReconciled).To(BeFalse())
 		stalledFound := false
 		for _, cond := range bindDef.Status.Conditions {
 			if cond.Type == "Stalled" {
@@ -2777,6 +2793,8 @@ func TestMarkStalledBindDefinition(t *testing.T) {
 			}
 		}
 		g.Expect(stalledFound).To(BeTrue(), "Stalled condition should be set")
+		g.Expect(appliedBindReconciled).NotTo(BeNil())
+		g.Expect(*appliedBindReconciled).To(BeFalse())
 	})
 }
 

--- a/internal/controller/authorization/binddefinition_helpers.go
+++ b/internal/controller/authorization/binddefinition_helpers.go
@@ -140,6 +140,7 @@ func (r *BindDefinitionReconciler) markStalled(
 	conditions.MarkStalled(bindDefinition, bindDefinition.Generation,
 		authorizationv1alpha1.StalledReasonError, authorizationv1alpha1.StalledMessageError, "check operator logs for details")
 	bindDefinition.Status.ObservedGeneration = bindDefinition.Generation
+	bindDefinition.Status.BindReconciled = false
 	if updateErr := ssa.ApplyBindDefinitionStatus(ctx, r.client, bindDefinition); updateErr != nil {
 		logger.Error(updateErr, "failed to apply Stalled status via SSA", "bindDefinitionName", bindDefinition.Name)
 	}


### PR DESCRIPTION
## Summary

- Clear `status.bindReconciled` when a BindDefinition is marked Stalled.
- Extend the stalled-status test to start from `bindReconciled=true` and assert both in-memory status and SSA status apply payload set it to false.

## Evidence

Successful BindDefinition reconciliation sets `status.bindReconciled=true`. If a later reconcile stalls, `markStalled` only updated conditions and `observedGeneration`, leaving JSONPath/status consumers able to see `bindReconciled=true` while the resource was Stalled.

This mirrors the RoleDefinition fix in #377 for the BindDefinition controller path.

## Duplicate/overlap check

- Target verified before update: `telekom/auth-operator` (`https://github.com/telekom/auth-operator`), non-fork, default branch `main`; this PR targets `main`.
- Open PR search `BindDefinition markStalled bindReconciled Stalled binddefinition_helpers.go clear status` only returned this PR (#379).
- Recently merged PR search with the same terms returned #224, `feat: implement Restricted CRDs with RBACPolicy for multi-tenant RBAC governance`; that is broad adjacent Restricted CRD work, not this BindDefinition stalled-status regression.
- Related open work: #377 handles the analogous RoleDefinition status path; this PR covers the separate BindDefinition controller path.

## Validation

- `go test ./internal/controller/authorization -run TestMarkStalledBindDefinition -count=1`
- `golangci-lint run --timeout 10m --new-from-rev origin/main ./internal/controller/authorization/...`
- `git diff --check`
