### PR TITLE
fix(restricted): count returned reconcile errors

### DIFF
--- a/internal/controller/authorization/restrictedbinddefinition_controller.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller.go
@@ -572,6 +572,7 @@ func (r *RestrictedBindDefinitionReconciler) Reconcile(ctx context.Context, req 
 			}
 			r.rbdMarkStalled(ctx, rbd, err)
 			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()
+			metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ErrorTypeAPI).Inc()
 			return ctrl.Result{}, fmt.Errorf("add finalizer to RestrictedBindDefinition %s: %w", rbd.Name, err)
 		}
 	}
@@ -677,6 +678,7 @@ func (r *RestrictedBindDefinitionReconciler) rbdFetchPolicy(
 		}
 		r.rbdMarkStalled(ctx, rbd, err)
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()
+		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ErrorTypeAPI).Inc()
 		return nil, ctrl.Result{}, false, fmt.Errorf("fetch RBACPolicy %s: %w", rbd.Spec.PolicyRef.Name, err)
 	}
 	return rbacPolicy, ctrl.Result{}, false, nil
@@ -715,7 +717,10 @@ func (r *RestrictedBindDefinitionReconciler) rbdHandleMissingPolicy(
 	}
 	rbdClearDeprovisionedStatus(rbd)
 	if err := r.rbdApplyStatusAndMarkStalled(ctx, rbd, "policy not found"); err != nil {
-		return ctrl.Result{}, err
+		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()
+		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ErrorTypeAPI).Inc()
+		return ctrl.Result{}, fmt.Errorf("apply stalled status for RestrictedBindDefinition %s after missing policy %s: %w",
+			rbd.Name, rbd.Spec.PolicyRef.Name, err)
 	}
 	metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultDegraded).Inc()
 	return ctrl.Result{RequeueAfter: DefaultRequeueInterval}, nil
@@ -744,7 +749,10 @@ func (r *RestrictedBindDefinitionReconciler) rbdHandleDeletingPolicy(
 	}
 	rbdClearDeprovisionedStatus(rbd)
 	if err := r.rbdApplyStatusAndMarkStalled(ctx, rbd, "policy deleting"); err != nil {
-		return ctrl.Result{}, err
+		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultError).Inc()
+		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ErrorTypeAPI).Inc()
+		return ctrl.Result{}, fmt.Errorf("apply stalled status for RestrictedBindDefinition %s after deleting policy %s: %w",
+			rbd.Name, rbacPolicy.Name, err)
 	}
 	metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedBindDefinition, metrics.ResultDegraded).Inc()
 	return ctrl.Result{RequeueAfter: DefaultRequeueInterval}, nil

--- a/internal/controller/authorization/restrictedbinddefinition_controller_test.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller_test.go
@@ -244,6 +244,24 @@ func policyViolationsMetricValue(t *testing.T, controller string) float64 {
 	return readGaugeValue(t, gauge)
 }
 
+func readCounterValue(t *testing.T, counter prometheus.Counter) float64 {
+	t.Helper()
+	metric := &dto.Metric{}
+	if err := counter.(prometheus.Metric).Write(metric); err != nil {
+		t.Fatalf("write counter: %v", err)
+	}
+	return metric.GetCounter().GetValue()
+}
+
+func reconcileErrorCount(t *testing.T, controller string) float64 {
+	t.Helper()
+	counter, err := metrics.ReconcileErrors.GetMetricWithLabelValues(controller, metrics.ErrorTypeAPI)
+	if err != nil {
+		t.Fatalf("get reconcile error counter: %v", err)
+	}
+	return readCounterValue(t, counter)
+}
+
 func rbdPolicyWithDefaultAllowances(policy *authorizationv1alpha1.RBACPolicy) *authorizationv1alpha1.RBACPolicy {
 	if policy.Spec.BindingLimits == nil {
 		policy.Spec.BindingLimits = &authorizationv1alpha1.BindingLimits{AllowClusterRoleBindings: true}
@@ -279,6 +297,85 @@ func TestRBD_Reconcile_NotFound(t *testing.T) {
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+}
+
+func TestRBD_Reconcile_FinalizerPatchErrorIncrementsReconcileErrors(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	s := newTestScheme()
+	rbd := &authorizationv1alpha1.RestrictedBindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "finalizer-error-rbd", Generation: 1},
+		Spec: authorizationv1alpha1.RestrictedBindDefinitionSpec{
+			PolicyRef:  authorizationv1alpha1.RBACPolicyReference{Name: "policy"},
+			TargetName: "target",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rbd).
+		WithStatusSubresource(&authorizationv1alpha1.RestrictedBindDefinition{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				return fmt.Errorf("patch failed")
+			},
+		}).
+		Build()
+	r := &RestrictedBindDefinitionReconciler{
+		client:   c,
+		reader:   c,
+		scheme:   s,
+		recorder: events.NewFakeRecorder(10),
+	}
+
+	before := reconcileErrorCount(t, metrics.ControllerRestrictedBindDefinition)
+	_, err := r.Reconcile(rbdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rbd.Name}})
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("add finalizer"))
+	g.Expect(reconcileErrorCount(t, metrics.ControllerRestrictedBindDefinition)).To(gomega.Equal(before + 1))
+}
+
+func TestRBD_Reconcile_PolicyReadErrorIncrementsReconcileErrors(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	s := newTestScheme()
+	rbd := &authorizationv1alpha1.RestrictedBindDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "policy-read-error-rbd",
+			Generation: 1,
+			Finalizers: []string{
+				authorizationv1alpha1.RestrictedBindDefinitionFinalizer,
+			},
+		},
+		Spec: authorizationv1alpha1.RestrictedBindDefinitionSpec{
+			PolicyRef:  authorizationv1alpha1.RBACPolicyReference{Name: "policy"},
+			TargetName: "target",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rbd).
+		WithStatusSubresource(&authorizationv1alpha1.RestrictedBindDefinition{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*authorizationv1alpha1.RBACPolicy); ok {
+					return fmt.Errorf("policy read failed")
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	r := &RestrictedBindDefinitionReconciler{
+		client:   c,
+		reader:   c,
+		scheme:   s,
+		recorder: events.NewFakeRecorder(10),
+	}
+
+	before := reconcileErrorCount(t, metrics.ControllerRestrictedBindDefinition)
+	_, err := r.Reconcile(rbdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rbd.Name}})
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("fetch RBACPolicy"))
+	g.Expect(reconcileErrorCount(t, metrics.ControllerRestrictedBindDefinition)).To(gomega.Equal(before + 1))
 }
 
 func TestRBD_Reconcile_PolicyNotFound(t *testing.T) {
@@ -383,12 +480,14 @@ func TestRBD_Reconcile_PolicyNotFoundReturnsStatusApplyError(t *testing.T) {
 		recorder: events.NewFakeRecorder(10),
 	}
 
+	before := reconcileErrorCount(t, metrics.ControllerRestrictedBindDefinition)
 	_, err := r.Reconcile(rbdCtx(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: rbd.Name},
 	})
 	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(err.Error()).To(gomega.ContainSubstring("stalled status"))
 	g.Expect(err.Error()).To(gomega.ContainSubstring("status apply failed"))
