### PR TITLE
fix(rbac): remove spec update on managed crds

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -67,7 +67,6 @@ rules:
   - get
   - list
   - patch
-  - update
   - watch
 - apiGroups:
   - authorization.t-caas.telekom.com

--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -106,7 +106,7 @@ var ErrMissingRoleRefs = errors.New("missing role references")
 
 var errRoleBindingRecreatePending = errors.New("role binding recreate pending")
 
-// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=binddefinitions,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=binddefinitions,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=binddefinitions/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=binddefinitions/finalizers,verbs=update
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch

--- a/internal/controller/authorization/rbacpolicy_controller.go
+++ b/internal/controller/authorization/rbacpolicy_controller.go
@@ -34,7 +34,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=rbacpolicies,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=rbacpolicies,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=rbacpolicies/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=rbacpolicies/finalizers,verbs=update
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=restrictedbinddefinitions,verbs=get;list;watch

--- a/internal/controller/authorization/restrictedbinddefinition_controller.go
+++ b/internal/controller/authorization/restrictedbinddefinition_controller.go
@@ -45,7 +45,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=restrictedbinddefinitions,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=restrictedbinddefinitions,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=restrictedbinddefinitions/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=restrictedbinddefinitions/finalizers,verbs=update
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=rbacpolicies,verbs=get;list;watch

--- a/internal/controller/authorization/restrictedroledefinition_controller.go
+++ b/internal/controller/authorization/restrictedroledefinition_controller.go
@@ -48,7 +48,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=restrictedroledefinitions,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=restrictedroledefinitions,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=restrictedroledefinitions/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=restrictedroledefinitions/finalizers,verbs=update
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=rbacpolicies,verbs=get;list;watch

--- a/internal/controller/authorization/roledefinition_controller.go
+++ b/internal/controller/authorization/roledefinition_controller.go
@@ -38,7 +38,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=roledefinitions,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=roledefinitions,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=roledefinitions/finalizers,verbs=update
 // +kubebuilder:rbac:groups=authorization.t-caas.telekom.com,resources=roledefinitions/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;patch;delete;escalate;bind


### PR DESCRIPTION
## Summary
- remove the manager ClusterRole `update` verb from the main RoleDefinition, BindDefinition, RestrictedRoleDefinition, RestrictedBindDefinition, and RBACPolicy resources
- keep `patch` for finalizer metadata updates and keep `*/status` plus `*/finalizers` subresource permissions unchanged
- regenerate `config/rbac/role.yaml` from kubebuilder RBAC markers

## Evidence
Controller inspection shows these reconcilers patch the custom resources for finalizers and use the status/finalizers subresources where update is still required. They do not need broad main-resource `update` on spec-bearing auth CRDs.

Duplicate check before opening:
- Open/recent PR search for `rbac update managed crds`, `manager-role update`, and `spec update` found no PR removing these manager auth CRD `update` verbs.
- File-overlap search found #386 touching `rbacpolicy_controller.go` for tracing only; it does not change RBAC marker verbs or generated manager permissions.

## Validation
- `make manifests`
- `make helm`
- `git diff --check`
- `golangci-lint run --timeout 10m --new-from-rev origin/main ./internal/controller/authorization/...`
- `KUBEBUILDER_ASSETS="/private/tmp/auth-operator-manager-rbac/bin/k8s/1.34.1-darwin-arm64" go test ./internal/controller/authorization -count=1`

Note: local Darwin/arm64 setup-envtest did not publish Kubernetes `1.36.1` assets, so local envtest validation used the installed `1.34.1` assets. GitHub CI will exercise the repository's Linux test path.
