### PR TITLE
fix(tracing): cover webhook authorizer reconciles

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -216,6 +216,7 @@ and their status is kept up to date.`,
 				mgr.GetClient(),
 				mgr.GetScheme(),
 				mgr.GetEventRecorder("WebhookAuthorizerReconciler"),
+				reconcilerOpts...,
 			)
 			if err := webhookAuthorizerController.SetupWithManager(mgr, webhookAuthorizerConcurrency); err != nil {
 				return fmt.Errorf("unable to setup controller WebhookAuthorizer with manager: %w", err)

--- a/internal/controller/authorization/rbacpolicy_controller.go
+++ b/internal/controller/authorization/rbacpolicy_controller.go
@@ -118,6 +118,7 @@ func (r *RBACPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			trace.WithAttributes(
 				tracing.AttrController.String("RBACPolicy"),
 				tracing.AttrResource.String(req.Name),
+				tracing.AttrNamespace.String(req.Namespace),
 			))
 		defer func() {
 			if retErr != nil {

--- a/internal/controller/authorization/webhookauthorizer_controller.go
+++ b/internal/controller/authorization/webhookauthorizer_controller.go
@@ -28,6 +28,10 @@ import (
 	"github.com/telekom/auth-operator/api/authorization/v1alpha1/applyconfiguration/ssa"
 	"github.com/telekom/auth-operator/pkg/conditions"
 	"github.com/telekom/auth-operator/pkg/metrics"
+	"github.com/telekom/auth-operator/pkg/tracing"
+
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // NamespaceSelectorValidationError indicates that a WebhookAuthorizer's
@@ -59,19 +63,28 @@ type WebhookAuthorizerReconciler struct {
 	client   client.Client
 	scheme   *runtime.Scheme
 	recorder events.EventRecorder
+	tracer   trace.Tracer
 }
+
+// setTracer implements tracerSetter.
+func (r *WebhookAuthorizerReconciler) setTracer(t trace.Tracer) { r.tracer = t }
 
 // NewWebhookAuthorizerReconciler creates a new WebhookAuthorizer reconciler.
 func NewWebhookAuthorizerReconciler(
 	c client.Client,
 	scheme *runtime.Scheme,
 	recorder events.EventRecorder,
+	opts ...ReconcilerOption,
 ) *WebhookAuthorizerReconciler {
-	return &WebhookAuthorizerReconciler{
+	r := &WebhookAuthorizerReconciler{
 		client:   c,
 		scheme:   scheme,
 		recorder: recorder,
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -91,9 +104,26 @@ func (r *WebhookAuthorizerReconciler) SetupWithManager(mgr ctrl.Manager, concurr
 //  4. Validate NamespaceSelector can be parsed (stall on error)
 //  5. Set status.authorizerConfigured = true and mark Ready
 //  6. Apply status via SSA
-func (r *WebhookAuthorizerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *WebhookAuthorizerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	startTime := time.Now()
 	logger := log.FromContext(ctx)
+
+	if r.tracer != nil {
+		var span trace.Span
+		ctx, span = r.tracer.Start(ctx, "reconcile.WebhookAuthorizer",
+			trace.WithAttributes(
+				tracing.AttrController.String("WebhookAuthorizer"),
+				tracing.AttrResource.String(req.Name),
+				tracing.AttrNamespace.String(req.Namespace),
+			))
+		defer func() {
+			if retErr != nil {
+				span.RecordError(retErr)
+				span.SetStatus(codes.Error, retErr.Error())
+			}
+			span.End()
+		}()
+	}
 
 	logger.V(1).Info("=== Reconcile START ===",
 		"webhookAuthorizer", req.Name)

--- a/internal/controller/authorization/webhookauthorizer_controller_test.go
+++ b/internal/controller/authorization/webhookauthorizer_controller_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.opentelemetry.io/otel/trace/noop"
 	authzv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -245,6 +246,32 @@ func TestReconcile_ActiveRulesGaugeRefreshErrorIsBestEffort(t *testing.T) {
 	g.Expect(updated.Status.ObservedGeneration).To(gomega.Equal(int64(1)))
 	g.Expect(updated.Status.AuthorizerConfigured).To(gomega.BeTrue())
 	g.Expect(conditions.IsReady(&updated)).To(gomega.BeTrue())
+}
+
+func TestReconcile_WithTracer(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	wa := &authorizationv1alpha1.WebhookAuthorizer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "traced-authorizer",
+			Generation: 1,
+		},
+		Spec: validWebhookAuthorizerSpec(),
+	}
+
+	scheme := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(wa).
+		WithStatusSubresource(&authorizationv1alpha1.WebhookAuthorizer{}).
+		Build()
+	recorder := events.NewFakeRecorder(10)
+	tracer := noop.NewTracerProvider().Tracer("test")
+	r := NewWebhookAuthorizerReconciler(c, scheme, recorder, WithTracer(tracer))
+
+	result, err := r.Reconcile(ctxWithLogger(), reconcileRequest("traced-authorizer"))
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(result.RequeueAfter).To(gomega.Equal(DefaultRequeueInterval))
 }
 
 func TestReconcile_WithMatchLabels_Ready(t *testing.T) {
@@ -589,6 +616,17 @@ func TestNewWebhookAuthorizerReconciler(t *testing.T) {
 	g.Expect(r.recorder).To(gomega.Equal(recorder))
 }
 
+func TestNewWebhookAuthorizerReconciler_WithTracer(t *testing.T) {
+	g := gomega.NewWithT(t)
+	scheme := newTestScheme()
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	recorder := events.NewFakeRecorder(10)
+	tracer := noop.NewTracerProvider().Tracer("test")
+
+	r := NewWebhookAuthorizerReconciler(c, scheme, recorder, WithTracer(tracer))
+	g.Expect(r.tracer).NotTo(gomega.BeNil())
+}
+
 func TestValidateNamespaceSelector_EmptySelector(t *testing.T) {
 	g := gomega.NewWithT(t)
 
@@ -696,7 +734,8 @@ func TestReconcile_TransientNamespaceListError_ReturnsError(t *testing.T) {
 		}).
 		Build()
 	recorder := events.NewFakeRecorder(10)
-	r := NewWebhookAuthorizerReconciler(c, scheme, recorder)
+	tracer := noop.NewTracerProvider().Tracer("test")
+	r := NewWebhookAuthorizerReconciler(c, scheme, recorder, WithTracer(tracer))
 
 	// Reconcile should return an error (transient, retryable)
 	_, err := r.Reconcile(ctxWithLogger(), reconcileRequest("transient-authorizer"))


### PR DESCRIPTION
## Summary
- wire `WithTracer` into `WebhookAuthorizerReconciler` from controller setup
- add WebhookAuthorizer reconcile spans with controller/resource/namespace attributes and error recording
- include namespace on RBACPolicy reconcile spans for consistency with the other reconcilers

## Evidence
RoleDefinition, BindDefinition, RestrictedBindDefinition, RestrictedRoleDefinition, and RBACPolicy already create reconcile spans. WebhookAuthorizer did not implement `tracerSetter`, did not receive `reconcilerOpts`, and did not create spans. RBACPolicy spans also lacked the namespace attribute used by the other reconcilers.

Duplicate check: open PRs #365-#385 cover validation, metrics, stale resources, generated metadata, docs, and RoleBinding/ServiceAccount cleanup. None add WebhookAuthorizer tracing or RBACPolicy namespace span attributes.

## Validation
- `go test ./internal/controller/authorization -run 'Test(Reconcile_WithTracer|NewWebhookAuthorizerReconciler_WithTracer|Reconcile_TransientNamespaceListError_ReturnsError|RBACPolicy_Reconcile_WithTracer|RBACPolicy_Reconcile_WithTracer_Error)' -count=1`\n- `golangci-lint run --timeout 10m --new-from-rev origin/main ./cmd/... ./internal/controller/authorization/...`\n- `git diff --check`