### PR TITLE
fix(binddefinition): drop stale serviceaccount owner refs

### DIFF
--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -329,10 +329,15 @@ func bindDefinitionMatchesNamespace(bd *authorizationv1alpha1.BindDefinition, ns
 	return false
 }
 
-// For checking if terminating BindDefinition refers a ServiceAccount
-// that other non-terminating BindDefinitions reference.
-func (r *BindDefinitionReconciler) isSAReferencedByOtherBindDefs(ctx context.Context, currentBindDefName, saName, saNamespace string) (bool, error) {
-	// List all BindDefinitions
+// isSAReferencedByOtherBindDefs checks whether another live BindDefinition
+// references and already owns the ServiceAccount. A spec reference alone is not
+// enough to retain the ServiceAccount during deletion because the peer
+// BindDefinition may not have reconciled/adopted it yet.
+func (r *BindDefinitionReconciler) isSAReferencedByOtherBindDefs(
+	ctx context.Context,
+	currentBindDefName, saName, saNamespace string,
+	sa *corev1.ServiceAccount,
+) (bool, error) {
 	bindDefList := &authorizationv1alpha1.BindDefinitionList{}
 	err := r.client.List(ctx, bindDefList)
 	if err != nil {
@@ -340,19 +345,21 @@ func (r *BindDefinitionReconciler) isSAReferencedByOtherBindDefs(ctx context.Con
 	}
 	for _, bindDef := range bindDefList.Items {
 		if bindDef.Name == currentBindDefName {
-			// Skip the BindDefinition that's being deleted
+			// Skip the BindDefinition that's being deleted.
 			continue
 		}
-		// Check if any of the subjects in this BindDefinition reference the ServiceAccount
+		if !bindDef.DeletionTimestamp.IsZero() {
+			continue
+		}
 		for _, subject := range bindDef.Spec.Subjects {
 			if subject.Kind == authorizationv1alpha1.BindSubjectServiceAccount &&
 				subject.Name == saName &&
-				subject.Namespace == saNamespace {
+				subject.Namespace == saNamespace &&
+				hasOwnerRef(sa, &bindDef) {
 				return true, nil
 			}
 		}
 	}
-	// No other BindDefinitions reference this ServiceAccount
 	return false, nil
 }
 

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -2103,17 +2103,18 @@ func TestIsSAReferencedByOtherBindDefs(t *testing.T) {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bd).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "my-sa", Namespace: "default"}}
 
-		ref, err := r.isSAReferencedByOtherBindDefs(ctx, "bd-1", "my-sa", "default")
+		ref, err := r.isSAReferencedByOtherBindDefs(ctx, "bd-1", "my-sa", "default", sa)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(ref).To(BeFalse())
 	})
 
