### PR TITLE
chore: sync kubebuilder project resources

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -33,9 +33,46 @@ resources:
     webhookVersion: v1
 - api:
     crdVersion: v1
+  controller: true
   domain: t-caas.telekom.com
   group: authorization
   kind: WebhookAuthorizer
   path: github.com/telekom/auth-operator/api/authorization/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+  controller: true
+  domain: t-caas.telekom.com
+  group: authorization
+  kind: RBACPolicy
+  path: github.com/telekom/auth-operator/api/authorization/v1alpha1
+  version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+  controller: true
+  domain: t-caas.telekom.com
+  group: authorization
+  kind: RestrictedRoleDefinition
+  path: github.com/telekom/auth-operator/api/authorization/v1alpha1
+  version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+  controller: true
+  domain: t-caas.telekom.com
+  group: authorization
+  kind: RestrictedBindDefinition
+  path: github.com/telekom/auth-operator/api/authorization/v1alpha1
+  version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 version: "3"


### PR DESCRIPTION
## Summary
- add RBACPolicy, RestrictedRoleDefinition, and RestrictedBindDefinition to Kubebuilder `PROJECT` metadata
- keep generated CRD/RBAC/Helm artifacts unchanged

## Evidence
- `yq '.resources[].kind' PROJECT` now lists all six authorization API resources\n- `make manifests generate helm`\n- `git diff --exit-code -- config/crd/bases config/rbac api/authorization/v1alpha1/zz_generated.deepcopy.go api/authorization/v1alpha1/applyconfiguration chart/auth-operator/crds`\n- `git diff --check`\n\n## Duplicate check\n- Live PRs #376-#382 do not touch `PROJECT`.\n- Generated artifacts were already in sync; this PR only updates scaffold metadata.