### PR TITLE
fix: align Helm E2E and generated checks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -242,6 +242,7 @@ jobs:
       - name: Cleanup cluster
         if: always()
         run: |
+          kind delete cluster --name auth-operator-e2e-ha-multi || true
           kind delete cluster --name auth-operator-e2e-ha || true
 
   e2e-full-chain:

--- a/Makefile
+++ b/Makefile
@@ -335,12 +335,20 @@ ci-checks: verify helm-lint ## Run all CI checks locally before pushing.
 	@echo "Checking go.mod is tidy..."
 	@go mod tidy
 	@git diff --exit-code go.mod go.sum || (echo "ERROR: go.mod/go.sum not tidy" && exit 1)
-	@echo "Checking generated code is up to date..."
-	@$(MAKE) generate manifests
-	@git diff --exit-code || (echo "ERROR: Generated code out of date" && exit 1)
+	@$(MAKE) verify-generated
 	@echo "Linting YAML files..."
 	@command -v yamllint >/dev/null 2>&1 && yamllint -c .yamllint.yml . || echo "yamllint not installed, skipping"
 	@echo "All CI checks passed!"
+
+.PHONY: verify-generated
+verify-generated: ## Verify generated manifests, Helm chart, and API docs are up to date.
+	@echo "Checking generated manifests, code, Helm chart, and docs are up to date..."
+	@$(MAKE) manifests
+	@$(MAKE) generate
+	@$(MAKE) helm
+	@$(MAKE) docs
+	@git diff --exit-code || (echo "ERROR: Generated files out of date. Run 'make manifests generate helm docs' and commit changes." && exit 1)
+	@git diff --cached --exit-code || (echo "ERROR: There are staged changes after generation." && exit 1)
 
 .PHONY: helm-lint
 helm-lint: ## Lint Helm chart.

--- a/Makefile
+++ b/Makefile
@@ -343,12 +343,12 @@ ci-checks: verify helm-lint ## Run all CI checks locally before pushing.
 .PHONY: verify-generated
 verify-generated: ## Verify generated manifests, Helm chart, and API docs are up to date.
 	@echo "Checking generated manifests, code, Helm chart, and docs are up to date..."
+	@git diff --cached --quiet || (echo "ERROR: Refusing to verify generated files with pre-existing staged changes." && exit 1)
 	@$(MAKE) manifests
 	@$(MAKE) generate
 	@$(MAKE) helm
 	@$(MAKE) docs
 	@git diff --exit-code || (echo "ERROR: Generated files out of date. Run 'make manifests generate helm docs' and commit changes." && exit 1)
-	@git diff --cached --exit-code || (echo "ERROR: There are staged changes after generation." && exit 1)
 
 .PHONY: helm-lint
 helm-lint: ## Lint Helm chart.

--- a/chart/auth-operator/README.md
+++ b/chart/auth-operator/README.md
@@ -75,7 +75,8 @@ Image reference precedence: `digest` > `tag` > `Chart.AppVersion`
 | `controller.startupProbe.failureThreshold` | Startup probe consecutive failures before restart | `30` |
 | `controller.startupProbe.periodSeconds` | How often to perform the startup probe | `2` |
 | `controller.podDisruptionBudget.enabled` | Enable PDB | `false` |
-| `controller.podDisruptionBudget.minAvailable` | Minimum available pods | `1` |
+| `controller.podDisruptionBudget.minAvailable` | Minimum available pods. Omit when using `maxUnavailable`. | `1` |
+| `controller.podDisruptionBudget.maxUnavailable` | Maximum unavailable pods. Mutually exclusive with `minAvailable`. | `""` |
 | `controller.bindDefinitionConcurrency` | Max concurrent BindDefinition reconciliations | `10` |
 | `controller.roleDefinitionConcurrency` | Max concurrent RoleDefinition reconciliations | `10` |
 | `controller.webhookAuthorizerConcurrency` | Max concurrent WebhookAuthorizer reconciliations | `1` |
