### PR TITLE
fix: include clusterrole special verbs in discovered RBAC

### DIFF
--- a/internal/controller/authorization/roledefinition_helpers_test.go
+++ b/internal/controller/authorization/roledefinition_helpers_test.go
@@ -457,6 +457,17 @@ func rulesContainVerb(rules map[string]*rbacv1.PolicyRule, verb string) bool {
 	return false
 }
 
+func policyRuleForResource(rules map[string]*rbacv1.PolicyRule, resource string) *rbacv1.PolicyRule {
+	for _, rule := range rules {
+		for _, res := range rule.Resources {
+			if res == resource {
+				return rule
+			}
+		}
+	}
+	return nil
+}
+
 // TestFilterAPIResourcesForRoleDefinition tests the filterAPIResourcesForRoleDefinition function
 func TestFilterAPIResourcesForRoleDefinition(t *testing.T) {
 	s := scheme.Scheme
@@ -573,6 +584,84 @@ func TestFilterAPIResourcesForRoleDefinition(t *testing.T) {
 		if rulesContainResource(rules, "nodes") {
 			t.Error("cluster-scoped resource 'nodes' should be filtered when ScopeNamespaced=true")
 		}
+	})
+
+	t.Run("should keep special verbs for clusterroles", func(t *testing.T) {
+		g := NewWithT(t)
+		rd := &authorizationv1alpha1.RoleDefinition{
+			Spec: authorizationv1alpha1.RoleDefinitionSpec{
+				TargetRole:      authorizationv1alpha1.DefinitionClusterRole,
+				ScopeNamespaced: false,
+			},
+		}
+
+		apiResources := discovery.APIResourcesByGroupVersion{
+			rbacv1.SchemeGroupVersion.String(): {
+				{
+					Name:       "clusterroles",
+					Group:      rbacv1.GroupName,
+					Verbs:      metav1.Verbs{"get", "list", "bind", "escalate"},
+					Namespaced: false,
+				},
+			},
+		}
+
+		rules, err := r.filterAPIResourcesForRoleDefinition(ctx, rd, apiResources)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(policyRuleForResource(rules, "clusterroles")).NotTo(BeNil())
+		g.Expect(policyRuleForResource(rules, "clusterroles").Verbs).To(ConsistOf("get", "list", "bind", "escalate"))
+	})
+
+	t.Run("should keep special verbs for namespaced roles", func(t *testing.T) {
+		g := NewWithT(t)
+		rd := &authorizationv1alpha1.RoleDefinition{
+			Spec: authorizationv1alpha1.RoleDefinitionSpec{
+				TargetRole:      authorizationv1alpha1.DefinitionNamespacedRole,
+				ScopeNamespaced: true,
+			},
+		}
+
+		apiResources := discovery.APIResourcesByGroupVersion{
+			rbacv1.SchemeGroupVersion.String(): {
+				{
+					Name:       "roles",
+					Group:      rbacv1.GroupName,
+					Verbs:      metav1.Verbs{"get", "list", "bind", "escalate"},
+					Namespaced: true,
+				},
+			},
+		}
+
+		rules, err := r.filterAPIResourcesForRoleDefinition(ctx, rd, apiResources)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(policyRuleForResource(rules, "roles")).NotTo(BeNil())
+		g.Expect(policyRuleForResource(rules, "roles").Verbs).To(ConsistOf("get", "list", "bind", "escalate"))
+	})
+
+	t.Run("should not add bind for rolebindings", func(t *testing.T) {
+		g := NewWithT(t)
+		rd := &authorizationv1alpha1.RoleDefinition{
+			Spec: authorizationv1alpha1.RoleDefinitionSpec{
+				TargetRole:      authorizationv1alpha1.DefinitionNamespacedRole,
+				ScopeNamespaced: true,
+			},
+		}
+
+		apiResources := discovery.APIResourcesByGroupVersion{
+			rbacv1.SchemeGroupVersion.String(): {
+				{
+					Name:       "rolebindings",
+					Group:      rbacv1.GroupName,
+					Verbs:      metav1.Verbs{"get", "list"},
+					Namespaced: true,
+				},
+			},
+		}
+
+		rules, err := r.filterAPIResourcesForRoleDefinition(ctx, rd, apiResources)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(policyRuleForResource(rules, "rolebindings")).NotTo(BeNil())
+		g.Expect(policyRuleForResource(rules, "rolebindings").Verbs).To(ConsistOf("get", "list"))
 	})
 
 	t.Run("should filter restricted verbs", func(t *testing.T) {

--- a/pkg/discovery/tracker.go
+++ b/pkg/discovery/tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -53,6 +54,9 @@ const (
 	verbList     = "list"
 	verbUpdate   = "update"
 	verbWatch    = "watch"
+
+	rbacResourceClusterRoles = "clusterroles"
+	rbacResourceRoles        = "roles"
 )
 
 // APIResourcesByGroupVersion maps GroupVersion strings to their corresponding API resources.
@@ -702,21 +706,7 @@ func (r *ResourceTracker) collectAPIResourcesForGroupVersion(
 			resource.Verbs = append(resource.Verbs, verbList, verbWatch)
 		}
 
-		// for roles and rolebindings in rbac.authorization.k8s.io/v1,
-		// we need to add the bind verb explicitly, as they are not part of the API discovery
-		requiresExplicitBind := group == rbacv1.GroupName && version == "v1" &&
-			(resource.Name == "roles" || resource.Name == "rolebindings")
-		if requiresExplicitBind {
-			resource.Verbs = append(resource.Verbs, verbBind)
-		}
-
-		// for roles in rbac.authorization.k8s.io/v1,
-		// we need to add the escalate verb explicitly, as it is not part of the API discovery
-		requiresExplicitEscalate := group == rbacv1.GroupName && version == "v1" &&
-			resource.Name == "roles"
-		if requiresExplicitEscalate {
-			resource.Verbs = append(resource.Verbs, verbEscalate)
-		}
+		resource = withExplicitRBACVerbs(group, version, resource)
 
 		// send the resource to the channel
 		result = append(result, resource)
@@ -745,4 +735,23 @@ func (r *ResourceTracker) collectAPIResourcesForGroupVersion(
 		}
 	}
 	return result, nil
+}
+
+func withExplicitRBACVerbs(group, version string, resource metav1.APIResource) metav1.APIResource {
+	if group != rbacv1.GroupName || version != "v1" {
+		return resource
+	}
+
+	switch resource.Name {
+	case rbacResourceClusterRoles, rbacResourceRoles:
+		// Kubernetes discovery omits the special RBAC verbs required to manage
+		// privilege escalation and role binding for role resources.
+		for _, verb := range []string{verbBind, verbEscalate} {
+			if !slices.Contains(resource.Verbs, verb) {
+				resource.Verbs = append(resource.Verbs, verb)
+			}
+		}
+	}
+
+	return resource
 }