-	t.Run("should return true when another BindDef references the SA", func(t *testing.T) {
+	t.Run("should return true when another live owning BindDef references the SA", func(t *testing.T) {
 		g := NewWithT(t)
 
 		bd1 := &authorizationv1alpha1.BindDefinition{
-			ObjectMeta: metav1.ObjectMeta{Name: "bd-1", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "bd-1", Namespace: "default", UID: "uid-1"},
 			Spec: authorizationv1alpha1.BindDefinitionSpec{
 				TargetName: "test-1",
 				Subjects: []rbacv1.Subject{
@@ -2122,7 +2123,7 @@ func TestIsSAReferencedByOtherBindDefs(t *testing.T) {
 			},
 		}
 		bd2 := &authorizationv1alpha1.BindDefinition{
-			ObjectMeta: metav1.ObjectMeta{Name: "bd-2", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "bd-2", Namespace: "default", UID: "uid-2"},
 			Spec: authorizationv1alpha1.BindDefinitionSpec{
 				TargetName: "test-2",
 				Subjects: []rbacv1.Subject{
@@ -2130,14 +2131,125 @@ func TestIsSAReferencedByOtherBindDefs(t *testing.T) {
 				},
 			},
 		}
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-sa",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: authorizationv1alpha1.GroupVersion.String(),
+						Kind:       authorizationv1alpha1.BindDefinitionKind,
+						Name:       "bd-2",
+						UID:        "uid-2",
+						Controller: ptr.To(false),
+					},
+				},
+			},
+		}
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bd1, bd2).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
 
-		// bd-1 is being deleted, check if bd-2 also references the SA
-		ref, err := r.isSAReferencedByOtherBindDefs(ctx, "bd-1", "shared-sa", "default")
+		ref, err := r.isSAReferencedByOtherBindDefs(ctx, "bd-1", "shared-sa", "default", sa)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(ref).To(BeTrue())
+	})
+
+	t.Run("should return false when another BindDef references but does not own the SA", func(t *testing.T) {
+		g := NewWithT(t)
+
+		bd1 := &authorizationv1alpha1.BindDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "bd-1", Namespace: "default", UID: "uid-1"},
+			Spec: authorizationv1alpha1.BindDefinitionSpec{
+				TargetName: "test-1",
+				Subjects: []rbacv1.Subject{
+					{Kind: "ServiceAccount", Name: "shared-sa", Namespace: "default"},
+				},
+			},
+		}
+		bd2 := &authorizationv1alpha1.BindDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "bd-2", Namespace: "default", UID: "uid-2"},
+			Spec: authorizationv1alpha1.BindDefinitionSpec{
+				TargetName: "test-2",
+				Subjects: []rbacv1.Subject{
+					{Kind: "ServiceAccount", Name: "shared-sa", Namespace: "default"},
+				},
+			},
+		}
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-sa",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: authorizationv1alpha1.GroupVersion.String(),
+						Kind:       authorizationv1alpha1.BindDefinitionKind,
+						Name:       "bd-1",
+						UID:        "uid-1",
+						Controller: ptr.To(false),
+					},
+				},
+			},
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bd1, bd2).Build()
+		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+
+		ref, err := r.isSAReferencedByOtherBindDefs(ctx, "bd-1", "shared-sa", "default", sa)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(ref).To(BeFalse())
+	})
+
+	t.Run("should return false when another owning BindDef is deleting", func(t *testing.T) {
+		g := NewWithT(t)
+
+		now := metav1.Now()
+		bd1 := &authorizationv1alpha1.BindDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "bd-1", Namespace: "default", UID: "uid-1"},
+			Spec: authorizationv1alpha1.BindDefinitionSpec{
+				TargetName: "test-1",
+				Subjects: []rbacv1.Subject{
+					{Kind: "ServiceAccount", Name: "shared-sa", Namespace: "default"},
+				},
+			},
+		}
+		bd2 := &authorizationv1alpha1.BindDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "bd-2",
+				Namespace:         "default",
+				UID:               "uid-2",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{authorizationv1alpha1.BindDefinitionFinalizer},
+			},
+			Spec: authorizationv1alpha1.BindDefinitionSpec{
+				TargetName: "test-2",
+				Subjects: []rbacv1.Subject{
+					{Kind: "ServiceAccount", Name: "shared-sa", Namespace: "default"},
+				},
+			},
+		}
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-sa",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: authorizationv1alpha1.GroupVersion.String(),
+						Kind:       authorizationv1alpha1.BindDefinitionKind,
+						Name:       "bd-2",
+						UID:        "uid-2",
+						Controller: ptr.To(false),
+					},
+				},
+			},
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bd1, bd2).Build()
+		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+
+		ref, err := r.isSAReferencedByOtherBindDefs(ctx, "bd-1", "shared-sa", "default", sa)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(ref).To(BeFalse())
 	})
 
 	t.Run("should not count the deleting BindDef itself", func(t *testing.T) {
@@ -2155,8 +2267,9 @@ func TestIsSAReferencedByOtherBindDefs(t *testing.T) {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bd).Build()
 		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "my-sa", Namespace: "default"}}
 
