### PR TITLE
fix: repair auth main CI regressions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -331,7 +331,7 @@ Do not pass raw logger instances across helper boundaries when `ctx` is availabl
 | `--cert-rotation-mutating-webhook` | Mutating webhook names to patch with CA bundle | `[]` |
 | `--cert-rotation-validating-webhook` | Validating webhook names to patch with CA bundle | `[]` |
 | `--tdg-migration` | Enable T-DDI to T-CaaS migration mode | `false` |
-| `--capi-operator-update-bypass` | Allow capi-operator-manager to skip BindDefinition authorization for Namespace UPDATE requests; protected-label validation still runs | `true` |
+| `--capi-operator-update-bypass` | Allow capi-operator-manager to skip BindDefinition authorization for Namespace UPDATE requests; protected-label validation still runs | `false` |
 | `--authorize-rate-limit` | Per-pod sustained requests/second for authorize endpoint | `0` |
 | `--authorize-rate-burst` | Burst size for authorize endpoint rate limiter | `200` |
 | `--authorize-auth-token-file` | Bearer-token file required by `/authorize` callers | `""` |

--- a/.github/workflows/output-delta.yml
+++ b/.github/workflows/output-delta.yml
@@ -53,6 +53,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Checkout PR sample corpus
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: sample-branch
+          persist-credentials: false
+
       - name: Load trusted tool versions
         run: |
           set -euo pipefail
@@ -265,6 +273,9 @@ jobs:
         id: main-output
         run: |
           set -euo pipefail
+          workspace="${GITHUB_WORKSPACE:?}"
+          sample_dir="$workspace/sample-branch/config/samples"
+          broken_sample_dir="$sample_dir/broken"
           cd main-branch
 
           make docker-build IMG=auth-operator:main
@@ -279,12 +290,14 @@ jobs:
             echo "::notice::Webhook server not found or not ready on main, continuing"
           sleep 5
 
-          /tmp/apply-output-delta-samples.sh config/samples
+          # Use the PR sample corpus for baseline and candidate so output
+          # differences reflect operator behavior, not stale sample fixtures.
+          /tmp/apply-output-delta-samples.sh "$sample_dir"
 
-          if [ -f config/samples/broken/kustomization.yaml ]; then
-            /tmp/apply-output-delta-samples.sh config/samples/broken
+          if [ -f "$broken_sample_dir/kustomization.yaml" ]; then
+            /tmp/apply-output-delta-samples.sh "$broken_sample_dir"
           else
-            echo "::notice::No config/samples/broken set on main, skipping broken-sample apply"
+            echo "::notice::No config/samples/broken set on PR sample corpus, skipping broken-sample apply"
           fi
 
           wait_ready() {
@@ -323,8 +336,8 @@ jobs:
             kubectl logs -n "$ns" -l control-plane=webhook-server > "/tmp/controller-logs/main-${ns}-webhook.log" 2>/dev/null || true
           done
 
-          kubectl delete -k config/samples/broken/ --ignore-not-found --timeout=60s 2>/dev/null || true
-          kubectl delete -k config/samples/ --ignore-not-found --timeout=60s 2>/dev/null || true
+          kubectl delete -k "$broken_sample_dir" --ignore-not-found --timeout=60s 2>/dev/null || true
+          kubectl delete -k "$sample_dir" --ignore-not-found --timeout=60s 2>/dev/null || true
           kubectl wait --for=delete roledefinition --all --timeout=60s 2>/dev/null || true
           kubectl wait --for=delete binddefinition --all --timeout=60s 2>/dev/null || true
           kubectl wait --for=delete webhookauthorizer --all --timeout=60s 2>/dev/null || true
@@ -366,6 +379,9 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
+          workspace="${GITHUB_WORKSPACE:?}"
+          sample_dir="$workspace/sample-branch/config/samples"
+          broken_sample_dir="$sample_dir/broken"
           cd tag-branch
 
           echo "tag_success=false" >> "$GITHUB_OUTPUT"
@@ -381,15 +397,15 @@ jobs:
             echo "::notice::Webhook server not found or not ready for tag, continuing"
           sleep 5
 
-          if ! /tmp/apply-output-delta-samples.sh config/samples; then
-            echo "::warning::Tag samples failed to apply; skipping tag comparison"
+          if ! /tmp/apply-output-delta-samples.sh "$sample_dir"; then
+            echo "::warning::PR sample corpus failed to apply to latest tag; skipping tag comparison"
             exit 0
           fi
 
-          if [ -d config/samples/broken/ ]; then
-            /tmp/apply-output-delta-samples.sh config/samples/broken
+          if [ -d "$broken_sample_dir" ]; then
+            /tmp/apply-output-delta-samples.sh "$broken_sample_dir"
           else
-            echo "::notice::No config/samples/broken set on tag, skipping broken-sample apply"
+            echo "::notice::No config/samples/broken set on PR sample corpus, skipping broken-sample apply"
           fi
 
           kubectl wait --for=condition=Ready roledefinition --all --timeout=180s 2>/dev/null || true

--- a/api/authorization/v1alpha1/binddefinition_webhook_unit_test.go
+++ b/api/authorization/v1alpha1/binddefinition_webhook_unit_test.go
@@ -45,7 +45,7 @@ func TestBindDefinitionValidatorSanitizesInternalErrors(t *testing.T) {
 	}
 	selectorRoleBinding := NamespaceBinding{
 		NamespaceSelector: []metav1.LabelSelector{{
-			MatchLabels: map[string]string{"team": "a"},
+			MatchLabels: map[string]string{LabelKeyOwner: "team-a"},
 		}},
 		RoleRefs: []string{"reader"},
 	}

--- a/chart/auth-operator/README.md
+++ b/chart/auth-operator/README.md
@@ -145,7 +145,7 @@ is restricted to platform administrators.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `metrics.auth.enabled` | Require authentication/authorization for `/metrics` and serve metrics over HTTPS | `false` |
+| `metrics.auth.enabled` | Require authentication/authorization for `/metrics` and serve metrics over HTTPS. Set to `false` only for trusted opt-out environments that require unauthenticated HTTP metrics. | `true` |
 | `metrics.service.enabled` | Create a dedicated metrics Service | `true` |
 | `metrics.service.port` | Metrics service port | `8080` |
 | `metrics.serviceMonitor.enabled` | Create a Prometheus ServiceMonitor | `false` |

--- a/chart/auth-operator/values.schema.json
+++ b/chart/auth-operator/values.schema.json
@@ -535,7 +535,7 @@
             "enabled": {
               "type": "boolean",
               "description": "Require authentication and authorization for the /metrics endpoint and serve metrics over HTTPS.",
-              "default": false
+              "default": true
             }
           }
         },