+	g.Expect(reconcileErrorCount(t, metrics.ControllerRestrictedBindDefinition)).To(gomega.Equal(before + 1))
 }
 
 func TestRBD_Reconcile_PolicyViolation_Deprovision(t *testing.T) {

--- a/internal/controller/authorization/restrictedroledefinition_controller.go
+++ b/internal/controller/authorization/restrictedroledefinition_controller.go
@@ -356,6 +356,7 @@ func (r *RestrictedRoleDefinitionReconciler) Reconcile(ctx context.Context, req 
 			}
 			r.rrdMarkStalled(ctx, rrd, err)
 			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ResultError).Inc()
+			metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ErrorTypeAPI).Inc()
 			return ctrl.Result{}, fmt.Errorf("add finalizer to RestrictedRoleDefinition %s: %w", rrd.Name, err)
 		}
 	}
@@ -398,6 +399,8 @@ func (r *RestrictedRoleDefinitionReconciler) Reconcile(ctx context.Context, req 
 	}
 	if requeue {
 		if err := ssa.ApplyRestrictedRoleDefinitionStatus(ctx, r.client, rrd); err != nil {
+			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ResultError).Inc()
+			metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ErrorTypeAPI).Inc()
 			return ctrl.Result{}, fmt.Errorf("apply status before requeue for RestrictedRoleDefinition %s: %w", rrd.Name, err)
 		}
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRestrictedRoleDefinition, metrics.ResultRequeue).Inc()

--- a/internal/controller/authorization/restrictedroledefinition_controller_test.go
+++ b/internal/controller/authorization/restrictedroledefinition_controller_test.go
@@ -100,6 +100,42 @@ func TestRRD_Reconcile_NotFound(t *testing.T) {
 	g.Expect(result).To(Equal(ctrl.Result{}))
 }
 
+func TestRRD_Reconcile_FinalizerPatchErrorIncrementsReconcileErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	s := newTestScheme()
+	rrd := &authorizationv1alpha1.RestrictedRoleDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "finalizer-error-rrd", Generation: 1},
+		Spec: authorizationv1alpha1.RestrictedRoleDefinitionSpec{
+			PolicyRef:  authorizationv1alpha1.RBACPolicyReference{Name: "policy"},
+			TargetName: "target",
+			TargetRole: authorizationv1alpha1.DefinitionClusterRole,
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(rrd).
+		WithStatusSubresource(&authorizationv1alpha1.RestrictedRoleDefinition{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				return fmt.Errorf("patch failed")
+			},
+		}).
+		Build()
+	r := &RestrictedRoleDefinitionReconciler{
+		client:   c,
+		reader:   c,
+		scheme:   s,
+		recorder: events.NewFakeRecorder(10),
+	}
+
+	before := reconcileErrorCount(t, metrics.ControllerRestrictedRoleDefinition)
+	_, err := r.Reconcile(rrdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rrd.Name}})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("add finalizer"))
+	g.Expect(reconcileErrorCount(t, metrics.ControllerRestrictedRoleDefinition)).To(Equal(before + 1))
+}
+
 func TestRRD_Reconcile_PolicyNotFound(t *testing.T) {
 	g := NewWithT(t)
 
@@ -177,12 +213,14 @@ func TestRRD_Reconcile_PolicyNotFoundReturnsStatusApplyError(t *testing.T) {
 		recorder: events.NewFakeRecorder(10),
 	}
 
+	before := reconcileErrorCount(t, metrics.ControllerRestrictedRoleDefinition)
 	_, err := r.Reconcile(rrdCtx(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: rrd.Name},
 	})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("stalled status"))
 	g.Expect(err.Error()).To(ContainSubstring("status apply failed"))