-		ref, err := r.isSAReferencedByOtherBindDefs(ctx, "only-bd", "my-sa", "default")
+		ref, err := r.isSAReferencedByOtherBindDefs(ctx, "only-bd", "my-sa", "default", sa)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(ref).To(BeFalse(), "should not count the BindDef being deleted")
 	})
@@ -4517,7 +4630,7 @@ func TestReconcileDeletePreservesSharedSA(t *testing.T) {
 		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 	}
 
-	isController := true
+	isNotController := false
 
 	// BD-A: being deleted, references shared-sa
 	bdA := &authorizationv1alpha1.BindDefinition{
@@ -4556,7 +4669,8 @@ func TestReconcileDeletePreservesSharedSA(t *testing.T) {
 		},
 	}
 
-	// SA owned by BD-A
+	// SA owned by both BDs, matching the state after both have reconciled the
+	// shared ServiceAccount. A peer spec reference alone is not enough to retain it.
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "shared-sa",
@@ -4567,7 +4681,14 @@ func TestReconcileDeletePreservesSharedSA(t *testing.T) {
 					Kind:       "BindDefinition",
 					Name:       "bd-a",
 					UID:        "uid-a",
-					Controller: &isController,
+					Controller: &isNotController,
+				},
+				{
+					APIVersion: authorizationv1alpha1.GroupVersion.String(),
+					Kind:       "BindDefinition",
+					Name:       "bd-b",
+					UID:        "uid-b",
+					Controller: &isNotController,
 				},
 			},
 		},
@@ -4586,6 +4707,93 @@ func TestReconcileDeletePreservesSharedSA(t *testing.T) {
 	existingSA := &corev1.ServiceAccount{}
 	err = c.Get(ctx, types.NamespacedName{Name: "shared-sa", Namespace: "shared-ns"}, existingSA)
 	g.Expect(err).NotTo(HaveOccurred(), "SA should be preserved because another BD references it")
+	g.Expect(existingSA.OwnerReferences).To(ContainElement(WithTransform(func(ref metav1.OwnerReference) string {
+		return ref.Name
+	}, Equal("bd-b"))))
+	g.Expect(existingSA.OwnerReferences).NotTo(ContainElement(WithTransform(func(ref metav1.OwnerReference) string {
+		return ref.Name
+	}, Equal("bd-a"))))
+}
+
+// TestReconcileDeleteRemovesSAWhenPeerOnlyReferences verifies that deleting a
+// BindDefinition does not leave an unowned ServiceAccount behind just because
+// another BindDefinition has a matching subject spec.
+func TestReconcileDeleteRemovesSAWhenPeerOnlyReferences(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	s := runtime.NewScheme()
+	_ = authorizationv1alpha1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-ns"},
+		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	}
+
+	isNotController := false
+
+	bdA := &authorizationv1alpha1.BindDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: authorizationv1alpha1.GroupVersion.String(),
+			Kind:       "BindDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "bd-a",
+			UID:        "uid-a",
+			Finalizers: []string{authorizationv1alpha1.BindDefinitionFinalizer},
+		},
+		Spec: authorizationv1alpha1.BindDefinitionSpec{
+			TargetName: "shared-target",
+			Subjects: []rbacv1.Subject{
+				{Kind: "ServiceAccount", Name: "shared-sa", Namespace: "shared-ns"},
+			},
+		},
+	}
+
+	bdB := &authorizationv1alpha1.BindDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: authorizationv1alpha1.GroupVersion.String(),
+			Kind:       "BindDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "bd-b", UID: "uid-b"},
+		Spec: authorizationv1alpha1.BindDefinitionSpec{
+			TargetName: "other-target",
+			Subjects: []rbacv1.Subject{
+				{Kind: "ServiceAccount", Name: "shared-sa", Namespace: "shared-ns"},
+			},
+		},
+	}
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-sa",
+			Namespace: "shared-ns",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: authorizationv1alpha1.GroupVersion.String(),
+					Kind:       "BindDefinition",
+					Name:       "bd-a",
+					UID:        "uid-a",
+					Controller: &isNotController,
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(bdA, bdB, ns, sa).
+		WithStatusSubresource(bdA).
+		Build()
+	r := &BindDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
+
+	_, err := r.reconcileDelete(ctx, bdA)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	deletedSA := &corev1.ServiceAccount{}
+	err = c.Get(ctx, types.NamespacedName{Name: "shared-sa", Namespace: "shared-ns"}, deletedSA)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "SA should be deleted when the peer has not adopted it")
 }
 
 // TestReconcileDeleteRemovesSAWhenNotShared verifies that deleting a BD removes

