### PR TITLE
fix(authz): index default policy resolution

### DIFF
--- a/api/authorization/v1alpha1/default_policy_assignment_webhook.go
+++ b/api/authorization/v1alpha1/default_policy_assignment_webhook.go
@@ -19,6 +19,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/telekom/auth-operator/pkg/helpers"
 )
 
 type requesterServiceAccount struct {
@@ -69,22 +71,51 @@ func requesterMatchesDefaultAssignment(da *DefaultPolicyAssignment, username str
 
 func resolveDefaultPoliciesForRequester(ctx context.Context, c client.Reader, username string, groups []string) ([]string, error) {
 	matchedPolicies := make([]string, 0)
+
+	policies, err := listPoliciesWithDefaultAssignment(ctx, c, true)
+	if err != nil {
+		if !helpers.IsMissingFieldIndexError(err) {
+			return nil, fmt.Errorf("list indexed RBACPolicies with defaultAssignment: %w", err)
+		}
+		policies, err = listPoliciesWithDefaultAssignment(ctx, c, false)
+		if err != nil {
+			return nil, fmt.Errorf("list admission page for RBACPolicies: %w", err)
+		}
+	}
+
+	for _, policy := range policies {
+		if policy.Spec.DefaultAssignment == nil {
+			continue
+		}
+		if requesterMatchesDefaultAssignment(policy.Spec.DefaultAssignment, username, groups) {
+			matchedPolicies = append(matchedPolicies, policy.Name)
+		}
+	}
+
+	sort.Strings(matchedPolicies)
+	return matchedPolicies, nil
+}
+
+func listPoliciesWithDefaultAssignment(ctx context.Context, c client.Reader, useIndex bool) ([]RBACPolicy, error) {
+	policies := make([]RBACPolicy, 0)
 	continueToken := ""
 
 	for {
 		policyList := &RBACPolicyList{}
-		nextContinueToken, err := listAdmissionPage(ctx, c, policyList, continueToken)
-		if err != nil {
-			return nil, fmt.Errorf("list admission page for RBACPolicies: %w", err)
+		listOpts := make([]client.ListOption, 0, 1)
+		if useIndex {
+			listOpts = append(listOpts, client.MatchingFields{HasDefaultAssignmentField: "true"})
 		}
 
+		nextContinueToken, err := listAdmissionPage(ctx, c, policyList, continueToken, listOpts...)
+		if err != nil {
+			return nil, err
+		}
 		for _, policy := range policyList.Items {
 			if policy.Spec.DefaultAssignment == nil {
 				continue
 			}
-			if requesterMatchesDefaultAssignment(policy.Spec.DefaultAssignment, username, groups) {
-				matchedPolicies = append(matchedPolicies, policy.Name)
-			}
+			policies = append(policies, policy)
 		}
 
 		if nextContinueToken == "" {
@@ -93,8 +124,7 @@ func resolveDefaultPoliciesForRequester(ctx context.Context, c client.Reader, us
 		continueToken = nextContinueToken
 	}
 
-	sort.Strings(matchedPolicies)
-	return matchedPolicies, nil
+	return policies, nil
 }
 
 func selectedPolicyAssignment(ctx context.Context, c client.Reader, selectedPolicy, username string, groups []string) (matchesRequester, hasDefaultAssignment, deleting bool, retErr error) {

--- a/api/authorization/v1alpha1/default_policy_assignment_webhook_test.go
+++ b/api/authorization/v1alpha1/default_policy_assignment_webhook_test.go
@@ -6,6 +6,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -21,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/telekom/auth-operator/pkg/helpers"
 )
 
 func TestParseRequesterServiceAccount(t *testing.T) {
@@ -81,7 +84,19 @@ func newAdmissionIndexedClient(t *testing.T, scheme *runtime.Scheme, objs ...cli
 		WithIndex(&RoleDefinition{}, TargetNamespaceField, func(obj client.Object) []string {
 			return []string{obj.(*RoleDefinition).Spec.TargetNamespace}
 		}).
+		WithIndex(&RBACPolicy{}, HasDefaultAssignmentField, rbacPolicyDefaultAssignmentIndexFunc).
 		Build()
+}
+
+func rbacPolicyDefaultAssignmentIndexFunc(obj client.Object) []string {
+	policy, ok := obj.(*RBACPolicy)
+	if !ok {
+		return nil
+	}
+	if policy.Spec.DefaultAssignment == nil {
+		return []string{"false"}
+	}
+	return []string{"true"}
 }
 
 func TestRestrictedValidatorsUseReaderForDefaultPolicyAssignment(t *testing.T) {
@@ -134,6 +149,7 @@ func TestRestrictedValidatorsUseReaderForDefaultPolicyAssignment(t *testing.T) {
 			WithIndex(&RoleDefinition{}, TargetNamespaceField, func(obj client.Object) []string {
 				return []string{obj.(*RoleDefinition).Spec.TargetNamespace}
 			}).
+			WithIndex(&RBACPolicy{}, HasDefaultAssignmentField, rbacPolicyDefaultAssignmentIndexFunc).
 			Build()
 	}
 
@@ -834,6 +850,159 @@ func TestRequesterMatchesDefaultAssignment(t *testing.T) {
 
 	if requesterMatchesDefaultAssignment(da, "system:serviceaccount:team-b:rbac-applier", nil) {
 		t.Fatal("expected non-matching serviceaccount to be false")
+	}
+}
+
+type defaultPolicyTrackingReader struct {
+	t           *testing.T
+	policies    []RBACPolicy
+	usedIndexed bool
+}
+
+func (r *defaultPolicyTrackingReader) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return apierrors.NewNotFound(schema.GroupResource{Group: GroupVersion.Group, Resource: "rbacpolicies"}, "")
+}
+
+func (r *defaultPolicyTrackingReader) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	listOpts := (&client.ListOptions{}).ApplyOptions(opts)
+	if listOpts.FieldSelector == nil || listOpts.FieldSelector.String() != HasDefaultAssignmentField+"=true" {
+		r.t.Fatalf("expected indexed defaultAssignment list, got field selector %v", listOpts.FieldSelector)
+	}
+	r.usedIndexed = true
+
+	policyList, ok := list.(*RBACPolicyList)
+	if !ok {
+		r.t.Fatalf("expected RBACPolicyList, got %T", list)
+	}
+	for _, policy := range r.policies {
+		if policy.Spec.DefaultAssignment != nil {
+			policyList.Items = append(policyList.Items, *policy.DeepCopy())
+		}
+	}
+	return nil
+}
+
+func TestResolveDefaultPoliciesForRequesterUsesDefaultAssignmentIndex(t *testing.T) {
+	reader := &defaultPolicyTrackingReader{
+		t: t,
+		policies: []RBACPolicy{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "ignored-without-default-assignment"},
+				Spec:       RBACPolicySpec{AppliesTo: PolicyScope{Namespaces: []string{"default"}}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "team-b"},
+				Spec: RBACPolicySpec{
+					DefaultAssignment: &DefaultPolicyAssignment{Groups: []string{"oidc:team-b"}},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "team-a"},
+				Spec: RBACPolicySpec{
+					DefaultAssignment: &DefaultPolicyAssignment{Groups: []string{"oidc:team-a"}},
+				},
+			},
+		},
+	}
+
+	matches, err := resolveDefaultPoliciesForRequester(context.Background(), reader, "alice", []string{"oidc:team-a"})
+	if err != nil {
+		t.Fatalf("resolve default policies: %v", err)
+	}
+	if !reader.usedIndexed {
+		t.Fatal("expected resolver to use defaultAssignment field index")
+	}
+	if !reflect.DeepEqual(matches, []string{"team-a"}) {
+		t.Fatalf("expected sorted matching policies [team-a], got %v", matches)
+	}
+}
+
+func TestResolveDefaultPoliciesForRequesterFallsBackWithoutDefaultAssignmentIndex(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&RBACPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "without-default-assignment"},
+				Spec:       RBACPolicySpec{AppliesTo: PolicyScope{Namespaces: []string{"default"}}},
+			},
+			&RBACPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "team-b"},
+				Spec: RBACPolicySpec{
+					DefaultAssignment: &DefaultPolicyAssignment{Groups: []string{"oidc:team-b"}},
+				},
+			},
+			&RBACPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "team-a"},
+				Spec: RBACPolicySpec{
+					DefaultAssignment: &DefaultPolicyAssignment{Groups: []string{"oidc:team-a"}},
+				},
+			},
+		).
+		Build()
+
+	matches, err := resolveDefaultPoliciesForRequester(context.Background(), fakeClient, "alice", []string{"oidc:team-a"})
+	if err != nil {
+		t.Fatalf("resolve default policies with missing index fallback: %v", err)
+	}
+	if !reflect.DeepEqual(matches, []string{"team-a"}) {
+		t.Fatalf("expected sorted matching policies [team-a], got %v", matches)
+	}
+}
+
+func TestListPoliciesWithDefaultAssignmentFiltersDuringPagination(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&RBACPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "without-default-assignment"},
+				Spec:       RBACPolicySpec{AppliesTo: PolicyScope{Namespaces: []string{"default"}}},
+			},
+			&RBACPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "with-default-assignment"},
+				Spec: RBACPolicySpec{
+					DefaultAssignment: &DefaultPolicyAssignment{Groups: []string{"oidc:team-a"}},
+				},
+			},
+		).
+		Build()
+
+	policies, err := listPoliciesWithDefaultAssignment(context.Background(), fakeClient, false)
+	if err != nil {
+		t.Fatalf("list policies with default assignment: %v", err)
+	}
+	if len(policies) != 1 || policies[0].Name != "with-default-assignment" {
+		t.Fatalf("expected only policy with defaultAssignment, got %#v", policies)
+	}
+}
+
+func TestDefaultPolicyMissingFieldIndexError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "fake client missing index", err: fmt.Errorf("no index with name %q", HasDefaultAssignmentField), want: true},
+		{name: "api server unsupported field label", err: fmt.Errorf("field label not supported: %s", HasDefaultAssignmentField), want: true},
+		{name: "other error", err: fmt.Errorf("connection refused"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := helpers.IsMissingFieldIndexError(tt.err); got != tt.want {
+				t.Fatalf("helpers.IsMissingFieldIndexError() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/helpers/resource.go
+++ b/pkg/helpers/resource.go
@@ -173,8 +173,9 @@ func IsLabelSelectorEmpty(selector *metav1.LabelSelector) bool {
 }
 
 // IsMissingFieldIndexError reports whether err is a controller-runtime error
-// indicating that a required field index has not been registered.
-// Callers should treat this as transient and retry rather than failing hard.
+// or API-server error indicating that a required field index/selector is not
+// available. Callers should treat this as transient and retry rather than
+// failing hard.
 func IsMissingFieldIndexError(err error) bool {
 	if err == nil {
 		return false
@@ -187,6 +188,9 @@ func IsMissingFieldIndexError(err error) bool {
 		return true
 	}
 	if strings.Contains(msg, "index with name") && strings.Contains(msg, "has been registered") {
+		return true
+	}
+	if strings.Contains(msg, "field label not supported") {
 		return true
 	}
 	return false

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -82,6 +82,14 @@ const (
 	// namespaceSelector entry.
 	RestrictedBindDefinitionHasNamespaceSelectorField = ".spec.hasNamespaceSelector"
 
+	// RestrictedBindDefinitionHasNamespaceSelectorTrue is the index value for
+	// RestrictedBindDefinitions that define at least one namespace selector.
+	RestrictedBindDefinitionHasNamespaceSelectorTrue = WebhookAuthorizerHasNamespaceSelectorTrue
+
+	// RestrictedBindDefinitionHasNamespaceSelectorFalse is the index value for
+	// RestrictedBindDefinitions that do not define namespace selectors.
+	RestrictedBindDefinitionHasNamespaceSelectorFalse = WebhookAuthorizerHasNamespaceSelectorFalse
+
 	// RestrictedBindDefinitionServiceAccountSubjectField indexes
 	// RestrictedBindDefinition resources by ServiceAccount subject namespace/name.
 	RestrictedBindDefinitionServiceAccountSubjectField = ".spec.subjects.serviceAccount"
@@ -110,6 +118,14 @@ const (
 	// RBACPolicyHasDefaultAssignmentField indexes RBACPolicy resources by whether
 	// defaultAssignment is configured.
 	RBACPolicyHasDefaultAssignmentField = authorizationv1alpha1.HasDefaultAssignmentField
+
+	// RBACPolicyHasDefaultAssignmentTrue is the index value for RBACPolicies
+	// that define defaultAssignment.
+	RBACPolicyHasDefaultAssignmentTrue = WebhookAuthorizerHasNamespaceSelectorTrue
+
+	// RBACPolicyHasDefaultAssignmentFalse is the index value for RBACPolicies
+	// that do not define defaultAssignment.
+	RBACPolicyHasDefaultAssignmentFalse = WebhookAuthorizerHasNamespaceSelectorFalse
 )
 
 // SetupBaseIndexes registers field indexes for legacy controller/webhook types.
@@ -466,11 +482,11 @@ func RestrictedBindDefinitionHasNamespaceSelectorFunc(obj client.Object) []strin
 
 	for _, rb := range rbd.Spec.RoleBindings {
 		if len(rb.NamespaceSelector) > 0 {
-			return []string{"true"}
+			return []string{RestrictedBindDefinitionHasNamespaceSelectorTrue}
 		}
 	}
 
-	return []string{"false"}
+	return []string{RestrictedBindDefinitionHasNamespaceSelectorFalse}
 }
 
 // RestrictedBindDefinitionServiceAccountSubjectFunc extracts ServiceAccount
@@ -605,7 +621,7 @@ func RBACPolicyHasDefaultAssignmentFunc(obj client.Object) []string {
 		return nil
 	}
 	if policy.Spec.DefaultAssignment == nil {
-		return []string{"false"}
+		return []string{RBACPolicyHasDefaultAssignmentFalse}
 	}
-	return []string{"true"}
+	return []string{RBACPolicyHasDefaultAssignmentTrue}
 }

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -41,6 +41,10 @@ func TestIndexerConstants(t *testing.T) {
 		t.Errorf("RestrictedBindDefinitionServiceAccountSubjectNamespaceField = %q, want %q",
 			RestrictedBindDefinitionServiceAccountSubjectNamespaceField, ".spec.subjects.serviceAccountNamespace")
 	}
+	if RBACPolicyHasDefaultAssignmentField != ".spec.hasDefaultAssignment" {
+		t.Errorf("RBACPolicyHasDefaultAssignmentField = %q, want %q",
+			RBACPolicyHasDefaultAssignmentField, ".spec.hasDefaultAssignment")
+	}
 }
 
 // indexExtractorTest represents a test case for index extractor functions
@@ -560,6 +564,89 @@ func TestBindDefinitionHasRoleBindingsFunc(t *testing.T) {
 	}
 
 	runIndexExtractorTests(t, tests)
+}
+
+func TestRBACPolicyHasDefaultAssignmentFunc(t *testing.T) {
+	tests := []indexExtractorTest{
+		{
+			name: "policy with defaultAssignment returns true",
+			object: &authorizationv1alpha1.RBACPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "policy-with-default"},
+				Spec: authorizationv1alpha1.RBACPolicySpec{
+					DefaultAssignment: &authorizationv1alpha1.DefaultPolicyAssignment{
+						Groups: []string{"oidc:team-a"},
+					},
+				},
+			},
+			indexFunc:  RBACPolicyHasDefaultAssignmentFunc,
+			wantValues: []string{"true"},
+		},
+		{
+			name: "policy without defaultAssignment returns false",
+			object: &authorizationv1alpha1.RBACPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "policy-without-default"},
+			},
+			indexFunc:  RBACPolicyHasDefaultAssignmentFunc,
+			wantValues: []string{"false"},
+		},
+		{
+			name:       "wrong object type returns nil",
+			object:     &authorizationv1alpha1.RoleDefinition{ObjectMeta: metav1.ObjectMeta{Name: "rd"}},
+			indexFunc:  RBACPolicyHasDefaultAssignmentFunc,
+			wantValues: nil,
+		},
+	}
+
+	runIndexExtractorTests(t, tests)
+}
+
+func TestRBACPolicyHasDefaultAssignmentIndexWithFakeClient(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := authorizationv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	withDefault := &authorizationv1alpha1.RBACPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "with-default"},
+		Spec: authorizationv1alpha1.RBACPolicySpec{
+			DefaultAssignment: &authorizationv1alpha1.DefaultPolicyAssignment{
+				Groups: []string{"oidc:team-a"},
+			},
+		},
+	}
+	withoutDefault := &authorizationv1alpha1.RBACPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "without-default"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(withDefault, withoutDefault).
+		WithIndex(
+			&authorizationv1alpha1.RBACPolicy{},
+			RBACPolicyHasDefaultAssignmentField,
+			RBACPolicyHasDefaultAssignmentFunc,
+		).
+		Build()
+
+	var withDefaultList authorizationv1alpha1.RBACPolicyList
+	if err := fakeClient.List(context.Background(), &withDefaultList, client.MatchingFields{
+		RBACPolicyHasDefaultAssignmentField: "true",
+	}); err != nil {
+		t.Fatalf("failed to list RBACPolicies with defaultAssignment: %v", err)
+	}
+	if len(withDefaultList.Items) != 1 || withDefaultList.Items[0].Name != "with-default" {
+		t.Fatalf("expected only with-default, got %#v", withDefaultList.Items)
+	}
+
+	var withoutDefaultList authorizationv1alpha1.RBACPolicyList
+	if err := fakeClient.List(context.Background(), &withoutDefaultList, client.MatchingFields{
+		RBACPolicyHasDefaultAssignmentField: "false",
+	}); err != nil {
+		t.Fatalf("failed to list RBACPolicies without defaultAssignment: %v", err)
+	}
+	if len(withoutDefaultList.Items) != 1 || withoutDefaultList.Items[0].Name != "without-default" {
+		t.Fatalf("expected only without-default, got %#v", withoutDefaultList.Items)
+	}
 }
 
 func TestRestrictedBindDefinitionPolicyRefFunc(t *testing.T) {


### PR DESCRIPTION
Summary:
- Try the existing `HasDefaultAssignmentField` index before scanning RBACPolicies.
- Preserve paginated fallback when the reader lacks the index or the API server rejects the custom field selector.
- Add resolver and indexer tests.

Caveat:
- Live APIReader paths can still fall back because Kubernetes API servers do not support custom cache indexes.

Tests:
- `KUBEBUILDER_ASSETS="$PWD/bin/k8s/1.36.0-darwin-arm64" go test ./api/authorization/v1alpha1/... ./pkg/indexer/...`
- `git diff --check`