@@ -109,7 +110,8 @@ Image reference precedence: `digest` > `tag` > `Chart.AppVersion`
 | `webhookServer.affinity` | Pod affinity rules (overrides global `affinity`) | Pod anti-affinity across nodes |
 | `webhookServer.service.port` | Service port | `443` |
 | `webhookServer.podDisruptionBudget.enabled` | Enable PDB | `true` |
-| `webhookServer.podDisruptionBudget.minAvailable` | Minimum available pods | `1` |
+| `webhookServer.podDisruptionBudget.minAvailable` | Minimum available pods. Omit when using `maxUnavailable`. | `1` |
+| `webhookServer.podDisruptionBudget.maxUnavailable` | Maximum unavailable pods. Mutually exclusive with `minAvailable`. | `""` |
 
 ### Namespace Admission
 
@@ -188,7 +190,8 @@ The webhook server defaults to 2 replicas with pod anti-affinity and PDB enabled
 When multiple replicas are deployed, leader election is automatically enabled so
 that only one replica drives certificate rotation. Non-leader replicas detect the
 TLS certificate via the Secret volume mount and become ready independently, so all
-replicas serve admission webhook traffic. To also enable HA for the controller:
+replicas serve admission webhook traffic. PDBs default to `minAvailable: 1` when
+neither `minAvailable` nor `maxUnavailable` is set. To also enable HA for the controller:
 
 ```bash
 helm install auth-operator oci://ghcr.io/telekom/charts/auth-operator \

--- a/chart/auth-operator/values.schema.json
+++ b/chart/auth-operator/values.schema.json
@@ -271,7 +271,7 @@
                 { "type": "integer", "minimum": 0 },
                 { "type": "string", "pattern": "^[0-9]+%$" }
               ],
-              "description": "Minimum number (or percentage) of pods that must be available during disruption.",
+              "description": "Minimum number (or percentage) of pods that must be available during disruption. Omit this field when using maxUnavailable.",
               "default": 1
             },
             "maxUnavailable": {
@@ -279,7 +279,7 @@
                 { "type": "integer", "minimum": 1 },
                 { "type": "string", "pattern": "^[0-9]+%$" }
               ],
-              "description": "Maximum number (or percentage) of pods that can be unavailable during disruption."
+              "description": "Maximum number (or percentage) of pods that can be unavailable during disruption. Set this without minAvailable; the chart defaults to minAvailable=1 only when neither field is set."
             }
           },
           "not": {
@@ -409,7 +409,7 @@
                 { "type": "integer", "minimum": 0 },
                 { "type": "string", "pattern": "^[0-9]+%$" }
               ],
-              "description": "Minimum number (or percentage) of pods that must be available during disruption.",
+              "description": "Minimum number (or percentage) of pods that must be available during disruption. Omit this field when using maxUnavailable.",
               "default": 1
             },
             "maxUnavailable": {
@@ -417,7 +417,7 @@
                 { "type": "integer", "minimum": 1 },
                 { "type": "string", "pattern": "^[0-9]+%$" }
               ],
-              "description": "Maximum number (or percentage) of pods that can be unavailable during disruption."
+              "description": "Maximum number (or percentage) of pods that can be unavailable during disruption. Set this without minAvailable; the chart defaults to minAvailable=1 only when neither field is set."
             }
           },
           "not": {

--- a/chart/auth-operator/values.yaml
+++ b/chart/auth-operator/values.yaml
@@ -95,8 +95,9 @@ controller:
   podDisruptionBudget:
     # Enable PodDisruptionBudget for high availability
     enabled: false
-    # Minimum number of pods that must be available during disruption
-    minAvailable: 1
+    # Minimum number of pods that must be available during disruption.
+    # Defaults to 1 when neither minAvailable nor maxUnavailable is set.
+    # minAvailable: 1
     # Maximum number of pods that can be unavailable during disruption
     # (mutually exclusive with minAvailable)
     # maxUnavailable: 1
@@ -129,8 +130,9 @@ webhookServer:
   podDisruptionBudget:
     # Enable PodDisruptionBudget for high availability
     enabled: true
-    # Minimum number of pods that must be available during disruption
-    minAvailable: 1
+    # Minimum number of pods that must be available during disruption.
+    # Defaults to 1 when neither minAvailable nor maxUnavailable is set.
+    # minAvailable: 1
     # Maximum number of pods that can be unavailable during disruption
     # (mutually exclusive with minAvailable)
     # maxUnavailable: 1

--- a/test/e2e/helm_e2e_test.go
+++ b/test/e2e/helm_e2e_test.go
@@ -152,6 +152,28 @@ var _ = Describe("Helm Chart E2E", Ordered, Label("helm"), func() {
 			saveOutput("helm-template-all-features.yaml", output)
 		})
 
+		It("should template PodDisruptionBudgets with maxUnavailable overrides", func() {
+			By("Running helm template with maxUnavailable PDBs")
+			templateArgs := append([]string{"template", helmReleaseName, helmChartPath,
+				"-n", helmNamespace},
+				imageSetArgs()...,
+			)
+			templateArgs = append(templateArgs,
+				"--set", "controller.replicas=2",
+				"--set", "controller.podDisruptionBudget.enabled=true",
+				"--set", "controller.podDisruptionBudget.maxUnavailable=1",
+				"--set", "webhookServer.replicas=2",
+				"--set", "webhookServer.podDisruptionBudget.enabled=true",
+				"--set", "webhookServer.podDisruptionBudget.maxUnavailable=1",
+			)
+			cmd := utils.CommandContext(context.Background(), "helm", templateArgs...) // #nosec G204
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Helm template with maxUnavailable PDBs failed: %s", string(output))
+			rendered := string(output)
+			Expect(strings.Count(rendered, "maxUnavailable: 1")).To(Equal(2))
+			Expect(rendered).NotTo(ContainSubstring("minAvailable: 1"))
+		})
+
 		It("should template metrics authentication by default and allow explicit opt-out", func() {
 			By("Rendering the default chart")
 			defaultArgs := append([]string{"template", helmReleaseName, helmChartPath,
@@ -816,7 +838,7 @@ spec:
 			Eventually(func() error {
 				return checkResourceExists("webhookauthorizer", "helm-e2e-authorizer", "")
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
-			// Note: .status.authorizerConfigured is not implemented in the controller
+			waitForHelmWebhookAuthorizerConfigured("helm-e2e-authorizer")
 		})
 
 		It("should create WebhookAuthorizer with denied principals", func() {
@@ -848,7 +870,7 @@ spec:
 			Eventually(func() error {
 				return checkResourceExists("webhookauthorizer", "helm-e2e-authorizer-deny", "")
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
-			// Note: .status.authorizerConfigured is not implemented in the controller
+			waitForHelmWebhookAuthorizerConfigured("helm-e2e-authorizer-deny")
 		})
 
 		It("should create WebhookAuthorizer with non-resource rules", func() {
@@ -879,7 +901,7 @@ spec:
 			Eventually(func() error {
 				return checkResourceExists("webhookauthorizer", "helm-e2e-authorizer-nonresource", "")
 			}, reconcileTimeout, pollingInterval).Should(Succeed())
-			// Note: .status.authorizerConfigured is not implemented in the controller
+			waitForHelmWebhookAuthorizerConfigured("helm-e2e-authorizer-nonresource")
 		})
 	})
 
@@ -1086,6 +1108,20 @@ func saveOutput(filename string, content []byte) {
 	} else {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Saved output to %s\n", fp)
 	}
+}
+
+func waitForHelmWebhookAuthorizerConfigured(name string) {
+	By("Verifying WebhookAuthorizer reports authorizerConfigured=true")
+	Eventually(func() string {
+		cmd := utils.CommandContext(context.Background(), "kubectl", "get",
+			"webhookauthorizer", name,
+			"-o", "jsonpath={.status.authorizerConfigured}") // #nosec G204
+		output, err := utils.Run(cmd)
+		if err != nil {
+			return ""
+		}
+		return string(output)
+	}, reconcileTimeout, pollingInterval).Should(Equal("true"))
 }
 
 func dumpAllGeneratedResources() {

--- a/test/e2e/helm_e2e_test.go
+++ b/test/e2e/helm_e2e_test.go
@@ -1120,7 +1120,7 @@ func waitForHelmWebhookAuthorizerConfigured(name string) {
 		if err != nil {
 			return ""
 		}
-		return string(output)
+		return strings.TrimSpace(string(output))
 	}, reconcileTimeout, pollingInterval).Should(Equal("true"))
 }
 

--- a/test/e2e/webhookauthorizer_e2e_test.go
+++ b/test/e2e/webhookauthorizer_e2e_test.go
@@ -486,9 +486,7 @@ spec:
 			_, _ = utils.Run(cmd)
 		})
 
-		It("should report status conditions", func() {
-			// The controller (if running) should update conditions.
-			// This test verifies the CRD supports the status subresource.
+		It("should report configured status and Ready condition", func() {
 			Eventually(func() bool {
 				cmd := utils.CommandContext(context.Background(), "kubectl", "get",
 					"webhookauthorizer", "wa-e2e-status", "-o", "json")
@@ -503,6 +501,8 @@ spec:
 				_, hasStatus := result["status"]
 				return hasStatus
 			}, reconcileWait, pollingInt).Should(BeTrue(), "Expected status field to be present")
+			waitForWebhookAuthorizerReady("wa-e2e-status")
+			waitForWebhookAuthorizerConfigured("wa-e2e-status")
 		})
 	})
 
@@ -680,6 +680,19 @@ func waitForWebhookAuthorizerReady(name string) {
 		}
 		return string(output)
 	}, 30*time.Second, 3*time.Second).Should(Equal(statusTrue))
+}
+
+func waitForWebhookAuthorizerConfigured(name string) {
+	Eventually(func() string {
+		cmd := utils.CommandContext(context.Background(), "kubectl", "get",
+			"webhookauthorizer", name,
+			"-o", "jsonpath={.status.authorizerConfigured}")
+		output, err := utils.Run(cmd)
+		if err != nil {
+			return ""
+		}
+		return string(output)
+	}, 30*time.Second, 3*time.Second).Should(Equal("true"))
 }
 
 func resourceSAR(user string, groups []string, verb, resource, namespace string) authzv1.SubjectAccessReview {

--- a/test/e2e/webhookauthorizer_e2e_test.go
+++ b/test/e2e/webhookauthorizer_e2e_test.go
@@ -678,7 +678,7 @@ func waitForWebhookAuthorizerReady(name string) {
 		if err != nil {
 			return ""
 		}
-		return string(output)
+		return strings.TrimSpace(string(output))
 	}, 30*time.Second, 3*time.Second).Should(Equal(statusTrue))
 }
 
@@ -691,7 +691,7 @@ func waitForWebhookAuthorizerConfigured(name string) {
 		if err != nil {
 			return ""
 		}
-		return string(output)
+		return strings.TrimSpace(string(output))
 	}, 30*time.Second, 3*time.Second).Should(Equal("true"))
 }
 


### PR DESCRIPTION
## Summary
- make PDB `maxUnavailable` overrides usable without also carrying the default `minAvailable` value in values.yaml
- add Helm/E2E coverage for PDB `maxUnavailable` rendering and WebhookAuthorizer `status.authorizerConfigured`
- clean up HA E2E cluster cleanup and make local `ci-checks` run the same manifests/generate/helm/docs generated-file guard

## Validation
- `git diff --check`
- `helm template test chart/auth-operator --set controller.replicas=2 --set controller.podDisruptionBudget.enabled=true --set controller.podDisruptionBudget.maxUnavailable=1 --set webhookServer.replicas=2 --set webhookServer.podDisruptionBudget.enabled=true --set webhookServer.podDisruptionBudget.maxUnavailable=1`
- `go test -tags e2e ./test/e2e/ -run ^`
- `helm lint chart/auth-operator --strict`
- `make docs`
- `KUBEBUILDER_ASSETS=/private/tmp/auth-operator-namespace-terminator-status-safety/bin/k8s/1.36.0-darwin-arm64 GOCACHE=/private/tmp/auth-operator-helm-e2e-go-build-cache GOMODCACHE=/private/tmp/auth-operator-helm-e2e-go-mod-cache go test -timeout=4m ./internal/controller/authorization`
- `make verify-generated`

Full kind E2E was not run locally.