--- a/internal/controller/authorization/binddefinition_helpers.go
+++ b/internal/controller/authorization/binddefinition_helpers.go
@@ -67,6 +67,26 @@ func hasControllerOwnerRef(obj, owner metav1.Object) bool {
 	return hasOwnerRefMatching(obj, owner, true)
 }
 
+func removeOwnerRef(obj, owner metav1.Object) bool {
+	ownerUID := owner.GetUID()
+	ownerAPIVersion, ownerKind := ownerReferenceIdentity(owner)
+	if ownerUID == "" || ownerAPIVersion == "" || ownerKind == "" || owner.GetName() == "" {
+		return false
+	}
+	originalLen := len(obj.GetOwnerReferences())
+	ownerRefs := slices.DeleteFunc(obj.GetOwnerReferences(), func(ref metav1.OwnerReference) bool {
+		return ref.APIVersion == ownerAPIVersion &&
+			ref.Kind == ownerKind &&
+			ref.Name == owner.GetName() &&
+			ref.UID == ownerUID
+	})
+	if len(ownerRefs) == originalLen {
+		return false
+	}
+	obj.SetOwnerReferences(ownerRefs)
+	return true
+}
+
 func hasOwnerRefMatching(obj, owner metav1.Object, requireController bool) bool {
 	ownerUID := owner.GetUID()
 	ownerAPIVersion, ownerKind := ownerReferenceIdentity(owner)
@@ -191,7 +211,7 @@ func (r *BindDefinitionReconciler) deleteServiceAccount(
 	}
 
 	// Check if referenced by other BindDefinitions
-	isReferenced, err := r.isSAReferencedByOtherBindDefs(ctx, bindDef.Name, sa.Name, sa.Namespace)
+	isReferenced, err := r.isSAReferencedByOtherBindDefs(ctx, bindDef.Name, sa.Name, sa.Namespace, sa)
 	if err != nil {
 		logger.Error(err, "Failed to check if ServiceAccount is referenced by other BindDefinitions",
 			"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name, "namespace", sa.Namespace)
@@ -208,27 +228,37 @@ func (r *BindDefinitionReconciler) deleteServiceAccount(
 			if getErr := r.client.Get(ctx, types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, fresh); getErr != nil {
 				return getErr
 			}
-			if fresh.Annotations == nil {
-				return nil
+			sourceNamesChanged := false
+			newSourceNames := ""
+			if fresh.Annotations != nil {
+				oldSourceNames := fresh.Annotations[helpers.SourceNamesAnnotation]
+				newSourceNames = helpers.RemoveSourceName(oldSourceNames, bindDef.Name)
+				if newSourceNames != oldSourceNames {
+					sourceNamesChanged = true
+				}
 			}
-			oldSourceNames := fresh.Annotations[helpers.SourceNamesAnnotation]
-			newSourceNames := helpers.RemoveSourceName(oldSourceNames, bindDef.Name)
-			if newSourceNames == oldSourceNames {
+			ownerRefChanged := hasOwnerRef(fresh, bindDef)
+			if !sourceNamesChanged && !ownerRefChanged {
 				return nil
 			}
 			orig := fresh.DeepCopy()
-			fresh.Annotations[helpers.SourceNamesAnnotation] = newSourceNames
+			if sourceNamesChanged {
+				fresh.Annotations[helpers.SourceNamesAnnotation] = newSourceNames
+			}
+			if ownerRefChanged {
+				removeOwnerRef(fresh, bindDef)
+			}
 			if err := r.client.Patch(ctx, fresh, sigs_client.MergeFromWithOptions(orig, sigs_client.MergeFromWithOptimisticLock{})); err != nil {
 				return err
 			}
 			patched = true
 			return nil
 		}); patchErr != nil {
-			logger.Error(patchErr, "Failed to update source-names annotation on retained ServiceAccount",
+			logger.Error(patchErr, "Failed to update metadata on retained ServiceAccount",
 				"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name, "namespace", sa.Namespace)
 			// Non-fatal - continue with deletion cleanup
 		} else if patched {
-			logger.V(2).Info("Updated source-names annotation on retained ServiceAccount",
+			logger.V(2).Info("Updated metadata on retained ServiceAccount",
 				"bindDefinitionName", bindDef.Name, "serviceAccount", sa.Name)
 		}
 

--- a/internal/controller/authorization/binddefinition_helpers_test.go
+++ b/internal/controller/authorization/binddefinition_helpers_test.go
@@ -961,6 +961,7 @@ func TestDeleteServiceAccountUnit(t *testing.T) {
 	t.Run("skips SA referenced by other BindDefinitions", func(t *testing.T) {
 		g := NewWithT(t)
 
+		isNotController := false
 		bindDef := &authorizationv1alpha1.BindDefinition{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: authorizationv1alpha1.GroupVersion.String(),
@@ -993,7 +994,8 @@ func TestDeleteServiceAccountUnit(t *testing.T) {
 					helpers.SourceNamesAnnotation: "other-bd,shared-sa-bd",
 				},
 				OwnerReferences: []metav1.OwnerReference{
-					{APIVersion: authorizationv1alpha1.GroupVersion.String(), Kind: "BindDefinition", Name: "shared-sa-bd", UID: "shared-sa-uid", Controller: &isController},
+					{APIVersion: authorizationv1alpha1.GroupVersion.String(), Kind: "BindDefinition", Name: "shared-sa-bd", UID: "shared-sa-uid", Controller: &isNotController},
+					{APIVersion: authorizationv1alpha1.GroupVersion.String(), Kind: "BindDefinition", Name: "other-bd", UID: "other-uid", Controller: &isNotController},
 				},
 			},
 		}
@@ -1008,6 +1010,12 @@ func TestDeleteServiceAccountUnit(t *testing.T) {
 		retainedSA := &corev1.ServiceAccount{}
 		g.Expect(c.Get(ctx, client.ObjectKey{Name: "shared-sa", Namespace: "test-ns"}, retainedSA)).To(Succeed())
 		g.Expect(retainedSA.Annotations).To(HaveKeyWithValue(helpers.SourceNamesAnnotation, "other-bd"))
+		g.Expect(retainedSA.OwnerReferences).To(ContainElement(WithTransform(func(ref metav1.OwnerReference) string {
+			return ref.Name
+		}, Equal("other-bd"))))
+		g.Expect(retainedSA.OwnerReferences).NotTo(ContainElement(WithTransform(func(ref metav1.OwnerReference) string {
+			return ref.Name
+		}, Equal("shared-sa-bd"))))
 	})
 }
 


### PR DESCRIPTION
## Summary
- remove the current BindDefinition ownerRef from a retained shared ServiceAccount when another BindDefinition still references it
- keep the remaining ownerRefs and source-names annotation in sync during ServiceAccount cleanup
- extend the retained shared ServiceAccount unit test to prove stale ownerRefs are pruned

## Evidence
- `go test ./internal/controller/authorization -run 'TestDeleteServiceAccountUnit|TestIsSAReferencedByOtherBindDefs|TestDeleteSubjectServiceAccounts' -count=1`\n- `golangci-lint run --timeout 10m --new-from-rev origin/main ./internal/controller/authorization/...`\n- `git diff --check`\n\n## Duplicate check\n- Confirmed against current `origin/main`; no open source PR in this batch covers retained shared ServiceAccount ownerRef cleanup.