### PR TITLE
fix: enable secure metrics by default

### DIFF
--- a/chart/auth-operator/values.yaml
+++ b/chart/auth-operator/values.yaml
@@ -178,7 +178,7 @@ metrics:
   # and SubjectAccessReview protect the metrics endpoint and auth-delegator
   # ClusterRoleBinding is created.
   auth:
-    enabled: false
+    enabled: true
   service:
     # Enable a dedicated Service for Prometheus scraping
     enabled: true


### PR DESCRIPTION
## Summary
- Enable Helm chart metrics authentication by default for secure-by-default installs.
- Keep an explicit `metrics.auth.enabled=false` opt-out for trusted unauthenticated HTTP metrics environments.
- Update chart README, values schema, operator guide, metrics docs, and Helm E2E expectations for the new default.
- Refactor the authorization webhook handler without behavior changes so repo lint stays green.

## Validation
- `helm lint chart/auth-operator --strict`
- Helm render matrix: default secure, explicit opt-out, ServiceMonitor TLS failure without trust config, ServiceMonitor success with `insecureSkipVerify=true` and scraper RBAC
- `go test ./test/e2e -run TestE2E -ginkgo.dry-run -ginkgo.focus 'Helm Chart E2E.*Metrics Authentication|Helm Chart E2E.*Helm Chart Validation' -tags=e2e -count=1`
- `KUBEBUILDER_ASSETS=/private/tmp/auth-pr467-secure-metrics/bin/k8s/1.34.1-darwin-arm64 go test ./internal/webhook/authorization -count=1`
- `make lint`
- `git diff --check`