### PR TITLE
docs(e2e): remove dead links to SUMMARY.md and IMPROVEMENTS.md

### DIFF
--- a/test/e2e/INDEX.md
+++ b/test/e2e/INDEX.md
@@ -44,8 +44,6 @@ Welcome to the auth-operator e2e test documentation!
 |----------|---------|-------------|
 | **[README.md](README.md)** | Complete guide | First time setup, comprehensive reference |
 | **[QUICKREF.md](QUICKREF.md)** | Cheat sheet | Quick commands, troubleshooting |
-| **[SUMMARY.md](SUMMARY.md)** | Quality assessment | Understanding test health |
-| **[IMPROVEMENTS.md](IMPROVEMENTS.md)** | Enhancement guide | Planning refactoring |
 
 ---
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -4,8 +4,6 @@ This guide provides comprehensive information about running, debugging, and unde
 
 > **📚 Quick Links:**
 > - [Quick Reference Card](QUICKREF.md) - Commands and troubleshooting at a glance
-> - [Analysis Summary](SUMMARY.md) - Test suite assessment and recommendations
-> - [Improvement Guide](IMPROVEMENTS.md) - Detailed code improvement recommendations
 
 ## Table of Contents
 


### PR DESCRIPTION
Removes links to `SUMMARY.md`, `IMPROVEMENTS.md` (never committed) from test/e2e/README.md and INDEX.md. Closes #426