--- a/chart/auth-operator/values.schema.json
+++ b/chart/auth-operator/values.schema.json
@@ -362,7 +362,7 @@
           "type": ["string", "boolean"],
           "description": "Allow capi-operator-manager to skip BindDefinition authorization for Namespace UPDATE requests; protected-label validation still runs.",
           "enum": ["true", "false", true, false],
-          "default": "true"
+          "default": "false"
         },
         "authorizeRateLimit": {
           "type": "number",

--- a/chart/auth-operator/values.yaml
+++ b/chart/auth-operator/values.yaml
@@ -174,9 +174,10 @@ namespaceAdmission:
 
 metrics:
   # Require authentication and authorization for the /metrics endpoint.
-  # Disabled by default for backwards compatibility. When enabled, TokenReview
-  # and SubjectAccessReview protect the metrics endpoint and auth-delegator
-  # ClusterRoleBinding is created.
+  # Enabled by default for secure Helm installs. TokenReview and
+  # SubjectAccessReview protect the metrics endpoint and auth-delegator
+  # ClusterRoleBinding is created. Set to false only for trusted opt-out
+  # environments that require unauthenticated HTTP metrics.
   auth:
     enabled: true
   service:

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -402,7 +402,7 @@ func TestFlagDefaults(t *testing.T) {
 		{"webhook", "enable-http2", "false"},
 		{"webhook", "disable-cert-rotation", "false"},
 		{"webhook", "tdg-migration", "false"},
-		{"webhook", "capi-operator-update-bypass", "true"},
+		{"webhook", "capi-operator-update-bypass", "false"},
 		{"webhook", "authorize-rate-limit", "0"},
 		{"webhook", "authorize-rate-burst", "200"},
 		{"webhook", "authorize-auth-token-file", ""},

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -368,7 +368,8 @@ func init() {
 	webhookCmd.Flags().BoolVar(&enableTDGMigration, "tdg-migration", false,
 		"If set, the legacy labels and behavior for TDG migration will be enabled.")
 	webhookCmd.Flags().BoolVar(&enableCAPIOperatorUpdateBypass, "capi-operator-update-bypass", false,
-		"If set, the capi-operator-manager ServiceAccount may skip BindDefinition authorization for Namespace UPDATE requests; protected-label validation still runs.")
+		"Allow the capi-operator-manager ServiceAccount to skip BindDefinition authorization for Namespace UPDATE requests; "+
+			"disabled by default. Protected-label validation still runs when enabled.")
 	webhookCmd.Flags().Float64Var(&authorizeRateLimit, "authorize-rate-limit", 0,
 		"Maximum sustained requests per second for the /authorize endpoint. Set to 0 to disable rate limiting.")
 	webhookCmd.Flags().IntVar(&authorizeRateBurst, "authorize-rate-burst", 200,

--- a/config/samples/authorization_v1alpha1_binddefinition.yaml
+++ b/config/samples/authorization_v1alpha1_binddefinition.yaml
@@ -128,11 +128,9 @@ spec:
         - t-caas-namespace-developer
       namespaceSelector:
         - matchLabels:
-            t-caas.telekom.com/tenant: alpha
-            t-caas.telekom.com/environment: development
+            kubernetes.io/metadata.name: tenant-alpha
         - matchLabels:
-            t-caas.telekom.com/tenant: alpha
-            t-caas.telekom.com/environment: staging
+            kubernetes.io/metadata.name: tenant-alpha-staging
     # Read-only access to production namespaces
     - clusterRoleRefs:
         - view
@@ -140,8 +138,7 @@ spec:
         - t-caas-namespace-viewer
       namespaceSelector:
         - matchLabels:
-            t-caas.telekom.com/tenant: alpha
-            t-caas.telekom.com/environment: production
+            kubernetes.io/metadata.name: tenant-alpha-prod
     # Full access to CI/CD namespaces only
     - clusterRoleRefs:
         - admin
@@ -151,12 +148,10 @@ spec:
               operator: In
               values:
                 - alpha
-            - key: t-caas.telekom.com/purpose
+            - key: kubernetes.io/metadata.name
               operator: In
               values:
-                - cicd
-                - gitops
-                - build
+                - tenant-alpha-cicd
 
 ---
 # -----------------------------------------------------------------------------
@@ -211,7 +206,7 @@ spec:
         - secret-reader
       namespaceSelector:
         - matchLabels:
-            t-caas.telekom.com/compliance-scope: pci-dss
+            t-caas.telekom.com/tenant: compliance
 
 ---
 # -----------------------------------------------------------------------------
@@ -261,11 +256,10 @@ spec:
         - view
       namespaceSelector:
         - matchExpressions:
-            - key: t-caas.telekom.com/monitoring
+            - key: kubernetes.io/metadata.name
               operator: In
               values:
-                - enabled
-                - required
+                - t-caas-monitoring
     # Special access to kube-system for cluster metrics (specific namespace, not selector)
     - clusterRoleRefs:
         - view
@@ -319,11 +313,15 @@ spec:
         - admin
       namespaceSelector:
         - matchExpressions:
-            - key: argocd.argoproj.io/managed-by
-              operator: Exists
+            - key: kubernetes.io/metadata.name
+              operator: In
+              values:
+                - argocd
         - matchExpressions:
-            - key: kustomize.toolkit.fluxcd.io/managed-by
-              operator: Exists
+            - key: kubernetes.io/metadata.name
+              operator: In
+              values:
+                - flux-system
     # Read access to argocd namespace (uses specific namespace, not selector)
     - clusterRoleRefs:
         - view
@@ -516,12 +514,12 @@ spec:
         - view
       namespaceSelector:
         - matchExpressions:
-            - key: t-caas.telekom.com/environment
+            - key: t-caas.telekom.com/tenant
               operator: In
               values:
-                - development
-                - staging
-                - production
+                - alpha
+                - beta
+                - compliance
     # Test Exists operator
     - clusterRoleRefs:
         - view
@@ -536,10 +534,10 @@ spec:
         - matchLabels:
             t-caas.telekom.com/owner: tenant
           matchExpressions:
-            - key: t-caas.telekom.com/environment
+            - key: t-caas.telekom.com/tenant
               operator: In
               values:
-                - development
+                - alpha
 
 ---
 # -----------------------------------------------------------------------------
@@ -568,7 +566,7 @@ spec:
       name: overlap-test-users@example.com
   roleBindings:
     # Single roleBinding entry with MULTIPLE namespaceSelector terms that OVERLAP
-    # Term 1: matches namespaces with environment=development (tenant-alpha)
+    # Term 1: matches tenant-alpha by metadata.name
     # Term 2: matches namespaces with tenant=alpha (tenant-alpha, tenant-alpha-staging, tenant-alpha-prod)
     # OVERLAP: tenant-alpha namespace matches BOTH terms
     - clusterRoleRefs:
@@ -576,7 +574,7 @@ spec:
       namespaceSelector:
         # Term 1: Development environments only
         - matchLabels:
-            t-caas.telekom.com/environment: development
+            kubernetes.io/metadata.name: tenant-alpha
         # Term 2: All tenant-alpha namespaces (overlaps with term 1 on tenant-alpha namespace)
         - matchLabels:
             t-caas.telekom.com/tenant: alpha
@@ -590,8 +588,8 @@ spec:
 # Tests that non-overlapping selector terms all contribute unique namespaces
 # This should create RoleBindings in:
 # - Platform namespaces (owner=platform): t-caas-system, t-caas-monitoring, t-caas-logging
-# - GitOps namespaces (gitops-source=true): argocd, flux-system
-# - Compliance namespaces (compliance-scope exists): compliance-pci
+# - GitOps namespaces by metadata.name: argocd, flux-system
+# - Compliance namespaces by tenant label: compliance-pci
 # No namespace should match multiple terms (no overlap)
 # -----------------------------------------------------------------------------
 apiVersion: authorization.t-caas.telekom.com/v1alpha1
@@ -618,12 +616,18 @@ spec:
         - matchLabels:
             t-caas.telekom.com/owner: platform
         # Term 2: GitOps source namespaces (disjoint from platform)
-        - matchLabels:
-            t-caas.telekom.com/gitops-source: "true"
+        - matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: In
+              values:
+                - argocd
+                - flux-system
         # Term 3: Compliance namespaces (disjoint from both)
         - matchExpressions:
-            - key: t-caas.telekom.com/compliance-scope
-              operator: Exists
+            - key: t-caas.telekom.com/tenant
+              operator: In
+              values:
+                - compliance
 
 ---
 # -----------------------------------------------------------------------------
@@ -664,7 +668,7 @@ spec:
         - t-caas-namespace-viewer
       namespaceSelector:
         - matchLabels:
-            t-caas.telekom.com/environment: staging
+            kubernetes.io/metadata.name: tenant-beta
         - matchLabels:
             t-caas.telekom.com/tenant: beta
     # Entry 4: Complex selector with matchLabels + matchExpressions combined
@@ -674,11 +678,10 @@ spec:
         - matchLabels:
             t-caas.telekom.com/owner: tenant
           matchExpressions:
-            - key: t-caas.telekom.com/purpose
+            - key: t-caas.telekom.com/tenant
               operator: In
               values:
-                - application
-                - cicd
+                - alpha
 
 # #############################################################################
 #  EDGE-CASE / CONFLICT SCENARIOS

--- a/docs/metrics-and-alerting.md
+++ b/docs/metrics-and-alerting.md
@@ -20,6 +20,8 @@ The Helm chart ships a **metrics Service** (enabled by default) and an optional
 ```yaml
 # values.yaml
 metrics:
+  auth:
+    enabled: true    # Secure-by-default HTTPS metrics with Kubernetes authn/authz
   service:
     enabled: true   # Dedicated ClusterIP Service on port 8080
     port: 8080
@@ -36,15 +38,17 @@ Enable the ServiceMonitor:
 
 ```bash
 helm upgrade auth-operator chart/auth-operator \
-  --set metrics.serviceMonitor.enabled=true
+  --set metrics.serviceMonitor.enabled=true \
+  --set metrics.serviceMonitor.tlsConfig.insecureSkipVerify=true
 ```
 
-When `metrics.auth.enabled=true`, the ServiceMonitor scrapes over HTTPS and TLS
-verification stays enabled by default. Helm rendering fails unless you set
-`metrics.serviceMonitor.tlsConfig.caFile` for the metrics serving certificate,
-or explicitly opt into `insecureSkipVerify=true` only for an accepted
-self-signed endpoint. Set `metrics.serviceMonitor.tlsConfig.serverName` when
-Prometheus needs an SNI or verification name override.
+Helm installs set `metrics.auth.enabled=true` by default. The ServiceMonitor
+therefore scrapes over HTTPS, and TLS verification stays enabled by default.
+Helm rendering fails unless you set `metrics.serviceMonitor.tlsConfig.caFile`
+for the metrics serving certificate, or explicitly opt into
+`insecureSkipVerify=true` only for an accepted self-signed endpoint. Set
+`metrics.serviceMonitor.tlsConfig.serverName` when Prometheus needs an SNI or
+verification name override.
 
 ### Kustomize
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -307,7 +307,7 @@ webhookServer:
 # Metrics and monitoring
 metrics:
   auth:
-    enabled: false  # Require auth for /metrics endpoint
+    enabled: true   # Require auth for /metrics endpoint by default
   service:
     enabled: true
     port: 8080
@@ -380,9 +380,11 @@ controller:
 
 ### Prometheus Metrics
 
-The operator exposes metrics at `:8080/metrics`. When `metrics.auth.enabled`
-is set to `true` in the Helm values, the endpoint requires a valid Kubernetes
-bearer token with permission to GET the non-resource URL `/metrics`.
+The operator exposes metrics at `:8080/metrics`. Helm installs set
+`metrics.auth.enabled=true` by default, so the endpoint requires a valid
+Kubernetes bearer token with permission to GET the non-resource URL `/metrics`.
+Set `metrics.auth.enabled=false` only for trusted opt-out environments that
+require unauthenticated HTTP metrics.
 
 **RBAC prerequisites**: The operator pods use `WithAuthenticationAndAuthorization`
 to validate metrics requests via the Kubernetes API. This requires both the
@@ -447,6 +449,7 @@ when `metrics.auth.enabled` is set.
 ```bash
 helm upgrade auth-operator oci://ghcr.io/telekom/charts/auth-operator \
   --set metrics.serviceMonitor.enabled=true \
+  --set metrics.serviceMonitor.tlsConfig.insecureSkipVerify=true \
   --set metrics.serviceMonitor.additionalLabels.release=prometheus
 ```
 

--- a/internal/controller/authorization/binddefinition_controller.go
+++ b/internal/controller/authorization/binddefinition_controller.go
@@ -1528,7 +1528,6 @@ func deleteBindDefinitionMetricSeries(name string) {
 	metrics.ManagedResources.DeleteLabelValues(metrics.ControllerBindDefinition, metrics.ResourceClusterRoleBinding, name)
 	metrics.ManagedResources.DeleteLabelValues(metrics.ControllerBindDefinition, metrics.ResourceRoleBinding, name)
 	metrics.ManagedResources.DeleteLabelValues(metrics.ControllerBindDefinition, metrics.ResourceServiceAccount, name)
-
 }
 
 // deleteSubjectServiceAccounts deletes ServiceAccounts specified in current

--- a/internal/controller/authorization/restrictedroledefinition_controller.go
+++ b/internal/controller/authorization/restrictedroledefinition_controller.go
@@ -930,4 +930,3 @@ func (r *RestrictedRoleDefinitionReconciler) rrdLogApplyIdentity(
 	trace.SpanFromContext(ctx).SetAttributes(tracing.AttrUser.String(impersonatedUser))
 	logger.V(2).Info("using impersonated apply identity", "name", resourceName, "impersonatedUser", impersonatedUser, "policy", policyName)
 }
-// Fixes issue #393

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -132,37 +132,17 @@ func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract trace context and start a tracing span only when tracing is
-	// enabled (non-nil Tracer). When disabled, this avoids header parsing and
-	// noop span creation on every request — true zero overhead.
-	if wa.Tracer != nil {
-		ctx = otel.GetTextMapPropagator().Extract(ctx, propagation.HeaderCarrier(r.Header))
-		var span trace.Span
-		ctx, span = wa.Tracer.Start(ctx, "webhook.SubjectAccessReview")
-		defer span.End()
+	ctx, endSpan := wa.startSubjectAccessReviewSpan(ctx, r)
+	if endSpan != nil {
+		defer endSpan()
 	}
 
-	var sar authzv1.SubjectAccessReview
-
-	if err := json.NewDecoder(r.Body).Decode(&sar); err != nil {
-		wa.Log.Info("failed to decode SubjectAccessReview request", "error", err,
-			"latency", time.Since(start).String())
-		if span := trace.SpanFromContext(ctx); span.IsRecording() {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "invalid request body")
-		}
-		wa.recordErrorMetrics(start)
-		wa.writeDeniedResponse(w, "invalid request body")
+	sar, ok := wa.decodeSubjectAccessReview(ctx, w, r, start)
+	if !ok {
 		return
 	}
 
-	if reason := validateSAR(&sar); reason != "" {
-		wa.Log.V(1).Info("rejecting malformed SubjectAccessReview",
-			"reason", reason,
-			"user", sar.Spec.User,
-			"latency", time.Since(start).String())
-		wa.recordRejectedMetrics(start)
-		wa.writeDeniedResponse(w, reason)
+	if !wa.validateSubjectAccessReview(w, &sar, start) {
 		return
 	}
 
@@ -182,31 +162,8 @@ func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	evalCtx, evalCancel := context.WithTimeout(ctx, authorizationv1alpha1.WebhookCacheTimeout)
 	defer evalCancel()
 
-	globalItems, err := wa.listAuthorizersByIndex(evalCtx, indexer.WebhookAuthorizerHasNamespaceSelectorFalse)
-	if err != nil {
-		wa.Log.Error(err, "failed to list global WebhookAuthorizers",
-			"user", sar.Spec.User,
-			"latency", time.Since(start).String())
-		if span := trace.SpanFromContext(ctx); span.IsRecording() {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "failed to list global WebhookAuthorizers")
-		}
-		wa.recordErrorMetrics(start)
-		wa.writeDeniedResponse(w, reasonInternalEvaluationError)
-		return
-	}
-
-	scopedItems, err := wa.listAuthorizersByIndex(evalCtx, indexer.WebhookAuthorizerHasNamespaceSelectorTrue)
-	if err != nil {
-		wa.Log.Error(err, "failed to list scoped WebhookAuthorizers",
-			"user", sar.Spec.User,
-			"latency", time.Since(start).String())
-		if span := trace.SpanFromContext(ctx); span.IsRecording() {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "failed to list scoped WebhookAuthorizers")
-		}
-		wa.recordErrorMetrics(start)
-		wa.writeDeniedResponse(w, reasonInternalEvaluationError)
+	globalItems, scopedItems, ok := wa.listAuthorizersForRequest(ctx, evalCtx, w, &sar, start)
+	if !ok {
 		return
 	}
 	allRules := countTotalRules(globalItems) + countTotalRules(scopedItems)
@@ -226,17 +183,8 @@ func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return strings.Compare(a.Name, b.Name)
 	})
 
-	result, err := wa.evaluateSAR(evalCtx, &sar, items)
-	if err != nil {
-		wa.Log.Error(err, "failed to evaluate SubjectAccessReview",
-			"user", sar.Spec.User,
-			"latency", time.Since(start).String())
-		if span := trace.SpanFromContext(ctx); span.IsRecording() {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "failed to evaluate SubjectAccessReview")
-		}
-		wa.recordErrorMetrics(start)
-		wa.writeDeniedResponse(w, reasonInternalEvaluationError)
+	result, ok := wa.evaluateSubjectAccessReview(ctx, evalCtx, w, &sar, items, start)
+	if !ok {
 		return
 	}
 
@@ -262,16 +210,8 @@ func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// are not recorded when serialization fails. Note: metrics are recorded
 	// after successful marshal but before w.Write — a late write failure
 	// (e.g. client disconnect) will still have metrics emitted.
-	respBytes, err := json.Marshal(response)
-	if err != nil {
-		wa.Log.Error(err, "failed to encode SubjectAccessReview response",
-			"latency", time.Since(start).String())
-		if span := trace.SpanFromContext(ctx); span.IsRecording() {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "failed to encode response")
-		}
-		wa.recordErrorMetrics(start)
-		http.Error(w, "internal evaluation error", http.StatusInternalServerError)
+	respBytes, ok := wa.marshalSubjectAccessReviewResponse(ctx, w, response, start)
+	if !ok {
 		return
 	}
 
@@ -294,6 +234,102 @@ func (wa *Authorizer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		wa.Log.Error(err, "failed to write SubjectAccessReview response",
 			"latency", time.Since(start).String())
 	}
+}
+
+func (wa *Authorizer) startSubjectAccessReviewSpan(ctx context.Context, r *http.Request) (spanCtx context.Context, end func()) {
+	// Extract trace context and start a tracing span only when tracing is
+	// enabled (non-nil Tracer). When disabled, this avoids header parsing and
+	// noop span creation on every request — true zero overhead.
+	if wa.Tracer == nil {
+		return ctx, nil
+	}
+
+	ctx = otel.GetTextMapPropagator().Extract(ctx, propagation.HeaderCarrier(r.Header))
+	ctx, span := wa.Tracer.Start(ctx, "webhook.SubjectAccessReview")
+	return ctx, func() { span.End() }
+}
+
+func (wa *Authorizer) decodeSubjectAccessReview(ctx context.Context, w http.ResponseWriter, r *http.Request, start time.Time) (authzv1.SubjectAccessReview, bool) {
+	var sar authzv1.SubjectAccessReview
+	if err := json.NewDecoder(r.Body).Decode(&sar); err != nil {
+		wa.Log.Info("failed to decode SubjectAccessReview request", "error", err,
+			"latency", time.Since(start).String())
+		if span := trace.SpanFromContext(ctx); span.IsRecording() {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "invalid request body")
+		}
+		wa.recordErrorMetrics(start)
+		wa.writeDeniedResponse(w, "invalid request body")
+		return authzv1.SubjectAccessReview{}, false
+	}
+	return sar, true
+}
+
+func (wa *Authorizer) validateSubjectAccessReview(w http.ResponseWriter, sar *authzv1.SubjectAccessReview, start time.Time) bool {
+	if reason := validateSAR(sar); reason != "" {
+		wa.Log.V(1).Info("rejecting malformed SubjectAccessReview",
+			"reason", reason,
+			"user", sar.Spec.User,
+			"latency", time.Since(start).String())
+		wa.recordRejectedMetrics(start)
+		wa.writeDeniedResponse(w, reason)
+		return false
+	}
+	return true
+}
+
+func (wa *Authorizer) listAuthorizersForRequest(ctx, evalCtx context.Context, w http.ResponseWriter, sar *authzv1.SubjectAccessReview, start time.Time) (globalItems, scopedItems []authorizationv1alpha1.WebhookAuthorizer, ok bool) {
+	var err error
+	globalItems, err = wa.listAuthorizersByIndex(evalCtx, indexer.WebhookAuthorizerHasNamespaceSelectorFalse)
+	if err != nil {
+		wa.handleAuthorizerEvaluationError(ctx, w, sar, start, err, "failed to list global WebhookAuthorizers")
+		return nil, nil, false
+	}
+
+	scopedItems, err = wa.listAuthorizersByIndex(evalCtx, indexer.WebhookAuthorizerHasNamespaceSelectorTrue)
+	if err != nil {
+		wa.handleAuthorizerEvaluationError(ctx, w, sar, start, err, "failed to list scoped WebhookAuthorizers")
+		return nil, nil, false
+	}
+
+	return globalItems, scopedItems, true
+}
+
+func (wa *Authorizer) evaluateSubjectAccessReview(ctx, evalCtx context.Context, w http.ResponseWriter, sar *authzv1.SubjectAccessReview, items []authorizationv1alpha1.WebhookAuthorizer, start time.Time) (evaluationResult, bool) {
+	result, err := wa.evaluateSAR(evalCtx, sar, items)
+	if err != nil {
+		wa.handleAuthorizerEvaluationError(ctx, w, sar, start, err, "failed to evaluate SubjectAccessReview")
+		return evaluationResult{}, false
+	}
+	return result, true
+}
+
+func (wa *Authorizer) handleAuthorizerEvaluationError(ctx context.Context, w http.ResponseWriter, sar *authzv1.SubjectAccessReview, start time.Time, err error, message string) {
+	wa.Log.Error(err, message,
+		"user", sar.Spec.User,
+		"latency", time.Since(start).String())
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, message)
+	}
+	wa.recordErrorMetrics(start)
+	wa.writeDeniedResponse(w, reasonInternalEvaluationError)
+}
+
+func (wa *Authorizer) marshalSubjectAccessReviewResponse(ctx context.Context, w http.ResponseWriter, response authzv1.SubjectAccessReview, start time.Time) ([]byte, bool) {
+	respBytes, err := json.Marshal(response)
+	if err != nil {
+		wa.Log.Error(err, "failed to encode SubjectAccessReview response",
+			"latency", time.Since(start).String())
+		if span := trace.SpanFromContext(ctx); span.IsRecording() {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "failed to encode response")
+		}
+		wa.recordErrorMetrics(start)
+		http.Error(w, "internal evaluation error", http.StatusInternalServerError)
+		return nil, false
+	}
+	return respBytes, true
 }
 
 func publicAuthorizerReason(result evaluationResult) string {

--- a/pkg/discovery/tracker.go
+++ b/pkg/discovery/tracker.go
@@ -61,15 +61,15 @@ type APIResourcesByGroupVersion map[string][]metav1.APIResource
 // Equals compares two APIResourcesByGroupVersion for equality.
 func (r APIResourcesByGroupVersion) Equals(other APIResourcesByGroupVersion) bool {
 	if len(r) != len(other) {
-		return true
+		return false
 	}
 	for gv, resources := range r {
 		otherResources, exists := other[gv]
 		if !exists {
-			return true
+			return false
 		}
 		if len(resources) != len(otherResources) {
-			return true
+			return false
 		}
 		resourceMap := make(map[string]metav1.APIResource)
 		for _, res := range resources {
@@ -78,13 +78,13 @@ func (r APIResourcesByGroupVersion) Equals(other APIResourcesByGroupVersion) boo
 		for _, otherRes := range otherResources {
 			res, exists := resourceMap[otherRes.Name]
 			if !exists {
-				return true
+				return false
 			}
 			// Compare relevant fields
 			if res.Namespaced != otherRes.Namespaced ||
 				res.Kind != otherRes.Kind ||
 				!cmp.Equal(res.Verbs, otherRes.Verbs, cmpopts.SortSlices(func(a, b string) bool { return a < b })) {
-				return true
+				return false
 			}
 		}
 	}
@@ -386,6 +386,26 @@ func (r *ResourceTracker) collectAPIResourcesWithLock(ctx context.Context, waitF
 
 	apiResourcesByGroupVersion := make(APIResourcesByGroupVersion)
 	mutex := sync.Mutex{}
+
+	coreGV := metav1.GroupVersion{Version: "v1"}
+	errorGroup.Go(func() error {
+		select {
+		case <-groupCtx.Done():
+			return groupCtx.Err()
+		default:
+		}
+
+		resources, err := r.collectAPIResourcesForGroupVersion(discoveryClient, coreGV.Group, coreGV.Version)
+		if err != nil {
+			logger.Error(err, "failed to discover API resources for core group version",
+				"group", coreGV.Group, "version", coreGV.Version)
+			return err
+		}
+		mutex.Lock()
+		apiResourcesByGroupVersion[coreGV.String()] = append(apiResourcesByGroupVersion[coreGV.String()], resources...)
+		mutex.Unlock()
+		return nil
+	})
 
 	for _, apiGroup := range discoveredAPIGroups.Groups {
 		select {

--- a/test/e2e/fixtures/binddefinition_rolebinding.yaml
+++ b/test/e2e/fixtures/binddefinition_rolebinding.yaml
@@ -22,4 +22,4 @@ spec:
         - e2e-namespaced-reader
       namespaceSelector:
         - matchLabels:
-            e2e-test: "true"
+            kubernetes.io/metadata.name: e2e-test-ns

--- a/test/e2e/helm_e2e_test.go
+++ b/test/e2e/helm_e2e_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 
 		// Label the test namespace
 		cmd = utils.CommandContext(context.Background(), "kubectl", "label", "ns", helmTestNamespace, // #nosec G204
-			"e2e-helm-test=true", "--overwrite")
+			"t-caas.telekom.com/owner=tenant", "t-caas.telekom.com/tenant=e2e-helm", "--overwrite")
 		_, _ = utils.Run(cmd)
 
 		By("Building the operator image")
@@ -135,6 +135,7 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 				"--set", "webhookServer.replicas=2",
 				"--set", "webhookServer.podDisruptionBudget.enabled=true",
 				"--set", "metrics.serviceMonitor.enabled=true",
+				"--set", "metrics.serviceMonitor.tlsConfig.insecureSkipVerify=true",
 				"--set", "namespaceAdmission.enabled=true",
 			)
 			cmd := utils.CommandContext(context.Background(), "helm", templateArgs...) // #nosec G204
@@ -151,7 +152,7 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 			saveOutput("helm-template-all-features.yaml", output)
 		})
 
-		It("should template metrics authentication only when explicitly enabled", func() {
+		It("should template metrics authentication by default and allow explicit opt-out", func() {
 			By("Rendering the default chart")
 			defaultArgs := append([]string{"template", helmReleaseName, helmChartPath,
 				"-n", helmNamespace},
@@ -160,17 +161,31 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 			cmd := utils.CommandContext(context.Background(), "helm", defaultArgs...) // #nosec G204
 			defaultOutput, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "default helm template failed: %s", string(defaultOutput))
-			Expect(string(defaultOutput)).NotTo(ContainSubstring("--metrics-secure"))
-			Expect(string(defaultOutput)).NotTo(ContainSubstring("system:auth-delegator"))
+			Expect(string(defaultOutput)).To(ContainSubstring("--metrics-secure"))
+			Expect(string(defaultOutput)).To(ContainSubstring("system:auth-delegator"))
 			Expect(string(defaultOutput)).NotTo(ContainSubstring("auth-operator-e2e-metrics-reader"))
 
-			By("Rendering the chart with metrics authentication enabled")
+			By("Rendering the chart with metrics authentication disabled")
+			optOutArgs := append([]string{"template", helmReleaseName, helmChartPath,
+				"-n", helmNamespace},
+				imageSetArgs()...,
+			)
+			optOutArgs = append(optOutArgs,
+				"--set", "metrics.auth.enabled=false",
+			)
+			cmd = utils.CommandContext(context.Background(), "helm", optOutArgs...) // #nosec G204
+			optOutOutput, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "metrics auth opt-out helm template failed: %s", string(optOutOutput))
+			Expect(string(optOutOutput)).NotTo(ContainSubstring("--metrics-secure"))
+			Expect(string(optOutOutput)).NotTo(ContainSubstring("system:auth-delegator"))
+			Expect(string(optOutOutput)).NotTo(ContainSubstring("auth-operator-e2e-metrics-reader"))
+
+			By("Rendering the chart with ServiceMonitor enabled")
 			authArgs := append([]string{"template", helmReleaseName, helmChartPath,
 				"-n", helmNamespace},
 				imageSetArgs()...,
 			)
 			authArgs = append(authArgs,
-				"--set", "metrics.auth.enabled=true",
 				"--set", "metrics.serviceMonitor.enabled=true",
 				"--set", "metrics.serviceMonitor.scraperRBAC.create=true",
 				"--set", "metrics.serviceMonitor.scraperRBAC.serviceAccount.name=e2e-metrics-scraper",
@@ -332,34 +347,80 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 	})
 
 	Context("Metrics Authentication", func() {
-		It("should serve unauthenticated HTTP metrics by default", func() {
-			By("Verifying deployments do not include --metrics-secure")
+		It("should require authenticated HTTPS metrics by default and support explicit opt-out", func() {
+			By("Verifying deployments include --metrics-secure by default")
 			args := helmDeploymentArgs("controller-manager")
-			Expect(args).NotTo(ContainSubstring("--metrics-secure"))
+			Expect(args).To(ContainSubstring("--metrics-secure"))
 			args = helmDeploymentArgs("webhook-server")
-			Expect(args).NotTo(ContainSubstring("--metrics-secure"))
+			Expect(args).To(ContainSubstring("--metrics-secure"))
 
-			By("Port-forwarding the metrics service")
+			By("Port-forwarding the secure metrics service")
 			stopForward := startMetricsPortForward(18080)
-			defer stopForward()
+			defer func() {
+				if stopForward != nil {
+					stopForward()
+				}
+			}()
 
-			By("Reading metrics without a bearer token")
+			By("Rejecting anonymous metrics requests by default")
 			Eventually(func() error {
-				status, body, err := requestMetrics(context.Background(), "http", 18080, "")
+				status, body, err := requestMetrics(context.Background(), "https", 18080, "")
+				if err != nil {
+					return err
+				}
+				if status != http.StatusUnauthorized {
+					return fmt.Errorf("anonymous metrics returned HTTP %d: %s", status, body)
+				}
+				return nil
+			}, shortTimeout, pollingInterval).Should(Succeed())
+			stopForward()
+			stopForward = nil
+
+			By("Disabling metrics authentication explicitly")
+			upgradeArgs := append([]string{"upgrade", helmReleaseName, helmChartPath,
+				"-n", helmNamespace},
+				imageSetArgs()...,
+			)
+			upgradeArgs = append(upgradeArgs,
+				"--set", "controller.replicas=1",
+				"--set", "webhookServer.replicas=1",
+				"--set", "metrics.auth.enabled=false",
+				"--wait",
+				"--timeout", "5m",
+			)
+			cmd := utils.CommandContext(context.Background(), "helm", upgradeArgs...) // #nosec G204
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Helm metrics auth opt-out upgrade failed: %s", string(output))
+
+			By("Waiting for metrics auth opt-out rollout")
+			Eventually(func() error {
+				return utils.WaitForDeploymentAvailable("control-plane=controller-manager", helmNamespace, deployTimeout)
+			}, deployTimeout, pollingInterval).Should(Succeed())
+			Eventually(func() error {
+				return utils.WaitForDeploymentAvailable("control-plane=webhook-server", helmNamespace, deployTimeout)
+			}, deployTimeout, pollingInterval).Should(Succeed())
+			Expect(helmDeploymentArgs("controller-manager")).NotTo(ContainSubstring("--metrics-secure"))
+			Expect(helmDeploymentArgs("webhook-server")).NotTo(ContainSubstring("--metrics-secure"))
+
+			By("Reading opt-out HTTP metrics without a bearer token")
+			stopForward = startMetricsPortForward(18082)
+			defer stopForward()
+			Eventually(func() error {
+				status, body, err := requestMetrics(context.Background(), "http", 18082, "")
 				if err != nil {
 					return err
 				}
 				if status != http.StatusOK {
-					return fmt.Errorf("metrics returned HTTP %d: %s", status, body)
+					return fmt.Errorf("opt-out metrics returned HTTP %d: %s", status, body)
 				}
 				if !strings.Contains(body, "# HELP") {
-					return fmt.Errorf("metrics response did not contain Prometheus HELP text")
+					return fmt.Errorf("opt-out metrics response did not contain Prometheus HELP text")
 				}
 				return nil
 			}, shortTimeout, pollingInterval).Should(Succeed())
 		})
 
-		It("should require authentication when metrics auth is enabled", func() {
+		It("should allow authenticated scraping when metrics auth is enabled", func() {
 			By("Creating the metrics scraper ServiceAccount")
 			scraperYAML := fmt.Sprintf(`
 apiVersion: v1
@@ -570,7 +631,7 @@ spec:
         - helm-e2e-generated-clusterrole
       namespaceSelector:
         - matchLabels:
-            e2e-helm-test: "true"
+            t-caas.telekom.com/tenant: e2e-helm
 `
 			cmd := utils.CommandContext(context.Background(), "kubectl", "apply", "-f", "-") // #nosec G204
 			cmd.Stdin = strings.NewReader(bindDefYAML)

--- a/test/e2e/integration_e2e_test.go
+++ b/test/e2e/integration_e2e_test.go
@@ -50,19 +50,25 @@ var _ = Describe("Integration Tests - Complex Multi-CRD Scenarios", Ordered, Lab
 
 		By("Creating test namespaces with different labels")
 		createNamespaceIfNotExists(testNS1, map[string]string{
-			"integration-test": "true",
-			"env":              "dev",
-			"team":             "alpha",
+			"integration-test":          "true",
+			"env":                       "dev",
+			"team":                      "alpha",
+			"t-caas.telekom.com/owner":  "tenant",
+			"t-caas.telekom.com/tenant": "integration-alpha",
 		})
 		createNamespaceIfNotExists(testNS2, map[string]string{
-			"integration-test": "true",
-			"env":              "staging",
-			"team":             "beta",
+			"integration-test":          "true",
+			"env":                       "staging",
+			"team":                      "beta",
+			"t-caas.telekom.com/owner":  "tenant",
+			"t-caas.telekom.com/tenant": "integration-beta",
 		})
 		createNamespaceIfNotExists(testNS3, map[string]string{
-			"integration-test": "true",
-			"env":              "prod",
-			"team":             "gamma",
+			"integration-test":          "true",
+			"env":                       "prod",
+			"team":                      "gamma",
+			"t-caas.telekom.com/owner":  "tenant",
+			"t-caas.telekom.com/tenant": "integration-gamma",
 		})
 
 		By("Installing auth-operator via Helm")
@@ -310,7 +316,7 @@ spec:
         - int-cluster-secret-reader
       namespaceSelector:
         - matchLabels:
-            integration-test: "true"
+            t-caas.telekom.com/owner: tenant
 `
 			applyYAML(bindDefYAML)
 
@@ -346,9 +352,9 @@ spec:
         - int-cluster-pod-reader
       namespaceSelector:
         - matchLabels:
-            env: dev
+            t-caas.telekom.com/tenant: integration-alpha
         - matchLabels:
-            env: staging
+            t-caas.telekom.com/tenant: integration-beta
 `
 			applyYAML(bindDefYAML)
 

--- a/test/e2e/testdata/complex/binddefinition-multi-role-multi-ns.yaml
+++ b/test/e2e/testdata/complex/binddefinition-multi-role-multi-ns.yaml
@@ -33,18 +33,18 @@ spec:
       - view
   # Multiple namespace-scoped bindings
   roleBindings:
-    # Bind view ClusterRole in namespaces with team=alpha label
+    # Bind view ClusterRole in namespaces owned by the complex-alpha tenant
     - clusterRoleRefs:
         - view
       namespaceSelector:
         - matchLabels:
-            team: alpha
-    # Bind edit ClusterRole in namespaces with env=dev label
+            t-caas.telekom.com/tenant: complex-alpha
+    # Bind edit ClusterRole in namespaces owned by the complex-alpha tenant
     - clusterRoleRefs:
         - edit
       namespaceSelector:
         - matchLabels:
-            env: dev
+            t-caas.telekom.com/tenant: complex-alpha
     # Bind specific role in explicit namespace
     - roleRefs:
         - complex-ns-filtered-role

--- a/test/e2e/testdata/complex/binddefinition-namespace-selector-complex.yaml
+++ b/test/e2e/testdata/complex/binddefinition-namespace-selector-complex.yaml
@@ -15,18 +15,17 @@ spec:
         - admin
       namespaceSelector:
         - matchLabels:
-            managed-by: auth-operator
+            t-caas.telekom.com/owner: tenant
           matchExpressions:
-            - key: environment
+            - key: t-caas.telekom.com/tenant
               operator: In
               values:
-                - production
-                - staging
-            - key: tenant
+                - complex-beta
+            - key: t-caas.telekom.com/tenant
               operator: NotIn
               values:
                 - restricted
                 - legacy
         # Second selector - OR with first
         - matchLabels:
-            special-access: "true"
+            kubernetes.io/metadata.name: complex-e2e-ns-team-b

--- a/test/e2e/testdata/complex/namespace-team-alpha.yaml
+++ b/test/e2e/testdata/complex/namespace-team-alpha.yaml
@@ -7,3 +7,5 @@ metadata:
     team: alpha
     env: dev
     managed-by: auth-operator
+    t-caas.telekom.com/owner: tenant
+    t-caas.telekom.com/tenant: complex-alpha

--- a/test/e2e/testdata/complex/namespace-team-beta.yaml
+++ b/test/e2e/testdata/complex/namespace-team-beta.yaml
@@ -8,3 +8,5 @@ metadata:
     env: staging
     managed-by: auth-operator
     environment: staging
+    t-caas.telekom.com/owner: tenant
+    t-caas.telekom.com/tenant: complex-beta

--- a/test/e2e/testdata/complex/namespace-test.yaml
+++ b/test/e2e/testdata/complex/namespace-test.yaml
@@ -9,3 +9,5 @@ metadata:
     managed-by: auth-operator
     environment: development
     authorization.t-caas.telekom.com/managed: "true"
+    t-caas.telekom.com/owner: tenant
+    t-caas.telekom.com/tenant: complex-alpha

--- a/test/e2e/testdata/golden/binddefinition-rolebinding-input.yaml
+++ b/test/e2e/testdata/golden/binddefinition-rolebinding-input.yaml
@@ -15,4 +15,4 @@ spec:
         - golden-cluster-reader
       namespaceSelector:
         - matchLabels:
-            golden-test: "true"
+            kubernetes.io/metadata.name: auth-operator-golden-test

--- a/test/e2e/testdata/golden/binddefinition-rolebinding-namespace-selector-input.yaml
+++ b/test/e2e/testdata/golden/binddefinition-rolebinding-namespace-selector-input.yaml
@@ -13,7 +13,7 @@ spec:
   roleBindings:
     - clusterRoleRefs:
         - view
-      # Select namespaces with the label team=golden-test
+      # Select the golden test namespace by Kubernetes metadata name
       namespaceSelector:
         - matchLabels:
-            team: golden-test
+            kubernetes.io/metadata.name: auth-operator-golden-test


### PR DESCRIPTION
## Summary
- restore core `v1` API discovery in ResourceTracker so RoleDefinition and RestrictedRoleDefinition generate rules for pods/configmaps/secrets again
- update BindDefinition samples, fixtures, and E2E/golden namespace selectors to use the tracked ownership labels accepted by the stricter admission webhook
- keep secure-by-default metrics chart/schema/docs/E2E fixes from the original repair branch

## Validation
- `make test`
- `make lint`
- `helm lint chart/auth-operator --strict`
- BindDefinition YAML namespace-selector allowed-key scan for `config/samples/**/*.yaml` and `test/e2e/**/*.yaml`
- `go test ./test/e2e -run TestE2E -ginkgo.dry-run -ginkgo.focus 'Helm Chart E2E.*CRD Functionality via Helm Install|Restricted CRD E2E.*RestrictedRoleDefinition CRD|Integration Tests - Complex Multi-CRD Scenarios.*BindDefinition with Namespace Selectors|Complex Feature Combinations.*BindDefinition with complex namespace selectors' -tags=e2e -count=1`
- `git diff --check`