--- a/pkg/discovery/tracker_test.go
+++ b/pkg/discovery/tracker_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -465,6 +466,52 @@ var _ = Describe("ResourceTracker APIResourcesByGroupVersion", func() {
 			}
 			Expect(a.Equals(b)).To(BeFalse())
 		})
+	})
+})
+
+var _ = Describe("ResourceTracker explicit RBAC verbs", func() {
+	It("adds bind and escalate for clusterroles", func() {
+		resource := withExplicitRBACVerbs(rbacv1.GroupName, "v1", metav1.APIResource{
+			Name:       rbacResourceClusterRoles,
+			Namespaced: false,
+			Kind:       "ClusterRole",
+			Verbs:      metav1.Verbs{verbGet, verbList},
+		})
+
+		Expect(resource.Verbs).To(ConsistOf(verbGet, verbList, verbBind, verbEscalate))
+	})
+
+	It("adds bind and escalate for roles", func() {
+		resource := withExplicitRBACVerbs(rbacv1.GroupName, "v1", metav1.APIResource{
+			Name:       rbacResourceRoles,
+			Namespaced: true,
+			Kind:       "Role",
+			Verbs:      metav1.Verbs{verbGet, verbList},
+		})
+
+		Expect(resource.Verbs).To(ConsistOf(verbGet, verbList, verbBind, verbEscalate))
+	})
+
+	It("does not duplicate existing explicit verbs", func() {
+		resource := withExplicitRBACVerbs(rbacv1.GroupName, "v1", metav1.APIResource{
+			Name:       rbacResourceClusterRoles,
+			Namespaced: false,
+			Kind:       "ClusterRole",
+			Verbs:      metav1.Verbs{verbGet, verbBind, verbEscalate},
+		})
+
+		Expect(resource.Verbs).To(Equal(metav1.Verbs{verbGet, verbBind, verbEscalate}))
+	})
+
+	It("does not add bind to rolebindings", func() {
+		resource := withExplicitRBACVerbs(rbacv1.GroupName, "v1", metav1.APIResource{
+			Name:       "rolebindings",
+			Namespaced: true,
+			Kind:       "RoleBinding",
+			Verbs:      metav1.Verbs{verbGet, verbList},
+		})
+
+		Expect(resource.Verbs).To(ConsistOf(verbGet, verbList))
 	})
 })
 


### PR DESCRIPTION
## Summary

- add Kubernetes RBAC `bind` and `escalate` special verbs for discovered `roles` and `clusterroles`
- stop adding `bind` to `rolebindings`, which is not a role resource special verb
- cover discovery normalization and final RoleDefinition rule generation with focused regressions

## Duplicate check

- `gh pr list --repo telekom/auth-operator --state all --limit 100 --search "clusterroles bind escalate ResourceTracker RoleDefinition"` only returned #335 and #476, neither of which implements this RBAC special-verb mapping.

## Validation

- `KUBEBUILDER_ASSETS=/private/tmp/auth-operator-rbac-special-verbs/bin/k8s/1.36.0-darwin-arm64 GOCACHE=/private/tmp/auth-rbac-go-cache go test -timeout=4m ./pkg/discovery ./internal/controller/authorization`
- `git -c core.fsmonitor=false diff --check`
