### PR TITLE
Secure /authorize caller authentication defaults

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -335,6 +335,7 @@ Do not pass raw logger instances across helper boundaries when `ctx` is availabl
 | `--authorize-rate-limit` | Per-pod sustained requests/second for authorize endpoint | `0` |
 | `--authorize-rate-burst` | Burst size for authorize endpoint rate limiter | `200` |
 | `--authorize-auth-token-file` | Bearer-token file required by `/authorize` callers | `""` |
+| `--allow-unauthenticated-authorize` | Explicit insecure opt-out for unauthenticated `/authorize` callers when no token file is configured | `false` |
 
 ## Common Issues & Workarounds
 

--- a/chart/auth-operator/README.md
+++ b/chart/auth-operator/README.md
@@ -95,6 +95,7 @@ Image reference precedence: `digest` > `tag` > `Chart.AppVersion`
 | `webhookServer.capiOperatorUpdateBypass` | Allow capi-operator-manager to skip BindDefinition authorization for Namespace UPDATE requests; protected-label validation still runs | `"false"` |
 | `webhookServer.authorizeRateLimit` | Max sustained requests/sec for /authorize endpoint (per pod, 0 to disable; requires caller auth when >0) | `0` |
 | `webhookServer.authorizeRateBurst` | Max burst size for /authorize rate limiter | `200` |
+| `webhookServer.allowUnauthenticatedAuthorize` | Explicit insecure opt-out for unauthenticated /authorize callers when no token Secret is configured | `false` |
 | `webhookServer.authorizeAuth.tokenSecretName` | Existing Secret with bearer token for /authorize caller authentication | `""` |
 | `webhookServer.authorizeAuth.tokenSecretKey` | Secret key containing the /authorize bearer token | `token` |
 | `webhookServer.resources.limits.cpu` | CPU limit | `150m` |
@@ -110,6 +111,12 @@ Image reference precedence: `digest` > `tag` > `Chart.AppVersion`
 | `webhookServer.service.port` | Service port | `443` |
 | `webhookServer.podDisruptionBudget.enabled` | Enable PDB | `true` |
 | `webhookServer.podDisruptionBudget.minAvailable` | Minimum available pods | `1` |
+
+By default, `/authorize` rejects callers unless
+`webhookServer.authorizeAuth.tokenSecretName` is configured. Existing local or
+development installs that intentionally need unauthenticated callers can set
+`webhookServer.allowUnauthenticatedAuthorize=true` while migrating clients to a
+shared bearer token. Keep this opt-out disabled in production.
 
 ### Namespace Admission
 

--- a/chart/auth-operator/authorize_auth_test.go
+++ b/chart/auth-operator/authorize_auth_test.go
@@ -26,8 +26,9 @@ func TestValuesSchemaDocumentsSecureAuthorizeDefault(t *testing.T) {
 	if got := prop["type"]; got != "boolean" {
 		t.Fatalf("allowUnauthenticatedAuthorize type = %v, want boolean", got)
 	}
-	if got := prop["default"]; got != false {
-		t.Fatalf("allowUnauthenticatedAuthorize default = %v, want false", got)
+	defaultValue, ok := prop["default"].(bool)
+	if !ok || defaultValue {
+		t.Fatalf("allowUnauthenticatedAuthorize default = %v, want false", prop["default"])
 	}
 	description, ok := prop["description"].(string)
 	if !ok || !strings.Contains(description, "insecure opt-out") {
@@ -56,7 +57,7 @@ func TestWebhookDeploymentAuthorizeAuthRendering(t *testing.T) {
 func helmTemplate(t *testing.T, args ...string) string {
 	t.Helper()
 	allArgs := append([]string{"template", "auth-operator", ".", "--namespace", "auth-operator-system"}, args...)
-	cmd := exec.Command("helm", allArgs...) // #nosec G204
+	cmd := exec.CommandContext(t.Context(), "helm", allArgs...) // #nosec G204
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("helm template failed: %v\n%s", err, string(output))

--- a/chart/auth-operator/authorize_auth_test.go
+++ b/chart/auth-operator/authorize_auth_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 Deutsche Telekom AG
+// SPDX-License-Identifier: Apache-2.0
+
+package authoperator_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestValuesSchemaDocumentsSecureAuthorizeDefault(t *testing.T) {
+	data, err := os.ReadFile("values.schema.json")
+	if err != nil {
+		t.Fatalf("read values schema: %v", err)
+	}
+
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("parse values schema: %v", err)
+	}
+
+	prop := nestedMap(t, schema, "properties", "webhookServer", "properties", "allowUnauthenticatedAuthorize")
+	if got := prop["type"]; got != "boolean" {
+		t.Fatalf("allowUnauthenticatedAuthorize type = %v, want boolean", got)
+	}
+	if got := prop["default"]; got != false {
+		t.Fatalf("allowUnauthenticatedAuthorize default = %v, want false", got)
+	}
+	description, ok := prop["description"].(string)
+	if !ok || !strings.Contains(description, "insecure opt-out") {
+		t.Fatalf("allowUnauthenticatedAuthorize description should document the insecure opt-out, got %q", description)
+	}
+}
+
+func TestWebhookDeploymentAuthorizeAuthRendering(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skipf("helm not installed: %v", err)
+	}
+
+	defaultRender := helmTemplate(t)
+	assertContains(t, defaultRender, "--allow-unauthenticated-authorize=false")
+	assertNotContains(t, defaultRender, "--authorize-auth-token-file")
+
+	optOutRender := helmTemplate(t, "--set", "webhookServer.allowUnauthenticatedAuthorize=true")
+	assertContains(t, optOutRender, "--allow-unauthenticated-authorize=true")
+	assertNotContains(t, optOutRender, "--authorize-auth-token-file")
+
+	tokenRender := helmTemplate(t, "--set", "webhookServer.authorizeAuth.tokenSecretName=authorize-token")
+	assertContains(t, tokenRender, "--allow-unauthenticated-authorize=false")
+	assertContains(t, tokenRender, "--authorize-auth-token-file=/var/run/auth-operator/authorize-auth/token")
+}
+
+func helmTemplate(t *testing.T, args ...string) string {
+	t.Helper()
+	allArgs := append([]string{"template", "auth-operator", ".", "--namespace", "auth-operator-system"}, args...)
+	cmd := exec.Command("helm", allArgs...) // #nosec G204
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm template failed: %v\n%s", err, string(output))
+	}
+	return string(output)
+}
+
+func nestedMap(t *testing.T, values map[string]any, path ...string) map[string]any {
+	t.Helper()
+	current := values
+	for _, key := range path {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			t.Fatalf("schema path %q is not an object", strings.Join(path, "."))
+		}
+		current = next
+	}
+	return current
+}
+
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Fatalf("expected rendered chart to contain %q", needle)
+	}
+}
+
+func assertNotContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Fatalf("expected rendered chart not to contain %q", needle)
+	}
+}

