### PR TITLE
ci: close a Dependabot blind spot for composite-action pins

### DIFF
--- a/.github/actions/build-operator-image/action.yml
+++ b/.github/actions/build-operator-image/action.yml
@@ -52,11 +52,11 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: Log in to Container Registry
       if: inputs.push-to-registry == 'true'
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.registry-username }}

--- a/.github/actions/setup-go-env/action.yml
+++ b/.github/actions/setup-go-env/action.yml
@@ -60,7 +60,7 @@ runs:
         echo "Using Go version: $VERSION"
 
     - name: Setup Go
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         cache: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,6 +70,79 @@ updates:
           - "minor"
           - "patch"
 
+  # GitHub Actions used inside local composite actions. Dependabot's
+  # github-actions ecosystem only scans the actions referenced directly in
+  # each configured directory, so composite actions under .github/actions/
+  # need their own entries or their pinned actions silently go stale.
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/build-operator-image"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-go-env"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup-kind-cluster"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   # Docker
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## Summary
Continues the explicit dependency-currency work (#519, #521). `go list -m -u all` already reports zero outdated Go modules; this PR closes a gap Dependabot itself was silently missing.

## Root cause
Dependabot's `github-actions` ecosystem only scans the actions used directly inside a configured `directory`. `dependabot.yml` only configured the repo root (`directory: "/"`), so the actions pinned inside `.github/actions/*/action.yml` (composite actions) were never scanned and had silently drifted behind versions already in use elsewhere in this same repo:

| Action | In composite action | Was | Now |
|---|---|---|---|
| `actions/setup-go` | `setup-go-env` | v6.5.0 | v7.0.0 |
| `docker/setup-buildx-action` | `build-operator-image` | v4.1.0 | v4.2.0 |
| `docker/login-action` | `build-operator-image` | v4.2.0 | v4.6.0 |

Each new SHA was verified against the action's GitHub Releases API and matches the SHA already pinned for that same version elsewhere in the repo (e.g. `docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0` is already used in `release.yml`).

**Fix for recurrence:** added a `github-actions` dependabot.yml entry per `.github/actions/*/` directory, so these composite-action pins get scanned going forward like any workflow file.

## Full currency audit (this PR + prior state)
- **Go modules**: `go list -m -u all` → 0 outdated (unchanged, from #521)
- **Docker base images**: `golang:1.26.5-alpine` and `gcr.io/distroless/static-debian12` digests match the registry's current manifest-list digest — already current
- **GitHub Actions**: all 22 unique SHA-pinned actions across every workflow + composite action now match their latest GitHub release — verified via `gh api repos/<owner>/<repo>/releases/latest`
- **versions.env tool pins**: kustomize, controller-tools, envtest, golangci-lint, crd-ref-docs, helmify, mockgen, yq, kind, helm, cert-manager, gateway-api, prometheus-operator, calico, external-secrets, velero — all already at each project's latest release

## Documented blocker (cannot update further)
`KIND_K8S_VERSION=v1.36.1` stays as-is. Kubernetes 1.36.2 and 1.36.3 exist, but **no `kindest/node` image has been published for either yet**:
```
$ docker manifest inspect kindest/node:v1.36.2
no such manifest: docker.io/kindest/node:v1.36.2
$ docker manifest inspect kindest/node:v1.36.3
no such manifest: docker.io/kindest/node:v1.36.3
```
`kindest/node:v1.36.1` is the newest node image kind has actually published for the 1.36 line; kind's node-image releases lag the Kubernetes release itself. `ENVTEST_K8S_VERSION=v1.36.2` is separately already at the latest envtest binary set published for 1.36 (`setup-envtest list` offers only v1.36.0 and v1.36.2, no v1.36.1/v1.36.3).

## Validation
- `go build ./...`, `go vet ./...` — pass (no Go source touched)
- All 3 touched YAML files parse cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- No other action across the repo has more than one distinct pinned version (checked via `grep` + `uniq`)
