### PR TITLE
test: assert Denied vs no-opinion on integration deny paths

### DIFF
--- a/internal/webhook/authorization/webhook_authorizer_integration_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_integration_test.go
@@ -159,6 +159,7 @@ var _ = Describe("WebhookAuthorizer Integration", func() {
 			})
 			Expect(resp.Status.Allowed).To(BeFalse())
 			Expect(resp.Status.Reason).To(ContainSubstring("denied"))
+			Expect(resp.Status.Denied).To(BeTrue())
 		})
 	})
 
@@ -231,6 +232,7 @@ var _ = Describe("WebhookAuthorizer Integration", func() {
 				},
 			})
 			Expect(resp.Status.Allowed).To(BeFalse())
+			Expect(resp.Status.Denied).To(BeFalse())
 		})
 
 		It("denies cluster-scoped request (no namespace)", func() {
@@ -243,6 +245,7 @@ var _ = Describe("WebhookAuthorizer Integration", func() {
 				},
 			})
 			Expect(resp.Status.Allowed).To(BeFalse())
+			Expect(resp.Status.Denied).To(BeFalse())
 		})
 	})
 
@@ -454,6 +457,7 @@ var _ = Describe("WebhookAuthorizer Integration", func() {
 				},
 			})
 			Expect(resp.Status.Allowed).To(BeFalse())
+			Expect(resp.Status.Denied).To(BeFalse())
 		})
 
 		It("denies bare user with same name as namespace-scoped service account", func() {
@@ -466,6 +470,7 @@ var _ = Describe("WebhookAuthorizer Integration", func() {
 				},
 			})
 			Expect(resp.Status.Allowed).To(BeFalse())
+			Expect(resp.Status.Denied).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
Locks SAR `Denied` semantics: `true` for explicit deny-override, `false` for the four no-opinion paths (ns mismatch, cluster-scoped, wrong-ns SA, bare user). Classification verified against evaluateSAR decision branches. Closes #414