--- a/chart/auth-operator/templates/webhook-server-deployment.yaml
+++ b/chart/auth-operator/templates/webhook-server-deployment.yaml
@@ -42,6 +42,7 @@ spec:
         - --capi-operator-update-bypass={{ .Values.webhookServer.capiOperatorUpdateBypass }}
         - --authorize-rate-limit={{ .Values.webhookServer.authorizeRateLimit }}
         - --authorize-rate-burst={{ .Values.webhookServer.authorizeRateBurst }}
+        - --allow-unauthenticated-authorize={{ .Values.webhookServer.allowUnauthenticatedAuthorize }}
         {{- if .Values.webhookServer.authorizeAuth.tokenSecretName }}
         - --authorize-auth-token-file=/var/run/auth-operator/authorize-auth/token
         {{- end }}

--- a/chart/auth-operator/values.schema.json
+++ b/chart/auth-operator/values.schema.json
@@ -376,6 +376,11 @@
           "minimum": 0,
           "default": 200
         },
+        "allowUnauthenticatedAuthorize": {
+          "type": "boolean",
+          "description": "Explicit insecure opt-out that allows /authorize requests without bearer-token authentication when no token Secret is configured. Keep false for production.",
+          "default": false
+        },
         "authorizeAuth": {
           "type": "object",
           "description": "Optional bearer-token authentication for /authorize callers.",
@@ -383,7 +388,7 @@
           "properties": {
             "tokenSecretName": {
               "type": "string",
-              "description": "Existing Secret name containing the bearer token required for /authorize requests. Leave empty to disable caller authentication.",
+              "description": "Existing Secret name containing the bearer token required for /authorize requests. Leave empty only when allowUnauthenticatedAuthorize is explicitly true for development or temporary migration.",
               "default": ""
             },
             "tokenSecretKey": {

--- a/chart/auth-operator/values.yaml
+++ b/chart/auth-operator/values.yaml
@@ -119,9 +119,15 @@ webhookServer:
   # Maximum burst size for the /authorize rate limiter.
   # Must be >= 1 when rate limiting is enabled.
   authorizeRateBurst: 200
+  # Explicit insecure opt-out for installations that intentionally allow
+  # /authorize callers without bearer-token authentication. Keep false in
+  # production; when false and no authorizeAuth.tokenSecretName is set,
+  # /authorize requests are denied before their body is decoded.
+  allowUnauthenticatedAuthorize: false
   authorizeAuth:
     # Optional existing Secret containing the bearer token required for
-    # /authorize requests. Keep empty to leave caller authentication disabled.
+    # /authorize requests. Keep empty only with allowUnauthenticatedAuthorize
+    # set to true for local development or temporary migration.
     # When authorizeRateLimit is > 0, this Secret must be configured and the
     # API server authorization webhook kubeconfig must use the same token.
     tokenSecretName: ""

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -344,6 +344,7 @@ func TestWebhookCmdFlags(t *testing.T) {
 		"authorize-rate-limit",
 		"authorize-rate-burst",
 		"authorize-auth-token-file",
+		"allow-unauthenticated-authorize",
 	}
 
 	for _, name := range expectedFlags {
@@ -406,6 +407,7 @@ func TestFlagDefaults(t *testing.T) {
 		{"webhook", "authorize-rate-limit", "0"},
 		{"webhook", "authorize-rate-burst", "200"},
 		{"webhook", "authorize-auth-token-file", ""},
+		{"webhook", "allow-unauthenticated-authorize", "false"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -47,6 +47,7 @@ var (
 	authorizeRateLimit             float64
 	authorizeRateBurst             int
 	authorizeAuthTokenFile         string
+	allowUnauthenticatedAuthorize  bool
 	webhookLeaderElect             bool
 )
 
@@ -267,6 +268,10 @@ func configureWebhooks(mgr manager.Manager, tp *tracing.Provider) error {
 	}
 	authorizer.BearerToken = token
 	authorizer.BearerTokenFile = authorizeAuthTokenFile
+	authorizer.AllowUnauthenticatedAuthorize = allowUnauthenticatedAuthorize
+	if allowUnauthenticatedAuthorize && authorizeAuthTokenFile == "" {
+		log.Info("allowing unauthenticated /authorize requests; configure --authorize-auth-token-file for production")
+	}
 	if authorizeRateLimit > 0 {
 		authorizer.Limiter = rate.NewLimiter(rate.Limit(authorizeRateLimit), authorizeRateBurst)
 		log.Info("rate limiting enabled for /authorize",
@@ -377,6 +382,9 @@ func init() {
 	webhookCmd.Flags().StringVar(&authorizeAuthTokenFile, "authorize-auth-token-file", "",
 		"Path to a file containing the bearer token required for /authorize requests. "+
 			"Required when /authorize rate limiting is enabled.")
+	webhookCmd.Flags().BoolVar(&allowUnauthenticatedAuthorize, "allow-unauthenticated-authorize", false,
+		"Allow /authorize requests without a bearer token when no authorize auth token file is configured. "+
+			"Insecure; use only for development or temporary migration.")
 
 	webhookCmd.Flags().BoolVar(&webhookLeaderElect, "leader-elect", false,
 		"Enable leader election for the webhook manager. Required when running "+

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -245,6 +245,7 @@ the assignment.
 | `--authorize-rate-limit` | Per-pod sustained requests/second for authorize endpoint | `0` |
 | `--authorize-rate-burst` | Burst size for authorize endpoint rate limiter | `200` |
 | `--authorize-auth-token-file` | Bearer-token file required by `/authorize` callers | `""` |
+| `--allow-unauthenticated-authorize` | Explicit insecure opt-out for unauthenticated `/authorize` callers when no token file is configured | `false` |
 
 ### Helm Values
 
@@ -275,6 +276,7 @@ webhookServer:
   tdgMigration: "false"  # Enable for T-DDI to T-CaaS migration
   authorizeRateLimit: 0     # Per-pod sustained requests/second; 0 disables
   authorizeRateBurst: 200   # Burst size for rate limiter
+  allowUnauthenticatedAuthorize: false
   authorizeAuth:
     tokenSecretName: ""     # Existing Secret with the /authorize bearer token
     tokenSecretKey: token
@@ -527,12 +529,18 @@ webhookServer:
   authorizeAuth:
     tokenSecretName: auth-operator-authorize-token
     tokenSecretKey: token
+  allowUnauthenticatedAuthorize: false
   authorizeRateLimit: 100   # sustained requests per second per pod
   authorizeRateBurst: 200   # burst capacity
 ```
 
 When `authorizeAuth.tokenSecretName` is set, requests to `/authorize` must
 include `Authorization: Bearer <token>` before the request body is decoded.
+When it is empty, `/authorize` callers are denied by default. Existing local or
+development installations that intentionally relied on unauthenticated callers
+must set `webhookServer.allowUnauthenticatedAuthorize: true` while they migrate
+the API server authorization webhook kubeconfig to send a bearer token. Keep the
+opt-out disabled in production.
 Setting `authorizeRateLimit` above zero without `authorizeAuth.tokenSecretName`
 causes the webhook server to fail startup.
 

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -945,7 +945,7 @@ func (wa *Authorizer) authenticateRequest(w http.ResponseWriter, r *http.Request
 			wa.Log.V(1).Info("allowing unauthenticated SubjectAccessReview request")
 			return true
 		}
-		wa.Log.V(1).Info("rejecting unauthorized SubjectAccessReview request because no bearer token is configured")
+		wa.Log.V(1).Info("rejecting unauthenticated SubjectAccessReview request because no bearer token is configured")
 		wa.writeDeniedResponse(w, reasonUnauthorized)
 		return false
 	}

--- a/internal/webhook/authorization/webhook_authorizer.go
+++ b/internal/webhook/authorization/webhook_authorizer.go
@@ -96,6 +96,10 @@ type Authorizer struct {
 	// file for each request so projected Secret rotations take effect without
 	// restarting the webhook pod.
 	BearerTokenFile string
+	// AllowUnauthenticatedAuthorize allows /authorize requests when no bearer
+	// token is configured. This is insecure and intended only for explicit
+	// development or migration opt-outs.
+	AllowUnauthenticatedAuthorize bool
 	// Limiter is used as a per-subject limiter template. Each SAR subject gets
 	// an independent token bucket with this limit and burst, preventing one
 	// identity from consuming another identity's authorization budget.
@@ -937,7 +941,13 @@ func (wa *Authorizer) authenticateRequest(w http.ResponseWriter, r *http.Request
 		return false
 	}
 	if expectedToken == "" {
-		return true
+		if wa.AllowUnauthenticatedAuthorize {
+			wa.Log.V(1).Info("allowing unauthenticated SubjectAccessReview request")
+			return true
+		}
+		wa.Log.V(1).Info("rejecting unauthorized SubjectAccessReview request because no bearer token is configured")
+		wa.writeDeniedResponse(w, reasonUnauthorized)
+		return false
 	}
 	token, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
 	if !ok || token == "" || !constantTimeTokenEqual(token, expectedToken) {

--- a/internal/webhook/authorization/webhook_authorizer_integration_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_integration_test.go
@@ -64,8 +64,9 @@ var _ = Describe("WebhookAuthorizer Integration", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		authorizer = &webhooks.Authorizer{
-			Client: envClient,
-			Log:    zap.New(zap.WriteTo(io.Discard)),
+			AllowUnauthenticatedAuthorize: true,
+			Client:                        envClient,
+			Log:                           zap.New(zap.WriteTo(io.Discard)),
 		}
 	})
 

--- a/internal/webhook/authorization/webhook_authorizer_test.go
+++ b/internal/webhook/authorization/webhook_authorizer_test.go
@@ -172,8 +172,9 @@ func TestServeHTTP_EvaluatesMatchingAuthorizersByName(t *testing.T) {
 				objs = append(objs, &tt.authorizer[i])
 			}
 			handler := &Authorizer{
-				Client: newIndexedClient(scheme, objs...),
-				Log:    logr.Discard(),
+				AllowUnauthenticatedAuthorize: true,
+				Client:                        newIndexedClient(scheme, objs...),
+				Log:                           logr.Discard(),
 			}
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(marshalSAR(t, sar)))
@@ -214,8 +215,9 @@ func TestServeHTTP_AuthorizerRulesUseLiveClient(t *testing.T) {
 		},
 	}
 	handler := &Authorizer{
-		Client: newIndexedClient(scheme, freshDeny),
-		Log:    logr.Discard(),
+		AllowUnauthenticatedAuthorize: true,
+		Client:                        newIndexedClient(scheme, freshDeny),
+		Log:                           logr.Discard(),
 	}
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -267,8 +269,9 @@ func TestServeHTTP_ScopedAuthorizerDeniesClusterScopedResourceSAR(t *testing.T) 
 		},
 	}
 	handler := &Authorizer{
-		Client: newIndexedClient(scheme, scopedDeny),
-		Log:    logr.Discard(),
+		AllowUnauthenticatedAuthorize: true,
+		Client:                        newIndexedClient(scheme, scopedDeny),
+		Log:                           logr.Discard(),
 	}
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -320,7 +323,8 @@ func TestAuditLog_DenyDecisionAtV0(t *testing.T) {
 		},
 	}
 	cl := newIndexedClient(scheme, &wa)
-	handler := &Authorizer{Client: cl, Log: logger}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -383,7 +387,8 @@ func TestAuditLog_AllowDecisionAtV1(t *testing.T) {
 	}
 	body := marshalSAR(t, sar)
 
-	handler0 := &Authorizer{Client: cl, Log: logger0}
+	handler0 := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger0}
 	req0 := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(body))
 	rec0 := httptest.NewRecorder()
 	handler0.ServeHTTP(rec0, req0)
@@ -399,7 +404,8 @@ func TestAuditLog_AllowDecisionAtV1(t *testing.T) {
 	// With verbosity=1 the allow decision SHOULD appear.
 	var buf1 strings.Builder
 	logger1 := capturingLogger(&buf1, 1)
-	handler1 := &Authorizer{Client: cl, Log: logger1}
+	handler1 := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger1}
 	body = marshalSAR(t, sar)
 	req1 := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(body))
 	rec1 := httptest.NewRecorder()
@@ -432,7 +438,8 @@ func TestAuditLog_NoOpinionDecisionAtV1(t *testing.T) {
 	// reduce noise at V(0).
 	var buf0 strings.Builder
 	logger0 := capturingLogger(&buf0, 0)
-	handler0 := &Authorizer{Client: cl, Log: logger0}
+	handler0 := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger0}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -456,7 +463,8 @@ func TestAuditLog_NoOpinionDecisionAtV1(t *testing.T) {
 	// At V(1) no-opinion should appear.
 	var buf1 strings.Builder
 	logger1 := capturingLogger(&buf1, 1)
-	handler1 := &Authorizer{Client: cl, Log: logger1}
+	handler1 := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger1}
 	body = marshalSAR(t, sar)
 	req = httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(body))
 	rec = httptest.NewRecorder()
@@ -488,7 +496,8 @@ func TestAuditLog_V2TraceLogs(t *testing.T) {
 		},
 	}
 	cl := newIndexedClient(scheme, &wa)
-	handler := &Authorizer{Client: cl, Log: logger}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -520,7 +529,8 @@ func TestAuditLog_DecodeError(t *testing.T) {
 	scheme := newScheme(t)
 
 	cl := newIndexedClient(scheme)
-	handler := &Authorizer{Client: cl, Log: logger}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger}
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader([]byte("not-json")))
 	rec := httptest.NewRecorder()
@@ -552,7 +562,8 @@ func TestAuditLog_NonResourceAttributes(t *testing.T) {
 		},
 	}
 	cl := newIndexedClient(scheme, &wa)
-	handler := &Authorizer{Client: cl, Log: logger}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -584,7 +595,8 @@ func TestAuditLog_NonResourceAttributes(t *testing.T) {
 func TestEvaluateSAR_ResultFields(t *testing.T) {
 	scheme := newScheme(t)
 	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	wa := authzv1alpha1.WebhookAuthorizer{
 		ObjectMeta: metav1.ObjectMeta{Name: "eval-wa"},
@@ -716,7 +728,8 @@ func TestEvaluateSAR_NamespaceGetError(t *testing.T) {
 
 	// The fake client does NOT have the namespace "missing-ns" — Get will return NotFound.
 	cl := newIndexedClient(s, wa)
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	sar := &authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -761,7 +774,8 @@ func TestServeHTTP_NamespaceGetError_ReturnsDeniedSAR(t *testing.T) {
 	// Use an indexed client (matching real manager setup) with the WA but without
 	// the "missing-ns" Namespace object — Get will return NotFound.
 	cl := newIndexedClient(s, wa)
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -800,7 +814,8 @@ func TestServeHTTP_OversizedBody(t *testing.T) {
 	scheme := newScheme(t)
 
 	cl := newIndexedClient(scheme)
-	handler := &Authorizer{Client: cl, Log: logger}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger}
 
 	// Create a body larger than 1MB
 	oversizedBody := make([]byte, 1<<20+1)
@@ -837,7 +852,8 @@ func TestServeHTTP_InvalidJSON(t *testing.T) {
 	scheme := newScheme(t)
 
 	cl := newIndexedClient(scheme)
-	handler := &Authorizer{Client: cl, Log: logger}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger}
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", strings.NewReader("{invalid json"))
 	rec := httptest.NewRecorder()
@@ -900,7 +916,8 @@ func TestAuditLog_StructuredFieldsComprehensive(t *testing.T) {
 
 	var buf strings.Builder
 	logger := capturingLogger(&buf, 0)
-	handler := &Authorizer{Client: cl, Log: logger}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger}
 
 	body := marshalSAR(t, sar)
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", bytes.NewReader(body))
@@ -987,7 +1004,8 @@ func TestMetrics_RecordedAfterServeHTTP(t *testing.T) {
 	pkgmetrics.AuthorizerActiveRules.Set(0)
 
 	// --- Deny decision ---
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 	denySAR := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
 			User:               "blocked",
@@ -1143,8 +1161,9 @@ func TestMetrics_ActiveRulesCountsMixedGlobalAndScopedAuthorizers(t *testing.T) 
 		},
 	}
 	handler := &Authorizer{
-		Client: newIndexedClient(scheme, ns, &global, &scoped),
-		Log:    logr.Discard(),
+		AllowUnauthenticatedAuthorize: true,
+		Client:                        newIndexedClient(scheme, ns, &global, &scoped),
+		Log:                           logr.Discard(),
 	}
 
 	pkgmetrics.AuthorizerActiveRules.Set(0)
@@ -1212,9 +1231,10 @@ func TestServeHTTP_RateLimiting(t *testing.T) {
 
 	// Limiter with burst=1: first request allowed, second rejected.
 	handler := &Authorizer{
-		Client:  cl,
-		Log:     logger,
-		Limiter: rate.NewLimiter(rate.Limit(0), 1), // 0 rps, burst 1
+		AllowUnauthenticatedAuthorize: true,
+		Client:                        cl,
+		Log:                           logger,
+		Limiter:                       rate.NewLimiter(rate.Limit(0), 1), // 0 rps, burst 1
 	}
 
 	sar := authzv1.SubjectAccessReview{
@@ -1284,10 +1304,11 @@ func TestServeHTTP_BearerTokenRequiredBeforeRateLimit(t *testing.T) {
 	scheme := newScheme(t)
 	cl := newIndexedClient(scheme)
 	handler := &Authorizer{
-		Client:      cl,
-		Log:         logr.Discard(),
-		BearerToken: "shared-token",
-		Limiter:     rate.NewLimiter(rate.Limit(0), 1),
+		AllowUnauthenticatedAuthorize: true,
+		Client:                        cl,
+		Log:                           logr.Discard(),
+		BearerToken:                   "shared-token",
+		Limiter:                       rate.NewLimiter(rate.Limit(0), 1),
 	}
 
 	sar := authzv1.SubjectAccessReview{
@@ -1361,6 +1382,64 @@ func TestServeHTTP_BearerTokenRequiredBeforeRateLimit(t *testing.T) {
 	}
 }
 
+func TestAuthenticateRequest_DeniesEmptyExpectedTokenByDefault(t *testing.T) {
+	handler := &Authorizer{
+		Log: logr.Discard(),
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", nil)
+	rec := httptest.NewRecorder()
+	if handler.authenticateRequest(rec, req) {
+		t.Fatal("request should not authenticate when no bearer token is configured")
+	}
+	assertUnauthorizedSARResponse(t, rec)
+}
+
+func TestAuthenticateRequest_AllowsEmptyExpectedTokenWithExplicitOptOut(t *testing.T) {
+	handler := &Authorizer{
+		Log:                           logr.Discard(),
+		AllowUnauthenticatedAuthorize: true,
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", nil)
+	if !handler.authenticateRequest(httptest.NewRecorder(), req) {
+		t.Fatal("request should authenticate when unauthenticated authorize is explicitly allowed")
+	}
+}
+
+func TestAuthenticateRequest_AcceptsConfiguredBearerToken(t *testing.T) {
+	handler := &Authorizer{
+		Log:         logr.Discard(),
+		BearerToken: "shared-token",
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", nil)
+	req.Header.Set("Authorization", "Bearer shared-token")
+	if !handler.authenticateRequest(httptest.NewRecorder(), req) {
+		t.Fatal("request should authenticate with the configured bearer token")
+	}
+}
+
+func assertUnauthorizedSARResponse(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected denied SAR response to return %d, got %d", http.StatusOK, rec.Code)
+	}
+	var response authzv1.SubjectAccessReview
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode denied response: %v", err)
+	}
+	if response.Status.Allowed {
+		t.Fatal("response should have Allowed=false")
+	}
+	if !response.Status.Denied {
+		t.Fatal("response should have Denied=true")
+	}
+	if response.Status.Reason != reasonUnauthorized {
+		t.Fatalf("expected reason %q, got %q", reasonUnauthorized, response.Status.Reason)
+	}
+}
+
 func TestAuthenticateRequest_ReloadsBearerTokenFile(t *testing.T) {
 	tokenFile := t.TempDir() + "/authorize-token"
 	if err := os.WriteFile(tokenFile, []byte("old-token\n"), 0o600); err != nil {
@@ -1368,8 +1447,9 @@ func TestAuthenticateRequest_ReloadsBearerTokenFile(t *testing.T) {
 	}
 
 	handler := &Authorizer{
-		Log:             logr.Discard(),
-		BearerTokenFile: tokenFile,
+		AllowUnauthenticatedAuthorize: true,
+		Log:                           logr.Discard(),
+		BearerTokenFile:               tokenFile,
 	}
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/authorize", nil)
@@ -1430,8 +1510,9 @@ func TestAuthenticateRequest_DeniesWhenBearerTokenFileUnavailable(t *testing.T) 
 		t.Run(tc.name, func(t *testing.T) {
 			tokenFile := tc.setup(t)
 			handler := &Authorizer{
-				Log:             logr.Discard(),
-				BearerTokenFile: tokenFile,
+				AllowUnauthenticatedAuthorize: true,
+				Log:                           logr.Discard(),
+				BearerTokenFile:               tokenFile,
 			}
 
 			if _, err := handler.expectedBearerToken(); err == nil {
@@ -1470,9 +1551,10 @@ func TestServeHTTP_RateLimitingIsPerSubject(t *testing.T) {
 	scheme := newScheme(t)
 	cl := newIndexedClient(scheme)
 	handler := &Authorizer{
-		Client:  cl,
-		Log:     logr.Discard(),
-		Limiter: rate.NewLimiter(rate.Limit(0), 1),
+		AllowUnauthenticatedAuthorize: true,
+		Client:                        cl,
+		Log:                           logr.Discard(),
+		Limiter:                       rate.NewLimiter(rate.Limit(0), 1),
 	}
 
 	sarFor := func(user string, groups ...string) []byte {
@@ -1522,10 +1604,11 @@ func TestServeHTTP_RateLimitingIsPerSubject(t *testing.T) {
 
 func TestSubjectLimiterCacheIsBounded(t *testing.T) {
 	handler := &Authorizer{
-		Log:                     logr.Discard(),
-		Limiter:                 rate.NewLimiter(rate.Limit(1), 1),
-		subjectLimiters:         make(map[string]*subjectLimiterEntry, maxSubjectLimiters),
-		subjectLimiterCleanupAt: time.Now().Add(time.Hour),
+		AllowUnauthenticatedAuthorize: true,
+		Log:                           logr.Discard(),
+		Limiter:                       rate.NewLimiter(rate.Limit(1), 1),
+		subjectLimiters:               make(map[string]*subjectLimiterEntry, maxSubjectLimiters),
+		subjectLimiterCleanupAt:       time.Now().Add(time.Hour),
 	}
 	for i := range maxSubjectLimiters {
 		handler.subjectLimiters[rateLimitSubjectKey(&authzv1.SubjectAccessReview{Spec: authzv1.SubjectAccessReviewSpec{User: "user-" + strconv.Itoa(i)}})] = &subjectLimiterEntry{
@@ -1554,8 +1637,9 @@ func TestServeHTTP_NoRateLimiter(t *testing.T) {
 
 	// No Limiter set — rate limiting should be disabled.
 	handler := &Authorizer{
-		Client: cl,
-		Log:    logger,
+		AllowUnauthenticatedAuthorize: true,
+		Client:                        cl,
+		Log:                           logger,
 	}
 
 	sar := authzv1.SubjectAccessReview{
@@ -1589,7 +1673,8 @@ func TestServeHTTP_RejectsEmptyIdentity(t *testing.T) {
 	scheme := newScheme(t)
 	cl := newIndexedClient(scheme)
 
-	handler := &Authorizer{Client: cl, Log: logger}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -1638,7 +1723,8 @@ func TestServeHTTP_AcceptsEmptyUserWithGroups(t *testing.T) {
 	scheme := newScheme(t)
 	cl := newIndexedClient(scheme)
 
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -1674,7 +1760,8 @@ func TestServeHTTP_RejectsNoAttributes(t *testing.T) {
 	scheme := newScheme(t)
 	cl := newIndexedClient(scheme)
 
-	handler := &Authorizer{Client: cl, Log: logger}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -1714,7 +1801,8 @@ func TestServeHTTP_RejectsBothResourceAndNonResourceAttributes(t *testing.T) {
 	scheme := newScheme(t)
 	cl := newIndexedClient(scheme)
 
-	handler := &Authorizer{Client: cl, Log: logger}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logger}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -1754,7 +1842,8 @@ func TestServeHTTP_AcceptsNonResourceAttributes(t *testing.T) {
 	scheme := newScheme(t)
 	cl := newIndexedClient(scheme)
 
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -1826,7 +1915,8 @@ func TestServeHTTP_UsesSingleEvaluationDeadline(t *testing.T) {
 			},
 		}).
 		Build()
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -1873,7 +1963,8 @@ func TestServeHTTP_DeniedResponseSetsDeniedTrue(t *testing.T) {
 		},
 	}
 	cl := newIndexedClient(scheme, &wa)
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -1911,7 +2002,8 @@ func TestServeHTTP_NoOpinionResponseDoesNotSetDeniedTrue(t *testing.T) {
 	// the next authorizer.
 	scheme := newScheme(t)
 	cl := newIndexedClient(scheme) // no authorizers
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -1946,9 +2038,10 @@ func TestServeHTTP_RateLimitResponseSetsDeniedTrue(t *testing.T) {
 
 	// Limiter with burst=0: every request is rate-limited.
 	handler := &Authorizer{
-		Client:  cl,
-		Log:     logr.Discard(),
-		Limiter: rate.NewLimiter(rate.Limit(0), 0),
+		AllowUnauthenticatedAuthorize: true,
+		Client:                        cl,
+		Log:                           logr.Discard(),
+		Limiter:                       rate.NewLimiter(rate.Limit(0), 0),
 	}
 
 	sar := authzv1.SubjectAccessReview{
@@ -1979,7 +2072,8 @@ func TestServeHTTP_RateLimitResponseSetsDeniedTrue(t *testing.T) {
 }
 
 func TestPrincipalMatches_ServiceAccountNamespaceScope(t *testing.T) {
-	handler := &Authorizer{Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Log: logr.Discard()}
 
 	tests := []struct {
 		name       string
@@ -2052,7 +2146,8 @@ func TestPrincipalMatches_ServiceAccountNamespaceScope(t *testing.T) {
 func TestResourceRuleIndex_SubresourceMatching(t *testing.T) {
 	scheme := newScheme(t)
 	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	rules := []authzv1.ResourceRule{
 		// Rule 0: allows "pods" but NOT "pods/log"
@@ -2089,7 +2184,8 @@ func TestResourceRuleIndex_SubresourceMatching(t *testing.T) {
 func TestResourceRuleIndex_ResourceNamesMatching(t *testing.T) {
 	scheme := newScheme(t)
 	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	rules := []authzv1.ResourceRule{
 		// Rule 0: allows only specific-pod by name
@@ -2137,7 +2233,8 @@ func TestResourceRuleIndex_ResourceNamesMatching(t *testing.T) {
 func TestResourceRuleIndex_KubernetesWildcardSemantics(t *testing.T) {
 	scheme := newScheme(t)
 	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	tests := []struct {
 		name string
@@ -2187,7 +2284,8 @@ func TestResourceRuleIndex_KubernetesWildcardSemantics(t *testing.T) {
 func TestNonResourceRuleIndex_SuffixWildcardMatching(t *testing.T) {
 	scheme := newScheme(t)
 	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	rules := []authzv1.NonResourceRule{
 		{Verbs: []string{"get"}, NonResourceURLs: []string{"/api/*"}},
@@ -2281,7 +2379,8 @@ func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
 		base := newIndexedClient(scheme, ns, &wa1, &wa2, &wa3)
 
 		counter := &namespaceGetCountingClient{Client: base}
-		handler := &Authorizer{Client: counter, Log: logr.Discard()}
+		handler := &Authorizer{
+			AllowUnauthenticatedAuthorize: true, Client: counter, Log: logr.Discard()}
 
 		sar := &authzv1.SubjectAccessReview{
 			Spec: authzv1.SubjectAccessReviewSpec{
@@ -2307,7 +2406,8 @@ func TestEvaluateSAR_NamespaceLabelCache_SingleGetPerNamespace(t *testing.T) {
 		base := newIndexedClient(scheme)
 
 		counter := &namespaceGetCountingClient{Client: base}
-		handler := &Authorizer{Client: counter, Log: logr.Discard()}
+		handler := &Authorizer{
+			AllowUnauthenticatedAuthorize: true, Client: counter, Log: logr.Discard()}
 
 		cache := make(map[string]namespaceLabelCacheEntry)
 		selector := &wa1.Spec.NamespaceSelector
@@ -2343,7 +2443,8 @@ func TestServeHTTP_NamespaceLabelCacheError_ReturnsDeniedSAR(t *testing.T) {
 		},
 	}
 	cl := newIndexedClient(scheme, wa)
-	handler := &Authorizer{Client: cl, Log: logr.Discard()}
+	handler := &Authorizer{
+		AllowUnauthenticatedAuthorize: true, Client: cl, Log: logr.Discard()}
 
 	sar := authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -2423,8 +2524,9 @@ func TestServeHTTP_SkipsUnconfiguredAuthorizers(t *testing.T) {
 	configured.Status.AuthorizerConfigured = true
 
 	handler := &Authorizer{
-		Client: newIndexedClient(scheme, ns, stalled, configured),
-		Log:    logr.Discard(),
+		AllowUnauthenticatedAuthorize: true,
+		Client:                        newIndexedClient(scheme, ns, stalled, configured),
+		Log:                           logr.Discard(),
 	}
 
 	pkgmetrics.AuthorizerActiveRules.Set(0)


### PR DESCRIPTION
## Summary

- Deny `/authorize` requests when no bearer token is configured unless the new explicit insecure opt-out is enabled.
- Add `--allow-unauthenticated-authorize` and wire it through `webhookServer.allowUnauthenticatedAuthorize`.
- Update chart values/schema/templates/docs and add focused runtime plus chart rendering/schema coverage.

## Compatibility / migration

This changes the default for deployments that leave `webhookServer.authorizeAuth.tokenSecretName` empty. `/authorize` now returns a denied `SubjectAccessReview` instead of accepting unauthenticated callers.

Production deployments should create a shared token Secret and configure the API server authorization webhook kubeconfig to send `Authorization: Bearer <token>`, then set `webhookServer.authorizeAuth.tokenSecretName` and `webhookServer.authorizeAuth.tokenSecretKey`.

Existing local or development installs that intentionally relied on unauthenticated callers can temporarily set `webhookServer.allowUnauthenticatedAuthorize=true` or pass `--allow-unauthenticated-authorize` while migrating. Keep this opt-out disabled in production. Rate limiting still requires `webhookServer.authorizeAuth.tokenSecretName`.

## Validation

- `go test -timeout=6m ./internal/webhook/authorization ./cmd`
- `go test -timeout=2m ./chart/auth-operator`
- `make helm`
- `make helm-lint`