+	g.Expect(reconcileErrorCount(t, metrics.ControllerRestrictedRoleDefinition)).To(Equal(before + 1))
 }
 
 func TestRRD_Reconcile_UsesReaderForPolicyEvaluation(t *testing.T) {
@@ -1019,6 +1057,64 @@ func TestRRD_Reconcile_TrackerNotStarted_Requeues(t *testing.T) {
 	})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.RequeueAfter).NotTo(BeZero())
+}
+
+func TestRRD_Reconcile_TrackerNotStartedStatusApplyErrorIncrementsReconcileErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	pol := &authorizationv1alpha1.RBACPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "tracker-status-error-pol", Generation: 1},
+		Spec: authorizationv1alpha1.RBACPolicySpec{
+			AppliesTo: authorizationv1alpha1.PolicyScope{Namespaces: []string{"*"}},
+			RoleLimits: &authorizationv1alpha1.RoleLimits{
+				AllowClusterRoles: true,
+			},
+		},
+	}
+	rrd := &authorizationv1alpha1.RestrictedRoleDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "tracker-status-error-rrd",
+			Generation: 1,
+			Finalizers: []string{
+				authorizationv1alpha1.RestrictedRoleDefinitionFinalizer,
+			},
+		},
+		Spec: authorizationv1alpha1.RestrictedRoleDefinitionSpec{
+			PolicyRef:  authorizationv1alpha1.RBACPolicyReference{Name: pol.Name},
+			TargetName: "tracker-role",
+			TargetRole: authorizationv1alpha1.DefinitionClusterRole,
+		},
+	}
+
+	s := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(pol, rrd).
+		WithStatusSubresource(
+			&authorizationv1alpha1.RestrictedRoleDefinition{},
+			&authorizationv1alpha1.RBACPolicy{},
+		).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceApply: func(_ context.Context, _ client.Client, _ string, _ runtime.ApplyConfiguration, _ ...client.SubResourceApplyOption) error {
+				return fmt.Errorf("status apply failed")
+			},
+		}).
+		Build()
+	tracker := discovery.NewResourceTracker(s, nil)
+	r := &RestrictedRoleDefinitionReconciler{
+		client:          c,
+		reader:          c,
+		scheme:          s,
+		recorder:        events.NewFakeRecorder(10),
+		resourceTracker: tracker,
+	}
+
+	before := reconcileErrorCount(t, metrics.ControllerRestrictedRoleDefinition)
+	_, err := r.Reconcile(rrdCtx(), ctrl.Request{NamespacedName: types.NamespacedName{Name: rrd.Name}})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("apply status before requeue"))
+	g.Expect(err.Error()).To(ContainSubstring("status apply failed"))
+	g.Expect(reconcileErrorCount(t, metrics.ControllerRestrictedRoleDefinition)).To(Equal(before + 1))
 }
 
 func TestRRD_EnsureRole_InvalidTargetRole(t *testing.T) {


### PR DESCRIPTION
## Summary
- increment `auth_operator_reconcile_errors_total` for restricted finalizer patch failures and RBACPolicy read failures
- count stalled-status apply failures on restricted missing/deleting policy and tracker requeue paths as returned reconcile errors
- add focused fake-client tests that assert counter deltas for those returned-error paths

## Evidence
The restricted reconcilers already incremented `reconcile_total{result="error"}` on several returned API errors, but some paths skipped the paired `reconcile_errors_total{error_type="api"}` counter. Other stalled-status apply failures returned an error without either error metric.

## Validation
- `go test ./internal/controller/authorization -run 'Test(RBD_Reconcile_(FinalizerPatchErrorIncrementsReconcileErrors|PolicyReadErrorIncrementsReconcileErrors|PolicyNotFoundReturnsStatusApplyError)|RRD_Reconcile_(FinalizerPatchErrorIncrementsReconcileErrors|PolicyNotFoundReturnsStatusApplyError|TrackerNotStartedStatusApplyErrorIncrementsReconcileErrors))$' -count=1`\n- `go test ./internal/controller/authorization -run 'Test(RBD_Reconcile|RRD_Reconcile)' -count=1`\n- `golangci-lint run --timeout 10m --new-from-rev origin/main ./internal/controller/authorization/...`\n- `git diff --check`\n\n## Duplicate check\nChecked live open PRs #365-#383. #382 touches the same restricted controller files for `PolicyViolationsActive` gauge updates, but does not change `ReconcileErrors` / `reconcile_errors_total`. No open PR covers these restricted returned-error counter gaps.