### PR TITLE
test: assert specific webhook warnings, not just non-empty

### DIFF
--- a/api/authorization/v1alpha1/webhookauthorizer_webhook_test.go
+++ b/api/authorization/v1alpha1/webhookauthorizer_webhook_test.go
@@ -273,7 +273,7 @@ func TestValidateCreate_WarnsEmptyAllowedPrincipals(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-	if !hasWarning(warnings, "spec.allowedPrincipals is empty") {
+	if !hasWarning(warnings, "spec.allowedPrincipals is empty", "no requests will be allowed") {
 		t.Errorf("expected empty-allowedPrincipals warning, got %v", warnings)
 	}
 }

--- a/api/authorization/v1alpha1/webhookauthorizer_webhook_test.go
+++ b/api/authorization/v1alpha1/webhookauthorizer_webhook_test.go
@@ -24,6 +24,19 @@ func containsAll(s string, parts ...string) bool {
 	return true
 }
 
+// hasWarning reports whether exactly one warning contains all parts. It fails
+// closed on duplicates so a regression that emits the same warning twice (or
+// replaces it with an unrelated one) is caught instead of silently passing.
+func hasWarning(warnings []string, parts ...string) bool {
+	matches := 0
+	for _, w := range warnings {
+		if containsAll(w, parts...) {
+			matches++
+		}
+	}
+	return matches == 1
+}
+
 var _ = Describe("WebhookAuthorizer CEL Validation", func() {
 
 	validResourceRules := []authzv1.ResourceRule{
@@ -260,8 +273,8 @@ func TestValidateCreate_WarnsEmptyAllowedPrincipals(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-	if len(warnings) == 0 {
-		t.Error("expected warning for empty allowedPrincipals")
+	if !hasWarning(warnings, "spec.allowedPrincipals is empty") {
+		t.Errorf("expected empty-allowedPrincipals warning, got %v", warnings)
 	}
 }
 
@@ -304,8 +317,8 @@ func TestValidateCreate_WarnsOverlappingPrincipals(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-	if len(warnings) == 0 {
-		t.Error("expected warning for overlapping principals")
+	if !hasWarning(warnings, `"user:alice"`, "denied takes precedence") {
+		t.Errorf("expected overlapping-principal warning, got %v", warnings)
 	}
 }
 
@@ -319,8 +332,8 @@ func TestValidateCreate_WarnsOverlappingGroups(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-	if len(warnings) == 0 {
-		t.Error("expected warning for overlapping groups")
+	if !hasWarning(warnings, `"group:admins"`, "denied takes precedence") {
+		t.Errorf("expected overlapping-group warning, got %v", warnings)
 	}
 }
 


### PR DESCRIPTION
## What
Tightens 3 `WebhookAuthorizer` warning tests that asserted only `len(warnings) != 0` — they stayed green if the intended warning disappeared and any unrelated warning replaced it.

## Change
- Add `hasWarning(warnings, parts...)` helper that fails closed on duplicates (`matches == 1`).
- Assert exact messages: empty-allowedPrincipals, overlapping principal `"user:alice"`, overlapping group `"group:admins"`.

## Verify
- `go test ./api/authorization/v1alpha1/ -run TestValidateCreate_Warns` passes.
- Mutation: altering the source warning string makes the test fail (confirmed), proving the assertions are load-bearing.

Closes #413