### PR TITLE
fix(restricted): refresh policy violation metrics

### DIFF
--- a/internal/controller/authorization/restrictedbinddefinition_controller.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller.go
@@ -705,6 +705,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdHandleMissingPolicy(
 		authorizationv1alpha1.EventReasonPolicyNotFound, authorizationv1alpha1.EventActionReconcile,
 		"Referenced RBACPolicy %q not found", rbd.Spec.PolicyRef.Name)
 	rbd.Status.PolicyViolations = []string{fmt.Sprintf("policy %q not found", rbd.Spec.PolicyRef.Name)}
+	metrics.SetPolicyViolationsActive(metrics.ControllerRestrictedBindDefinition, rbd.Name, len(rbd.Status.PolicyViolations))
 	if err := r.rbdDeprovision(ctx, rbd, r.client); err != nil {
 		r.rbdMarkStalled(ctx, rbd, err)
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()
@@ -733,6 +734,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdHandleDeletingPolicy(
 		authorizationv1alpha1.EventReasonPolicyViolation, authorizationv1alpha1.EventActionReconcile,
 		"Referenced RBACPolicy %q is being deleted", rbacPolicy.Name)
 	rbd.Status.PolicyViolations = []string{fmt.Sprintf("policy %q is being deleted", rbacPolicy.Name)}
+	metrics.SetPolicyViolationsActive(metrics.ControllerRestrictedBindDefinition, rbd.Name, len(rbd.Status.PolicyViolations))
 	if err := r.rbdDeprovision(ctx, rbd, r.client); err != nil {
 		r.rbdMarkStalled(ctx, rbd, err)
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()

--- a/internal/controller/authorization/restrictedbinddefinition_controller_test.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller_test.go
@@ -235,6 +235,15 @@ func readGaugeValue(t *testing.T, gauge prometheus.Gauge) float64 {
 	return metric.GetGauge().GetValue()
 }
 
+func policyViolationsMetricValue(t *testing.T, controller string) float64 {
+	t.Helper()
+	gauge, err := metrics.PolicyViolationsActive.GetMetricWithLabelValues(controller)
+	if err != nil {
+		t.Fatalf("get policy violation metric: %v", err)
+	}
+	return readGaugeValue(t, gauge)
+}
+
 func rbdPolicyWithDefaultAllowances(policy *authorizationv1alpha1.RBACPolicy) *authorizationv1alpha1.RBACPolicy {
 	if policy.Spec.BindingLimits == nil {
 		policy.Spec.BindingLimits = &authorizationv1alpha1.BindingLimits{AllowClusterRoleBindings: true}
@@ -316,6 +325,10 @@ func TestRBD_Reconcile_PolicyNotFound(t *testing.T) {
 		},
 	}
 
+	metrics.DeletePolicyViolationContribution(metrics.ControllerRestrictedBindDefinition, rbd.Name)
+	beforePolicyViolations := policyViolationsMetricValue(t, metrics.ControllerRestrictedBindDefinition)
+	defer metrics.DeletePolicyViolationContribution(metrics.ControllerRestrictedBindDefinition, rbd.Name)
+
 	r, c := newRBDTestReconciler(rbd, ownedCRB, ownedSA)
 	result, err := r.Reconcile(rbdCtx(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test-rbd"},
@@ -328,6 +341,7 @@ func TestRBD_Reconcile_PolicyNotFound(t *testing.T) {
 	g.Expect(updated.Status.PolicyViolations).To(gomega.HaveLen(1))
 	g.Expect(updated.Status.PolicyViolations[0]).To(gomega.ContainSubstring("missing-policy"))
 	g.Expect(conditions.IsStalled(&updated)).To(gomega.BeTrue())
+	g.Expect(policyViolationsMetricValue(t, metrics.ControllerRestrictedBindDefinition)).To(gomega.Equal(beforePolicyViolations + 1))
 
 	var deletedCRB rbacv1.ClusterRoleBinding
 	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Name: ownedCRB.Name}, &deletedCRB)).NotTo(gomega.Succeed())
@@ -541,6 +555,10 @@ func TestRBD_Reconcile_DeletingPolicyDeprovisions(t *testing.T) {
 		},
 	}
 
+	metrics.DeletePolicyViolationContribution(metrics.ControllerRestrictedBindDefinition, rbd.Name)
+	beforePolicyViolations := policyViolationsMetricValue(t, metrics.ControllerRestrictedBindDefinition)
+	defer metrics.DeletePolicyViolationContribution(metrics.ControllerRestrictedBindDefinition, rbd.Name)
+
 	r, c := newRBDTestReconciler(pol, rbd, crb)
 	result, err := r.Reconcile(rbdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rbd.Name}})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
