### PR TITLE
ci: allow known-broken security checks to fail without blocking PRs

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -26,6 +26,7 @@ jobs:
   govulncheck:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest
+    continue-on-error: true # upstream panic in golang.org/x/tools@v0.46.0 vs Go 1.26 (ForEachElement on *types.TypeParam)
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -151,6 +152,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (image)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        continue-on-error: true # CVE-2026-39822 in golang base image, pending upstream fix
         with:
           image-ref: 'auth-operator:scan'
           format: 'sarif'


### PR DESCRIPTION
## Summary
- `govulncheck` currently panics on every PR/branch due to an upstream bug in `golang.org/x/tools@v0.46.0` incompatible with Go 1.26 (`ForEachElement called on type containing *types.TypeParam`), unrelated to any PR's own changes.
- `Trivy Image Scan` fails on CVE-2026-39822 (Go stdlib `os.Root` symlink traversal) in the pinned golang base image; this also fails today on `main`.
- Both are marked `continue-on-error: true` so they stop hard-blocking every Dependabot/other PR while still surfacing failures in the UI. Should be reverted once the upstream govulncheck bug is fixed and the base image is bumped.

## Test plan
- [x] CI runs on this PR itself; the two affected jobs no longer block merge even if they still report failures.