### PR TITLE
fix(authz): harden namespace terminator status

### DIFF
--- a/internal/controller/authorization/binddefinition_controller_test.go
+++ b/internal/controller/authorization/binddefinition_controller_test.go
@@ -235,13 +235,11 @@ var _ = Describe("BindDefinition Controller", func() {
 					ResourceType: "pods",
 					APIGroup:     "",
 					Count:        1,
-					Names:        []string{"test-pod"},
 				},
 			}
 
 			message := formatBlockingResourcesMessage(blockingResources)
-			Expect(message).To(ContainSubstring("pods"))
-			Expect(message).To(ContainSubstring("test-pod"))
+			Expect(message).To(Equal("pods=1"))
 		})
 
 		It("should correctly format blocking resources message for multiple resource types", func() {
@@ -250,21 +248,18 @@ var _ = Describe("BindDefinition Controller", func() {
 					ResourceType: "pods",
 					APIGroup:     "",
 					Count:        2,
-					Names:        []string{"frontend", "backend"},
 				},
 				{
 					ResourceType: "persistentvolumeclaims",
 					APIGroup:     "",
 					Count:        1,
-					Names:        []string{"storage-pvc"},
 				},
 			}
 
 			message := formatBlockingResourcesMessage(blockingResources)
-			Expect(message).To(ContainSubstring("pods"))
-			Expect(message).To(ContainSubstring("frontend"))
-			Expect(message).To(ContainSubstring("persistentvolumeclaims"))
-			Expect(message).To(ContainSubstring("storage-pvc"))
+			Expect(message).To(Equal("persistentvolumeclaims=1; pods=2"))
+			Expect(message).NotTo(ContainSubstring("frontend"))
+			Expect(message).NotTo(ContainSubstring("storage-pvc"))
 		})
 
 		It("should include API group in resource type when present", func() {
@@ -273,40 +268,34 @@ var _ = Describe("BindDefinition Controller", func() {
 					ResourceType: "deployments",
 					APIGroup:     "apps",
 					Count:        1,
-					Names:        []string{"my-deployment"},
 				},
 			}
 
 			message := formatBlockingResourcesMessage(blockingResources)
-			Expect(message).To(ContainSubstring("deployments (apps)"))
+			Expect(message).To(Equal("deployments.apps=1"))
 		})
 	})
 
 	Context("ResourceBlocking type", func() {
-		It("should create ResourceBlocking with correct fields", func() {
+		It("should create ResourceBlocking with correct summary fields", func() {
 			rb := namespaceDeletionResourceBlocking{
 				ResourceType: "pods",
 				APIGroup:     "core",
 				Count:        3,
-				Names:        []string{"pod1", "pod2", "pod3"},
 			}
 
 			Expect(rb.ResourceType).To(Equal("pods"))
 			Expect(rb.APIGroup).To(Equal("core"))
 			Expect(rb.Count).To(Equal(3))
-			Expect(rb.Names).To(HaveLen(3))
-			Expect(rb.Names).To(ContainElements("pod1", "pod2", "pod3"))
 		})
 
-		It("should handle empty Names slice", func() {
+		It("should handle zero count", func() {
 			rb := namespaceDeletionResourceBlocking{
 				ResourceType: "pods",
 				APIGroup:     "",
 				Count:        0,
-				Names:        []string{},
 			}
 
-			Expect(rb.Names).To(BeEmpty())
 			Expect(rb.Count).To(Equal(0))
 		})
 
@@ -315,7 +304,6 @@ var _ = Describe("BindDefinition Controller", func() {
 				ResourceType: "pods",
 				APIGroup:     "",
 				Count:        1,
-				Names:        []string{"test-pod"},
 			}
 
 			Expect(rb.APIGroup).To(BeEmpty())
@@ -327,7 +315,6 @@ var _ = Describe("BindDefinition Controller", func() {
 				ResourceType: "customresources",
 				APIGroup:     "custom.example.com",
 				Count:        2,
-				Names:        []string{"resource1", "resource2"},
 			}
 
 			Expect(rb.APIGroup).To(Equal("custom.example.com"))
@@ -336,38 +323,30 @@ var _ = Describe("BindDefinition Controller", func() {
 	})
 
 	Context("Message formatting edge cases", func() {
-		It("should handle large resource names", func() {
+		It("should omit object names from message", func() {
 			blockingResources := []namespaceDeletionResourceBlocking{
 				{
 					ResourceType: "pods",
 					APIGroup:     "",
 					Count:        1,
-					Names:        []string{"very-long-pod-name-with-many-characters-123456789"},
 				},
 			}
 
 			message := formatBlockingResourcesMessage(blockingResources)
-			Expect(message).To(ContainSubstring("very-long-pod-name-with-many-characters-123456789"))
+			Expect(message).To(Equal("pods=1"))
 		})
 
 		It("should format many resources of same type", func() {
-			names := make([]string, 0, 10)
-			for i := range 10 {
-				names = append(names, fmt.Sprintf("pod-%d", i))
-			}
-
 			blockingResources := []namespaceDeletionResourceBlocking{
 				{
 					ResourceType: "pods",
 					APIGroup:     "",
 					Count:        10,
-					Names:        names,
 				},
 			}
 
 			message := formatBlockingResourcesMessage(blockingResources)
-			Expect(message).To(ContainSubstring("pods"))
-			Expect(message).To(ContainSubstring("10"))
+			Expect(message).To(Equal("pods=10"))
 		})
 
 		It("should format many different resource types", func() {
@@ -376,33 +355,26 @@ var _ = Describe("BindDefinition Controller", func() {
 					ResourceType: "pods",
 					APIGroup:     "",
 					Count:        2,
-					Names:        []string{"pod1", "pod2"},
 				},
 				{
 					ResourceType: "services",
 					APIGroup:     "",
 					Count:        1,
-					Names:        []string{"service1"},
 				},
 				{
 					ResourceType: "deployments",
 					APIGroup:     "apps",
 					Count:        1,
-					Names:        []string{"deploy1"},
 				},
 				{
 					ResourceType: "statefulsets",
 					APIGroup:     "apps",
 					Count:        3,
-					Names:        []string{"stateful1", "stateful2", "stateful3"},
 				},
 			}
 
 			message := formatBlockingResourcesMessage(blockingResources)
-			Expect(message).To(ContainSubstring("pods"))
-			Expect(message).To(ContainSubstring("services"))
-			Expect(message).To(ContainSubstring("deployments (apps)"))
-			Expect(message).To(ContainSubstring("statefulsets (apps)"))
+			Expect(message).To(Equal("deployments.apps=1; pods=2; services=1; statefulsets.apps=3"))
 		})
 
 		It("should handle single resource in many types", func() {
@@ -411,19 +383,16 @@ var _ = Describe("BindDefinition Controller", func() {
 					ResourceType: "pod",
 					APIGroup:     "",
 					Count:        1,
-					Names:        []string{"single-pod"},
 				},
 				{
 					ResourceType: "service",
 					APIGroup:     "",
 					Count:        1,
-					Names:        []string{"single-service"},
 				},
 			}
 
 			message := formatBlockingResourcesMessage(blockingResources)
-			Expect(message).To(ContainSubstring("pod"))
-			Expect(message).To(ContainSubstring("service"))
+			Expect(message).To(Equal("pod=1; service=1"))
 		})
 
 		It("should include count in message", func() {
@@ -432,26 +401,24 @@ var _ = Describe("BindDefinition Controller", func() {
 					ResourceType: "pods",
 					APIGroup:     "",
 					Count:        5,
-					Names:        []string{"pod1", "pod2", "pod3", "pod4", "pod5"},
 				},
 			}
 
 			message := formatBlockingResourcesMessage(blockingResources)
-			Expect(message).To(ContainSubstring("5"))
+			Expect(message).To(Equal("pods=5"))
 		})
 
-		It("should handle special characters in resource names", func() {
+		It("should handle API groups with dots", func() {
 			blockingResources := []namespaceDeletionResourceBlocking{
 				{
-					ResourceType: "pods",
-					APIGroup:     "",
+					ResourceType: "widgets",
+					APIGroup:     "custom.example.com",
 					Count:        1,
-					Names:        []string{"pod-with-dashes-and_underscores.123"},
 				},
 			}
 
 			message := formatBlockingResourcesMessage(blockingResources)
-			Expect(message).To(ContainSubstring("pod-with-dashes-and_underscores.123"))
+			Expect(message).To(Equal("widgets.custom.example.com=1"))
 		})
 	})
 
@@ -461,14 +428,12 @@ var _ = Describe("BindDefinition Controller", func() {
 				ResourceType: "pods",
 				APIGroup:     "",
 				Count:        1,
-				Names:        []string{"test-pod"},
 			}
 
 			rb2 := namespaceDeletionResourceBlocking{
 				ResourceType: "pods",
 				APIGroup:     "",
 				Count:        1,
-				Names:        []string{"test-pod"},
 			}
 
 			Expect(rb1.ResourceType).To(Equal(rb2.ResourceType))
@@ -481,14 +446,12 @@ var _ = Describe("BindDefinition Controller", func() {
 				ResourceType: "pods",
 				APIGroup:     "",
 				Count:        1,
-				Names:        []string{"test"},
 			}
 
 			rb2 := namespaceDeletionResourceBlocking{
 				ResourceType: "services",
 				APIGroup:     "",
 				Count:        1,
-				Names:        []string{"test"},
 			}
 
 			Expect(rb1.ResourceType).NotTo(Equal(rb2.ResourceType))
@@ -499,14 +462,12 @@ var _ = Describe("BindDefinition Controller", func() {
 				ResourceType: "pods",
 				APIGroup:     "",
 				Count:        1,
-				Names:        []string{"test"},
 			}
 
 			rb2 := namespaceDeletionResourceBlocking{
 				ResourceType: "pods",
 				APIGroup:     "apps",
 				Count:        1,
-				Names:        []string{"test"},
 			}
 
 			Expect(rb1.APIGroup).NotTo(Equal(rb2.APIGroup))
@@ -517,14 +478,12 @@ var _ = Describe("BindDefinition Controller", func() {
 				ResourceType: "pods",
 				APIGroup:     "",
 				Count:        1,
-				Names:        []string{"test"},
 			}
 
 			rb2 := namespaceDeletionResourceBlocking{
 				ResourceType: "pods",
 				APIGroup:     "",
 				Count:        5,
-				Names:        []string{"test"},
 			}
 
 			Expect(rb1.Count).NotTo(Equal(rb2.Count))
@@ -545,12 +504,12 @@ func TestSummarizeNamespaceNames(t *testing.T) {
 }
 
 // TestReconcileTerminatingNamespaces verifies that the controller properly handles terminating namespaces
-// and logs blocking resources with detailed information.
+// and logs blocking resources with count-only information.
 //
 // Test Coverage:
-// 1. formatBlockingResourcesMessage() - Converts ResourceBlocking data to human-readable messages
-// 2. ResourceBlocking type - Captures resource details for logging
-// 3. Logging of blocking resources - Structured logs with namespace, resource type, count, and names
+// 1. formatBlockingResourcesMessage() - Converts ResourceBlocking data to count-only messages
+// 2. ResourceBlocking type - Captures resource type and count details for logging
+// 3. Logging of blocking resources - Structured logs with namespace, resource type, and count
 //
 // To run these tests:
 //   go test -v ./internal/controller/authorization/...

--- a/internal/controller/authorization/rolebinding_terminator_controller.go
+++ b/internal/controller/authorization/rolebinding_terminator_controller.go
@@ -600,7 +600,7 @@ func (r *RoleBindingTerminator) Reconcile(ctx context.Context, req ctrl.Request)
 		authorizationv1alpha1.NamespaceTerminationAllowedMessage,
 	)
 	if err := r.applyNamespaceTerminationStatus(ctx, &namespace); err != nil {
-		logger.Error(err, "failed to update Namespace status with blocking resources information", "namespace", namespace.Name)
+		logger.Error(err, "failed to clear Namespace termination blocked status", "namespace", namespace.Name)
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRoleBindingTerminator, metrics.ResultError).Inc()
 		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRoleBindingTerminator, metrics.ErrorTypeAPI).Inc()
 		return ctrl.Result{}, err

--- a/internal/controller/authorization/rolebinding_terminator_controller.go
+++ b/internal/controller/authorization/rolebinding_terminator_controller.go
@@ -61,12 +61,11 @@ var (
 	errBindDefinitionOwnerUIDMismatch   = errors.New("BindDefinition owner reference UID mismatch")
 )
 
-// namespaceDeletionResourceBlocking represents a resource type and the specific instances blocking namespace deletion.
+// namespaceDeletionResourceBlocking represents a resource type blocking namespace deletion.
 type namespaceDeletionResourceBlocking struct {
 	ResourceType string // e.g., "pods", "persistentvolumeclaims"
 	APIGroup     string // e.g., "", "apps"
 	Count        int
-	Names        []string // List of specific resource names
 }
 
 // namespaceTerminationStatus caches the blocking resources for a namespace and manages access with a mutex.
@@ -176,9 +175,6 @@ func (r *RoleBindingTerminator) getNamespacedBlockingResources(ctx context.Conte
 		)
 	}
 
-	// Return a defensive copy of the top-level slice so callers cannot
-	// append/remove elements in the cached data. Note: nested slices
-	// (e.g. Names) are shared with the cache and must not be mutated.
 	result := make([]namespaceDeletionResourceBlocking, len(blockingResources))
 	copy(result, blockingResources)
 	return result, lastError
@@ -291,20 +287,11 @@ func namespaceHasResources(ctx context.Context, resourceTracker apiResourceProvi
 
 				logger.V(2).Info("found resources in namespace - will NOT remove finalizers", "namespace", namespace, "gvr", gvr.String(), "itemCount", len(list.Items))
 
-				// Collect names of blocking resources (limit to first 10)
-				var resourceNames []string
-				for i, item := range list.Items {
-					if i < 10 { // Collect up to 10 resource names for event
-						resourceNames = append(resourceNames, item.GetName())
-						logger.V(3).Info("found resource", "namespace", namespace, "gvr", gvr.String(), "name", item.GetName(), "index", i)
-					}
-				}
 				// Add to blocking resources list
 				blockingResourcesChannel <- namespaceDeletionResourceBlocking{
 					ResourceType: resource.Name,
 					APIGroup:     gv.Group,
 					Count:        len(list.Items),
-					Names:        resourceNames,
 				}
 				return nil
 			})
@@ -337,7 +324,7 @@ func supportsList(verbs []string) bool {
 	return false
 }
 
-// formatBlockingResourcesMessage creates a detailed event message about what resources are blocking namespace deletion.
+// formatBlockingResourcesMessage creates a count-only message about resources blocking namespace deletion.
 func formatBlockingResourcesMessage(blockingResources []namespaceDeletionResourceBlocking) string {
 	// Sort for deterministic event messages across reconciliation runs.
 	slices.SortFunc(blockingResources, func(a, b namespaceDeletionResourceBlocking) int {
@@ -359,35 +346,17 @@ func formatBlockingResourcesMessage(blockingResources []namespaceDeletionResourc
 	resourceDetails := make([]string, 0, len(blockingResources))
 
 	for _, rb := range blockingResources {
-		// Sort names within each entry for stable output.
-		// Clone the shared Names slice before sorting to prevent concurrent
-		// reconcilers from racing on the cached backing array.
-		names := slices.Clone(rb.Names)
-		slices.Sort(names)
-
-		var resourceType string
-		if rb.APIGroup == "" {
-			resourceType = rb.ResourceType
-		} else {
-			resourceType = fmt.Sprintf("%s (%s)", rb.ResourceType, rb.APIGroup)
-		}
-
-		switch {
-		case rb.Count == 1 && len(names) > 0:
-			resourceDetails = append(resourceDetails, fmt.Sprintf("%s: %s", resourceType, names[0]))
-		case len(names) > 0:
-			// Show first few names if multiple.
-			if len(names) <= 3 {
-				resourceDetails = append(resourceDetails, fmt.Sprintf("%s (%d): %s", resourceType, rb.Count, strings.Join(names, ", ")))
-			} else {
-				resourceDetails = append(resourceDetails, fmt.Sprintf("%s (%d): %s, +%d more", resourceType, rb.Count, strings.Join(names[:3], ", "), rb.Count-3))
-			}
-		default:
-			resourceDetails = append(resourceDetails, fmt.Sprintf("%s (%d)", resourceType, rb.Count))
-		}
+		resourceDetails = append(resourceDetails, fmt.Sprintf("%s=%d", blockingResourceType(rb), rb.Count))
 	}
 
 	return strings.Join(resourceDetails, "; ")
+}
+
+func blockingResourceType(resource namespaceDeletionResourceBlocking) string {
+	if resource.APIGroup == "" {
+		return resource.ResourceType
+	}
+	return fmt.Sprintf("%s.%s", resource.ResourceType, resource.APIGroup)
 }
 
 // isOwnedByBindDefinition reports whether the given owner references include
@@ -471,6 +440,18 @@ func extractNamespaceCondition(ns *corev1.Namespace, condType authorizationv1alp
 				WithMessage(c.Message).
 				WithLastTransitionTime(c.LastTransitionTime)
 		}
+	}
+	return nil
+}
+
+func (r *RoleBindingTerminator) applyNamespaceTerminationStatus(ctx context.Context, namespace *corev1.Namespace) error {
+	condAC := extractNamespaceCondition(namespace, authorizationv1alpha1.NamespaceTerminationBlockedCondition)
+	if condAC == nil {
+		return nil
+	}
+	ac := corev1ac.Namespace(namespace.Name).WithStatus(corev1ac.NamespaceStatus().WithConditions(condAC))
+	if err := r.client.SubResource("status").Apply(ctx, ac, client.FieldOwner("auth-operator"), client.ForceOwnership); err != nil {
+		return fmt.Errorf("apply Namespace %s status: %w", namespace.Name, err)
 	}
 	return nil
 }
@@ -585,13 +566,8 @@ func (r *RoleBindingTerminator) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if !terminationAllowed {
 		logger.V(1).Info("terminating namespace still has resources - NOT removing RoleBinding finalizer", "namespace", namespace.Name)
-		// Log detailed information about blocking resources
 		for _, br := range blockingResources {
-			resourceType := br.ResourceType
-			if br.APIGroup != "" {
-				resourceType = fmt.Sprintf("%s.%s", br.ResourceType, br.APIGroup)
-			}
-			logger.V(1).Info("blocking resource found", "namespace", namespace.Name, "resourceType", resourceType, "count", br.Count, "names", br.Names)
+			logger.V(1).Info("blocking resource found", "namespace", namespace.Name, "resourceType", blockingResourceType(br), "count", br.Count)
 		}
 
 		conditions.MarkTrue(
@@ -601,11 +577,11 @@ func (r *RoleBindingTerminator) Reconcile(ctx context.Context, req ctrl.Request)
 			authorizationv1alpha1.NamespaceTerminationBlockedReason,
 			conditions.ConditionMessage(fmt.Sprintf("%s: %s", authorizationv1alpha1.NamespaceTerminationBlockedMessage, formatBlockingResourcesMessage(blockingResources))),
 		)
-		if condAC := extractNamespaceCondition(&namespace, authorizationv1alpha1.NamespaceTerminationBlockedCondition); condAC != nil {
-			ac := corev1ac.Namespace(namespace.Name).WithStatus(corev1ac.NamespaceStatus().WithConditions(condAC))
-			if err := r.client.SubResource("status").Apply(ctx, ac, client.FieldOwner("auth-operator"), client.ForceOwnership); err != nil {
-				logger.Error(err, "Failed to update Namespace status with blocking resources information", "namespace", namespace.Name)
-			}
+		if err := r.applyNamespaceTerminationStatus(ctx, &namespace); err != nil {
+			logger.Error(err, "failed to update Namespace status with blocking resources information", "namespace", namespace.Name)
+			metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRoleBindingTerminator, metrics.ResultError).Inc()
+			metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRoleBindingTerminator, metrics.ErrorTypeAPI).Inc()
+			return ctrl.Result{}, err
 		}
 
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRoleBindingTerminator, metrics.ResultRequeue).Inc()
@@ -616,6 +592,20 @@ func (r *RoleBindingTerminator) Reconcile(ctx context.Context, req ctrl.Request)
 	logger = logger.WithValues("bindDefinitionName", bindDefinition.Name)
 
 	logger.V(1).Info("terminating namespace has no more resources - proceeding to remove RoleBinding finalizers")
+	conditions.MarkFalse(
+		conditions.NewNamespaceWrapper(&namespace),
+		authorizationv1alpha1.NamespaceTerminationBlockedCondition,
+		0,
+		authorizationv1alpha1.NamespaceTerminationAllowedReason,
+		authorizationv1alpha1.NamespaceTerminationAllowedMessage,
+	)
+	if err := r.applyNamespaceTerminationStatus(ctx, &namespace); err != nil {
+		logger.Error(err, "failed to update Namespace status with blocking resources information", "namespace", namespace.Name)
+		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRoleBindingTerminator, metrics.ResultError).Inc()
+		metrics.ReconcileErrors.WithLabelValues(metrics.ControllerRoleBindingTerminator, metrics.ErrorTypeAPI).Inc()
+		return ctrl.Result{}, err
+	}
+
 	if removed, err := r.removeRoleBindingFinalizer(ctx, &roleBinding); err != nil {
 		logger.Error(err, "failed to remove finalizer from RoleBinding", "roleBindingName", roleBinding.Name, "roleBinding", roleBinding.Name, "namespace", namespace.Name)
 		metrics.ReconcileTotal.WithLabelValues(metrics.ControllerRoleBindingTerminator, metrics.ResultError).Inc()
@@ -632,20 +622,6 @@ func (r *RoleBindingTerminator) Reconcile(ctx context.Context, req ctrl.Request)
 		logger.V(1).Info("successfully removed finalizer from RoleBinding in terminating namespace")
 	} else {
 		logger.V(3).Info("RoleBinding does not have finalizer", "roleBindingName", roleBinding.Name)
-	}
-
-	conditions.MarkFalse(
-		conditions.NewNamespaceWrapper(&namespace),
-		authorizationv1alpha1.NamespaceTerminationBlockedCondition,
-		0,
-		authorizationv1alpha1.NamespaceTerminationAllowedReason,
-		authorizationv1alpha1.NamespaceTerminationAllowedMessage,
-	)
-	if condAC := extractNamespaceCondition(&namespace, authorizationv1alpha1.NamespaceTerminationBlockedCondition); condAC != nil {
-		ac := corev1ac.Namespace(namespace.Name).WithStatus(corev1ac.NamespaceStatus().WithConditions(condAC))
-		if err := r.client.SubResource("status").Apply(ctx, ac, client.FieldOwner("auth-operator"), client.ForceOwnership); err != nil {
-			logger.Error(err, "failed to update Namespace status with blocking resources information", "namespace", namespace.Name)
-		}
 	}
 
 	logger.V(2).Info("reconcileTerminatingNamespaces completed")

--- a/internal/controller/authorization/rolebinding_terminator_controller_test.go
+++ b/internal/controller/authorization/rolebinding_terminator_controller_test.go
@@ -72,6 +72,15 @@ func (f fakeAPIResourceProvider) GetAPIResources() (discovery.APIResourcesByGrou
 	return f.resources, f.err
 }
 
+func namespaceCondition(ns *corev1.Namespace, condType authorizationv1alpha1.AuthZConditionType) *corev1.NamespaceCondition {
+	for i := range ns.Status.Conditions {
+		if string(ns.Status.Conditions[i].Type) == string(condType) {
+			return &ns.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
 func TestIsOwnedByBindDefinition(t *testing.T) {
 	t.Run("empty owner references returns false", func(t *testing.T) {
 		g := NewWithT(t)
@@ -158,52 +167,51 @@ func TestSupportsList(t *testing.T) {
 }
 
 func TestFormatBlockingResourcesMessage(t *testing.T) {
-	t.Run("single resource with name", func(t *testing.T) {
+	t.Run("single resource", func(t *testing.T) {
 		g := NewWithT(t)
 		resources := []namespaceDeletionResourceBlocking{
-			{ResourceType: "pods", APIGroup: "", Count: 1, Names: []string{"my-pod"}},
+			{ResourceType: "pods", APIGroup: "", Count: 1},
 		}
 		msg := formatBlockingResourcesMessage(resources)
-		g.Expect(msg).To(Equal("pods: my-pod"))
+		g.Expect(msg).To(Equal("pods=1"))
 	})
 
 	t.Run("resource with API group", func(t *testing.T) {
 		g := NewWithT(t)
 		resources := []namespaceDeletionResourceBlocking{
-			{ResourceType: "deployments", APIGroup: "apps", Count: 2, Names: []string{"dep1", "dep2"}},
+			{ResourceType: "deployments", APIGroup: "apps", Count: 2},
 		}
 		msg := formatBlockingResourcesMessage(resources)
-		g.Expect(msg).To(ContainSubstring("deployments (apps)"))
-		g.Expect(msg).To(ContainSubstring("dep1"))
+		g.Expect(msg).To(Equal("deployments.apps=2"))
 	})
 
 	t.Run("multiple resources combined", func(t *testing.T) {
 		g := NewWithT(t)
 		resources := []namespaceDeletionResourceBlocking{
-			{ResourceType: "pods", APIGroup: "", Count: 1, Names: []string{"pod1"}},
-			{ResourceType: "services", APIGroup: "", Count: 1, Names: []string{"svc1"}},
+			{ResourceType: "pods", APIGroup: "", Count: 1},
+			{ResourceType: "services", APIGroup: "", Count: 1},
 		}
 		msg := formatBlockingResourcesMessage(resources)
-		g.Expect(msg).To(ContainSubstring("pods: pod1"))
-		g.Expect(msg).To(ContainSubstring("services: svc1"))
+		g.Expect(msg).To(Equal("pods=1; services=1"))
 	})
 
-	t.Run("resource with many names truncated", func(t *testing.T) {
+	t.Run("resource names are omitted", func(t *testing.T) {
 		g := NewWithT(t)
 		resources := []namespaceDeletionResourceBlocking{
-			{ResourceType: "pods", APIGroup: "", Count: 5, Names: []string{"p1", "p2", "p3", "p4", "p5"}},
+			{ResourceType: "pods", APIGroup: "", Count: 5},
 		}
 		msg := formatBlockingResourcesMessage(resources)
-		g.Expect(msg).To(ContainSubstring("+2 more"))
+		g.Expect(msg).To(Equal("pods=5"))
+		g.Expect(msg).NotTo(ContainSubstring("p1"))
 	})
 
 	t.Run("resource with no names", func(t *testing.T) {
 		g := NewWithT(t)
 		resources := []namespaceDeletionResourceBlocking{
-			{ResourceType: "configmaps", APIGroup: "", Count: 3, Names: nil},
+			{ResourceType: "configmaps", APIGroup: "", Count: 3},
 		}
 		msg := formatBlockingResourcesMessage(resources)
-		g.Expect(msg).To(Equal("configmaps (3)"))
+		g.Expect(msg).To(Equal("configmaps=3"))
 	})
 }
 
@@ -488,7 +496,7 @@ func TestRBTerminatorReconcileTerminatingNamespaceWithBlockingResources(t *testi
 	// Burn the first rate limiter call so subsequent Do() won't re-execute.
 	cacheEntry := &namespaceTerminationStatus{
 		blockingResources: []namespaceDeletionResourceBlocking{
-			{ResourceType: "pods", APIGroup: "", Count: 3, Names: []string{"pod-a", "pod-b", "pod-c"}},
+			{ResourceType: "pods", APIGroup: "", Count: 3},
 		},
 		rateLimiter: rate.Sometimes{},
 	}
@@ -504,6 +512,71 @@ func TestRBTerminatorReconcileTerminatingNamespaceWithBlockingResources(t *testi
 	// Verify finalizer was NOT removed
 	updated := &rbacv1.RoleBinding{}
 	g.Expect(c.Get(ctx, types.NamespacedName{Name: "term-rb", Namespace: "terminating-ns"}, updated)).To(Succeed())
+	g.Expect(updated.Finalizers).To(ContainElement(authorizationv1alpha1.RoleBindingFinalizer))
+
+	updatedNS := &corev1.Namespace{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: "terminating-ns"}, updatedNS)).To(Succeed())
+	condition := namespaceCondition(updatedNS, authorizationv1alpha1.NamespaceTerminationBlockedCondition)
+	g.Expect(condition).NotTo(BeNil())
+	g.Expect(condition.Message).To(ContainSubstring("pods=3"))
+	g.Expect(condition.Message).NotTo(ContainSubstring("pod-a"))
+}
+
+func TestRBTerminatorReconcileBlockedNamespaceStatusApplyError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	scheme := newTestScheme()
+
+	now := metav1.Now()
+	bdOwnerRef := testBindDefinitionControllerOwnerRef("test-bd", "bd-uid")
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "term-rb-status-error",
+			Namespace:         "blocked-status-error-ns",
+			OwnerReferences:   []metav1.OwnerReference{bdOwnerRef},
+			DeletionTimestamp: &now,
+			Finalizers:        []string{authorizationv1alpha1.RoleBindingFinalizer},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "blocked-status-error-ns",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"kubernetes"},
+		},
+		Status: corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(rb, ns, testBindDefinition()).
+		WithStatusSubresource(ns).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceApply: func(_ context.Context, _ client.Client, _ string, _ runtime.ApplyConfiguration, _ ...client.SubResourceApplyOption) error {
+				return fmt.Errorf("injected namespace status apply error")
+			},
+		}).
+		Build()
+	r := &RoleBindingTerminator{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+
+	cacheEntry := &namespaceTerminationStatus{
+		blockingResources: []namespaceDeletionResourceBlocking{
+			{ResourceType: "pods", APIGroup: "", Count: 3},
+		},
+		rateLimiter: rate.Sometimes{},
+	}
+	cacheEntry.rateLimiter.Do(func() {})
+	r.namespaceTerminationResourcesCache.Store("blocked-status-error-ns", cacheEntry)
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "term-rb-status-error", Namespace: "blocked-status-error-ns"},
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("injected namespace status apply error"))
+	g.Expect(result).To(Equal(reconcile.Result{}))
+
+	updated := &rbacv1.RoleBinding{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: "term-rb-status-error", Namespace: "blocked-status-error-ns"}, updated)).To(Succeed())
 	g.Expect(updated.Finalizers).To(ContainElement(authorizationv1alpha1.RoleBindingFinalizer))
 }
 
@@ -573,6 +646,74 @@ func TestRBTerminatorReconcileTerminatingNamespaceNoBlockingResources(t *testing
 	// data is stale.
 	_, loaded := r.namespaceTerminationResourcesCache.Load("clean-term-ns")
 	g.Expect(loaded).To(BeFalse(), "cache entry should be evicted after finalizer removal in terminating namespace")
+}
+
+func TestRBTerminatorReconcileFinalizationNamespaceStatusApplyError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+	scheme := newTestScheme()
+
+	now := metav1.Now()
+	bd := &authorizationv1alpha1.BindDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-bd", UID: "bd-uid"},
+		Spec: authorizationv1alpha1.BindDefinitionSpec{
+			TargetName: "test-target",
+			Subjects: []rbacv1.Subject{
+				{Kind: "User", Name: "test-user", APIGroup: rbacv1.GroupName},
+			},
+		},
+	}
+	bdOwnerRef := testBindDefinitionControllerOwnerRef("test-bd", "bd-uid")
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "term-rb-clean-status-error",
+			Namespace:         "clean-status-error-ns",
+			OwnerReferences:   []metav1.OwnerReference{bdOwnerRef},
+			DeletionTimestamp: &now,
+			Finalizers:        []string{authorizationv1alpha1.RoleBindingFinalizer},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "view"},
+	}
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "clean-status-error-ns",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"kubernetes"},
+		},
+		Status: corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(rb, ns, bd).
+		WithStatusSubresource(ns, bd).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceApply: func(_ context.Context, _ client.Client, _ string, _ runtime.ApplyConfiguration, _ ...client.SubResourceApplyOption) error {
+				return fmt.Errorf("injected namespace status apply error")
+			},
+		}).
+		Build()
+	r := &RoleBindingTerminator{client: c, scheme: scheme, recorder: events.NewFakeRecorder(10)}
+
+	cacheEntry := &namespaceTerminationStatus{
+		blockingResources: nil,
+		rateLimiter:       rate.Sometimes{},
+	}
+	cacheEntry.rateLimiter.Do(func() {})
+	r.namespaceTerminationResourcesCache.Store("clean-status-error-ns", cacheEntry)
+
+	result, err := r.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "term-rb-clean-status-error", Namespace: "clean-status-error-ns"},
+	})
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("injected namespace status apply error"))
+	g.Expect(result).To(Equal(reconcile.Result{}))
+
+	updated := &rbacv1.RoleBinding{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: "term-rb-clean-status-error", Namespace: "clean-status-error-ns"}, updated)).To(Succeed())
+	g.Expect(updated.Finalizers).To(ContainElement(authorizationv1alpha1.RoleBindingFinalizer))
+
+	_, loaded := r.namespaceTerminationResourcesCache.Load("clean-status-error-ns")
+	g.Expect(loaded).To(BeTrue(), "cache entry should be retained when namespace status clearing fails")
 }
 
 func TestRBTerminatorCacheEvictionOnNonTerminatingNamespace(t *testing.T) {
@@ -1003,7 +1144,7 @@ func TestRBTerminatorReconcileUsesLiveReaderForStaleOwnerCache(t *testing.T) {
 
 	cacheEntry := &namespaceTerminationStatus{
 		blockingResources: []namespaceDeletionResourceBlocking{
-			{ResourceType: "pods", Count: 1, Names: []string{"still-running"}},
+			{ResourceType: "pods", Count: 1},
 		},
 		rateLimiter: rate.Sometimes{},
 	}
@@ -1063,7 +1204,7 @@ func TestRBTerminatorReconcileUsesLiveReaderForStaleOwnerUID(t *testing.T) {
 
 	cacheEntry := &namespaceTerminationStatus{
 		blockingResources: []namespaceDeletionResourceBlocking{
-			{ResourceType: "pods", Count: 1, Names: []string{"still-running"}},
+			{ResourceType: "pods", Count: 1},
 		},
 		rateLimiter: rate.Sometimes{},
 	}
@@ -1167,4 +1308,11 @@ func TestRBTerminator_NamespaceHasResources_NetworkRoleBindings(t *testing.T) {
 	var updatedRB rbacv1.RoleBinding
 	g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "test-ns", Name: "test-rb"}, &updatedRB)).To(Succeed())
 	g.Expect(updatedRB.Finalizers).To(ContainElement(authorizationv1alpha1.RoleBindingFinalizer), "Finalizer should not be removed while resources exist")
+
+	updatedNS := &corev1.Namespace{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: "test-ns"}, updatedNS)).To(Succeed())
+	condition := namespaceCondition(updatedNS, authorizationv1alpha1.NamespaceTerminationBlockedCondition)
+	g.Expect(condition).NotTo(BeNil())
+	g.Expect(condition.Message).To(ContainSubstring("networkrolebindings.network.example.com=1"))
+	g.Expect(condition.Message).NotTo(ContainSubstring("test-networkrb"))
 }


### PR DESCRIPTION
## Summary
- report namespace-termination blockers by resource type and count only, avoiding object names in namespace status and logs
- fail reconciliation when namespace status apply fails before leaving the RoleBinding finalizer path
- clear the namespace termination condition before removing RoleBinding finalizers when blocking resources are gone

## Validation
- `KUBEBUILDER_ASSETS=/private/tmp/auth-operator-namespace-terminator-status-safety/bin/k8s/1.36.0-darwin-arm64 GOCACHE=/private/tmp/auth-operator-namespace-terminator-go-build-cache GOMODCACHE=/private/tmp/auth-operator-namespace-terminator-go-mod-cache go test -count=1 -timeout=8m ./internal/controller/authorization`
- `gofmt -w internal/controller/authorization/rolebinding_terminator_controller.go internal/controller/authorization/rolebinding_terminator_controller_test.go internal/controller/authorization/binddefinition_controller_test.go`
- `git diff --check`