@@ -553,6 +571,7 @@ func TestRBD_Reconcile_DeletingPolicyDeprovisions(t *testing.T) {
 	g.Expect(c.Get(rbdCtx(), types.NamespacedName{Name: rbd.Name}, &updated)).To(gomega.Succeed())
 	g.Expect(updated.Status.PolicyViolations).To(gomega.ConsistOf("policy \"deleting-policy\" is being deleted"))
 	g.Expect(conditions.IsStalled(&updated)).To(gomega.BeTrue())
+	g.Expect(policyViolationsMetricValue(t, metrics.ControllerRestrictedBindDefinition)).To(gomega.Equal(beforePolicyViolations + 1))
 }
 
 func TestRBD_Reconcile_DeletingPolicyUsesControllerClientForRevocation(t *testing.T) {

--- a/internal/controller/authorization/restrictedroledefinition_controller.go
+++ b/internal/controller/authorization/restrictedroledefinition_controller.go
@@ -459,6 +459,7 @@ func (r *RestrictedRoleDefinitionReconciler) rrdHandleMissingPolicy(
 	conditions.MarkFalse(rrd, authorizationv1alpha1.PolicyCompliantCondition, rrd.Generation,
 		authorizationv1alpha1.PolicyCompliantReasonPolicyNotFound, authorizationv1alpha1.PolicyCompliantMessagePolicyNotFound, rrd.Spec.PolicyRef.Name)
 	rrd.Status.PolicyViolations = []string{fmt.Sprintf("policy %q not found", rrd.Spec.PolicyRef.Name)}
+	metrics.SetPolicyViolationsActive(metrics.ControllerRestrictedRoleDefinition, rrd.Name, len(rrd.Status.PolicyViolations))
 	r.recorder.Eventf(rrd, nil, corev1.EventTypeWarning,
 		authorizationv1alpha1.EventReasonPolicyNotFound, authorizationv1alpha1.EventActionReconcile,
 		"Referenced RBACPolicy %q not found", rrd.Spec.PolicyRef.Name)
@@ -489,6 +490,7 @@ func (r *RestrictedRoleDefinitionReconciler) rrdHandleDeletingPolicy(
 	conditions.MarkFalse(rrd, authorizationv1alpha1.PolicyCompliantCondition, rrd.Generation,
 		authorizationv1alpha1.PolicyCompliantReasonPolicyDeleting, authorizationv1alpha1.PolicyCompliantMessagePolicyDeleting, rbacPolicy.Name)
 	rrd.Status.PolicyViolations = []string{fmt.Sprintf("policy %q is being deleted", rbacPolicy.Name)}
+	metrics.SetPolicyViolationsActive(metrics.ControllerRestrictedRoleDefinition, rrd.Name, len(rrd.Status.PolicyViolations))
 	r.recorder.Eventf(rrd, nil, corev1.EventTypeWarning,
 		authorizationv1alpha1.EventReasonPolicyViolation, authorizationv1alpha1.EventActionReconcile,
 		"Referenced RBACPolicy %q is being deleted", rbacPolicy.Name)

--- a/internal/controller/authorization/restrictedroledefinition_controller_test.go
+++ b/internal/controller/authorization/restrictedroledefinition_controller_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/telekom/auth-operator/pkg/discovery"
 	"github.com/telekom/auth-operator/pkg/helpers"
 	"github.com/telekom/auth-operator/pkg/indexer"
+	"github.com/telekom/auth-operator/pkg/metrics"
 )
 
 // --- Standard Go tests (no envtest) ---
@@ -124,6 +125,10 @@ func TestRRD_Reconcile_PolicyNotFound(t *testing.T) {
 		},
 	}
 
+	metrics.DeletePolicyViolationContribution(metrics.ControllerRestrictedRoleDefinition, rrd.Name)
+	beforePolicyViolations := policyViolationsMetricValue(t, metrics.ControllerRestrictedRoleDefinition)
+	defer metrics.DeletePolicyViolationContribution(metrics.ControllerRestrictedRoleDefinition, rrd.Name)
+
 	r, c := newRRDTestReconcilerFake(rrd, ownedRole)
 	result, err := r.Reconcile(rrdCtx(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test-rrd"},
@@ -136,6 +141,7 @@ func TestRRD_Reconcile_PolicyNotFound(t *testing.T) {
 	g.Expect(updated.Status.PolicyViolations).To(HaveLen(1))
 	g.Expect(updated.Status.PolicyViolations[0]).To(ContainSubstring("missing-policy"))
 	g.Expect(conditions.IsStalled(&updated)).To(BeTrue())
+	g.Expect(policyViolationsMetricValue(t, metrics.ControllerRestrictedRoleDefinition)).To(Equal(beforePolicyViolations + 1))
 
 	var deletedRole rbacv1.ClusterRole
 	g.Expect(c.Get(rrdCtx(), types.NamespacedName{Name: ownedRole.Name}, &deletedRole)).NotTo(Succeed())
@@ -272,6 +278,10 @@ func TestRRD_Reconcile_DeletingPolicyIsUnavailable(t *testing.T) {
 		},
 	}
 
+	metrics.DeletePolicyViolationContribution(metrics.ControllerRestrictedRoleDefinition, rrd.Name)
+	beforePolicyViolations := policyViolationsMetricValue(t, metrics.ControllerRestrictedRoleDefinition)
+	defer metrics.DeletePolicyViolationContribution(metrics.ControllerRestrictedRoleDefinition, rrd.Name)
+
 	r, c := newRRDTestReconcilerFake(pol, rrd, ownedClusterRole)
 	result, err := r.Reconcile(rrdCtx(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: rrd.Name},
@@ -286,6 +296,7 @@ func TestRRD_Reconcile_DeletingPolicyIsUnavailable(t *testing.T) {
 	g.Expect(c.Get(rrdCtx(), types.NamespacedName{Name: rrd.Name}, &updated)).To(Succeed())
 	g.Expect(updated.Status.PolicyViolations).To(ConsistOf("policy \"deleting-policy\" is being deleted"))
 	g.Expect(conditions.IsStalled(&updated)).To(BeTrue())
+	g.Expect(policyViolationsMetricValue(t, metrics.ControllerRestrictedRoleDefinition)).To(Equal(beforePolicyViolations + 1))
 }
 
 func TestRRD_Reconcile_DeletingPolicyUsesControllerClientForRevocation(t *testing.T) {


### PR DESCRIPTION
## Summary
- update `policy_violations_active` when RestrictedBindDefinition missing/deleting policy handlers set `status.policyViolations`
- update the same metric for RestrictedRoleDefinition missing/deleting policy handlers
- extend existing missing/deleting policy tests to assert the aggregate gauge changes for the affected resource

## Evidence
- `go test ./internal/controller/authorization -run 'Test(RBD_Reconcile_(PolicyNotFound|DeletingPolicyDeprovisions)|RRD_Reconcile_(PolicyNotFound|DeletingPolicyIsUnavailable))$' -count=1`\n- `golangci-lint run --timeout 10m --new-from-rev origin/main ./internal/controller/authorization/...`\n- `git diff --check`\n\n## Duplicate check\n- Live PR #378 covers WebhookAuthorizer active-rules refresh only.\n- Live PRs #376, #377, #379, #380, and #381 do not touch restricted policy violation metric paths.