### PR TITLE
fix(binddefinition): requeue rolebinding roleRef changes

### DIFF
--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -76,6 +76,11 @@ const (
 	// self-heal within a reasonable window once they appear.
 	roleRefRequeueMax = 5 * time.Minute
 
+	// roleBindingRecreateRequeueInterval is used after deleting a RoleBinding
+	// whose immutable roleRef must change. The next pass should wait for the
+	// old binding to disappear before applying the replacement.
+	roleBindingRecreateRequeueInterval = 2 * time.Second
+
 	// maxActiveNamespaceNamesToLog bounds namespace-name logging to avoid
 	// oversized log lines that include large namespace sets.
 	maxActiveNamespaceNamesToLog = 20
@@ -99,6 +104,8 @@ func summarizeNamespaceNames(namespaces []corev1.Namespace, limit int) []string 
 
 // ErrMissingRoleRefs indicates that one or more referenced roles do not exist in the cluster.
 var ErrMissingRoleRefs = errors.New("missing role references")
+
+var errRoleBindingRecreatePending = errors.New("role binding recreate pending")
 
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=binddefinitions,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=binddefinitions/status,verbs=get;update;patch
@@ -508,6 +515,14 @@ func (r *BindDefinitionReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		"roleBindings", len(bindDefinition.Spec.RoleBindings))
 	missingRoleRefCount, err := r.reconcileResources(ctx, bindDefinition, activeNamespaces, perRoleBindingNamespaces)
 	if err != nil {
+		if errors.Is(err, errRoleBindingRecreatePending) {
+			logger.Info("Requeuing after deleting RoleBinding before immutable roleRef change",
+				"bindDefinition", bindDefinition.Name,
+				"requeueAfter", roleBindingRecreateRequeueInterval)
+			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerBindDefinition, metrics.ResultDegraded).Inc()
+			return ctrl.Result{RequeueAfter: roleBindingRecreateRequeueInterval}, nil
+		}
+
 		// When the error policy blocks reconciliation due to missing roles,
 		// apply status (which includes the RoleRefsValid=False condition) and
 		// requeue with the short interval so we retry quickly once the roles
@@ -894,11 +909,15 @@ func (r *BindDefinitionReconciler) ensureSingleRoleBinding(
 		Name:     roleRef,
 	}
 
-	if err := r.deleteOwnedRoleBindingOnRoleRefChange(ctx, bindDef, namespace, rbName, desiredRoleRef); err != nil {
+	roleRefChangePending, err := r.deleteOwnedRoleBindingOnRoleRefChange(ctx, bindDef, namespace, rbName, desiredRoleRef)
+	if err != nil {
 		conditions.MarkFalse(bindDef, authorizationv1alpha1.CreateCondition, bindDef.Generation,
 			authorizationv1alpha1.CreateReason, authorizationv1alpha1.CreateMessage)
 		r.applyStatusNonFatal(ctx, bindDef)
 		return err
+	}
+	if roleRefChangePending {
+		return errRoleBindingRecreatePending
 	}
 	if err := r.checkBindingOwnership(ctx, bindDef, "RoleBinding", rbName, namespace); err != nil {
 		conditions.MarkFalse(bindDef, authorizationv1alpha1.CreateCondition, bindDef.Generation,
@@ -992,19 +1011,25 @@ func (r *BindDefinitionReconciler) deleteOwnedRoleBindingOnRoleRefChange(
 	namespace string,
 	name string,
 	desiredRoleRef rbacv1.RoleRef,
-) error {
+) (bool, error) {
 	existing := &rbacv1.RoleBinding{}
 	if err := r.ownershipReader().Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, existing); err != nil {
-		return client.IgnoreNotFound(err)
+		return false, client.IgnoreNotFound(err)
 	}
 	if !hasControllerOwnerRef(existing, bindDef) || existing.RoleRef == desiredRoleRef {
-		return nil
+		return false, nil
 	}
-	if err := r.client.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("delete RoleBinding %s/%s before roleRef change: %w", namespace, name, err)
+	if !existing.DeletionTimestamp.IsZero() {
+		return true, nil
+	}
+	if err := r.client.Delete(ctx, existing); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("delete RoleBinding %s/%s before roleRef change: %w", namespace, name, err)
 	}
 	metrics.RBACResourcesDeleted.WithLabelValues(metrics.ResourceRoleBinding).Inc()
-	return nil
+	return true, nil
 }
 
 func (r *BindDefinitionReconciler) ownershipReader() client.Reader {

--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -2,6 +2,7 @@ package authorization
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -2484,7 +2485,7 @@ func TestEnsureRoleBindings(t *testing.T) {
 		g.Expect(roleRB.RoleRef.Name).To(Equal("developer"))
 	})
 
-	t.Run("recreates owned RoleBinding when roleRef kind changes", func(t *testing.T) {
+	t.Run("deletes owned RoleBinding before roleRef kind change and recreates on next pass", func(t *testing.T) {
 		g := NewWithT(t)
 
 		ns := &corev1.Namespace{
@@ -2534,12 +2535,80 @@ func TestEnsureRoleBindings(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 
 		err = r.ensureRoleBindings(ctx, bindDef, perRoleBindingNamespaces)
+		g.Expect(errors.Is(err, errRoleBindingRecreatePending)).To(BeTrue())
+
+		var deleted rbacv1.RoleBinding
+		err = c.Get(ctx, types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, &deleted)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "first pass should only delete the old immutable RoleBinding")
+
+		err = r.ensureRoleBindings(ctx, bindDef, perRoleBindingNamespaces)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		var rb rbacv1.RoleBinding
 		g.Expect(c.Get(ctx, types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, &rb)).To(Succeed())
 		g.Expect(rb.RoleRef).To(Equal(rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: "admin"}))
 		g.Expect(rb.Subjects).To(ConsistOf(bindDef.Spec.Subjects))
+	})
+
+	t.Run("waits while old RoleBinding with changed roleRef is terminating", func(t *testing.T) {
+		g := NewWithT(t)
+
+		now := metav1.Now()
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "transition-ns"},
+			Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+		}
+		bindDef := &authorizationv1alpha1.BindDefinition{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: authorizationv1alpha1.GroupVersion.String(),
+				Kind:       "BindDefinition",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "transition-bd",
+				UID:  "transition-bd-uid",
+			},
+			Spec: authorizationv1alpha1.BindDefinitionSpec{
+				TargetName: "transition-target",
+				Subjects: []rbacv1.Subject{
+					{Kind: rbacv1.GroupKind, Name: "devs", APIGroup: rbacv1.GroupName},
+				},
+				RoleBindings: []authorizationv1alpha1.NamespaceBinding{
+					{Namespace: "transition-ns", RoleRefs: []string{"admin"}},
+				},
+			},
+		}
+		existing := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              helpers.BuildBindingName("transition-target", "admin"),
+				Namespace:         "transition-ns",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{authorizationv1alpha1.RoleBindingFinalizer},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         authorizationv1alpha1.GroupVersion.String(),
+					Kind:               "BindDefinition",
+					Name:               bindDef.Name,
+					UID:                bindDef.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				}},
+			},
+			Subjects: bindDef.Spec.Subjects,
+			RoleRef:  rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "admin"},
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bindDef, ns, existing).Build()
+		r := &BindDefinitionReconciler{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+
+		_, perRoleBindingNamespaces, _, err := r.collectNamespaces(ctx, bindDef)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		err = r.ensureRoleBindings(ctx, bindDef, perRoleBindingNamespaces)
+		g.Expect(errors.Is(err, errRoleBindingRecreatePending)).To(BeTrue())
+
+		var rb rbacv1.RoleBinding
+		g.Expect(c.Get(ctx, types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, &rb)).To(Succeed())
+		g.Expect(rb.RoleRef).To(Equal(rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "admin"}))
+		g.Expect(rb.DeletionTimestamp).NotTo(BeNil())
 	})
 
 	t.Run("skips terminating namespaces", func(t *testing.T) {
@@ -2616,6 +2685,73 @@ func TestEnsureRoleBindings(t *testing.T) {
 		err := r.ensureRoleBindings(ctx, bindDef, nil)
 		g.Expect(err).NotTo(HaveOccurred())
 	})
+}
+
+func TestReconcileRequeuesAfterRoleBindingRoleRefChangeDelete(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	s := runtime.NewScheme()
+	_ = authorizationv1alpha1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "transition-ns"},
+		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	}
+	bindDef := &authorizationv1alpha1.BindDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: authorizationv1alpha1.GroupVersion.String(),
+			Kind:       "BindDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "transition-bd",
+			UID:        "transition-bd-uid",
+			Generation: 1,
+			Finalizers: []string{authorizationv1alpha1.BindDefinitionFinalizer},
+		},
+		Spec: authorizationv1alpha1.BindDefinitionSpec{
+			TargetName: "transition-target",
+			Subjects: []rbacv1.Subject{
+				{Kind: rbacv1.GroupKind, Name: "devs", APIGroup: rbacv1.GroupName},
+			},
+			RoleBindings: []authorizationv1alpha1.NamespaceBinding{
+				{Namespace: "transition-ns", RoleRefs: []string{"admin"}},
+			},
+		},
+	}
+	rbName := helpers.BuildBindingName("transition-target", "admin")
+	existing := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rbName,
+			Namespace: "transition-ns",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         authorizationv1alpha1.GroupVersion.String(),
+				Kind:               "BindDefinition",
+				Name:               bindDef.Name,
+				UID:                bindDef.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			}},
+		},
+		Subjects: bindDef.Spec.Subjects,
+		RoleRef:  rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "admin"},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(bindDef, ns, existing).
+		WithStatusSubresource(bindDef).
+		Build()
+	r := &BindDefinitionReconciler{client: c, scheme: s, recorder: events.NewFakeRecorder(10)}
+
+	result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: bindDef.Name}})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(roleBindingRecreateRequeueInterval))
+
+	var deleted rbacv1.RoleBinding
+	err = c.Get(ctx, types.NamespacedName{Name: rbName, Namespace: "transition-ns"}, &deleted)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 }
 
 func TestDeleteAllRoleBindings(t *testing.T) {


### PR DESCRIPTION
## Summary
- delete owned RoleBindings whose immutable `roleRef` differs from the desired binding and requeue before applying the replacement
- treat this transition as a benign degraded requeue instead of a hard reconcile error
- add regression coverage for the two-pass recreate path, terminating old RoleBindings, and the reconcile-level requeue result

## Evidence
`ensureSingleRoleBinding` deleted an owned RoleBinding on `roleRef` changes, then immediately continued to ownership checks and server-side apply. If the old RoleBinding is still terminating, for example because `auth-operator.telekom.com/rolebinding-cleanup` is present, the same reconcile can try to apply over an object whose immutable `roleRef` still has the old value.

Duplicate check: open PRs #365-#384 cover webhook contracts, missing-role pruning, selector pruning, deletion-once, metrics/docs, validation, and ServiceAccount owner refs. None cover the RoleBinding immutable `roleRef` delete-and-requeue path.

## Validation
- `go test ./internal/controller/authorization -run 'TestEnsureRoleBindings|TestReconcileRequeuesAfterRoleBindingRoleRefChangeDelete' -count=1`\n- `go test ./internal/controller/authorization -run 'TestEnsureRoleBindings|TestReconcileRequeuesAfterRoleBindingRoleRefChangeDelete|TestReconcileResourcesEnsureRBError|TestEnsureSingleRoleBindingError|TestDeleteAllRoleBindings' -count=1`\n- `golangci-lint run --timeout 10m --new-from-rev origin/main ./internal/controller/authorization/...`\n- `git diff --check`